### PR TITLE
feat(kmdf): 0323 MagicMouseDriver — Wheel on live 0x12 path (do not merge)

### DIFF
--- a/.github/workflows/ps-lint.yml
+++ b/.github/workflows/ps-lint.yml
@@ -2,12 +2,12 @@ name: PowerShell Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ai/magic-mouse-initial-release ]
     paths:
       - '**.ps1'
       - '.github/workflows/ps-lint.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, ai/magic-mouse-initial-release ]
     paths:
       - '**.ps1'
       - '.github/workflows/ps-lint.yml'

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,12 @@ TestResults/
 Thumbs.db
 .DS_Store
 
-# Git-ignore driver binaries EXCEPT in release/
+# Git-ignore driver binaries EXCEPT the labeled PATH-A ship-blocker (if present).
+# KMDF still *installs* as MagicMouseDriver.sys; PATH-A still *installs* as
+# applewirelessmouse.sys. Package / backup names must stay distinct.
 *.sys
-!v1-binary-patch/applewirelessmouse.sys
-!v1-binary-patch/installer/applewirelessmouse.sys
+!v1-binary-patch/applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
+!v1-binary-patch/installer/applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
 
 # Certificates EXCEPT release/
 *.cer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-08-31
+
+### Changed
+
+- Live HID 2026-08-30 21:23 MDT on Apr 30 MagicMouseFix (`AD5D244B`): **stay on the path HidBth delivers**
+  - COL01 Input **0x12** is X/Y only (no Wheel usage 0x0038) — that is why pointer moves and scroll does not
+  - COL02 `HidD_GetInputReport(0x90)` works: `bytes=[90 04 2F ...]` → 47% at `buf[2]`
+  - Feature **0x47 fails** on COL01 and COL02. Product battery is RID **0x90 Input**, not 0x47
+- SDP inject now adds Wheel (GD 0x38) and AC Pan (Consumer 0x0238) on **RID 0x12**, plus RID **0x90** battery Input
+- Gesture/ACL rewrite stays on 8-byte RID **0x12** (`[12][buttons][X i16][Y i16][AC Pan][Wheel]`). Does **not** convert to RID 0x02
+- Do not install this build on the live Apr 30 PC until a Windows WDK `.sys` exists. Do not merge until hardware proves scroll
+
 ## [2.0.3] - 2026-08-31
 
 ### Added
@@ -12,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - KMDF `MagicMouseDriver` source package in `v2-kmdf-driver/` (PID **0x0323 only**)
 - One-click `Install-KMDF.cmd`: first run registers SYSTEM tasks `MM-Kmdf-Install` and `MM-Kmdf-PostBoot`; later runs start the task with no UAC
 - Unattended SYSTEM path: test-signing, self-sign cert + catalog, `pnputil` install, sole `LowerFilters=MagicMouseDriver`, Bluetooth disable/enable bounce, reboot if required, post-boot verify
-- RID 0x12 / 0x27 → 6-byte RID 0x02 translation (optical X/Y + buttons + **vertical and horizontal surface scroll**) on ACL completions and IRP_MJ_READ
+- RID 0x12 / 0x27 → 6-byte RID 0x02 translation (optical X/Y + buttons + **vertical and horizontal surface scroll**) on ACL completions and IRP_MJ_READ — **superseded in 2.0.4** (live hidclass bound 0x12, not 0x02)
 - Installer refuses May 20 WDKTestCert SHA256 `559B136A…`; reuses `CN=MagicMouseFix` when present; Bluetooth bounce only if HID did not start
 - `MAGIC-TRAY.md`: tray PR #74 should pull this KMDF for 0323 and must not vendor it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Artifact / backup / FileVersion labels so KMDF and PATH-A cannot be mixed up. Windows still installs KMDF as `MagicMouseDriver.sys` and PATH-A as `applewirelessmouse.sys`.
+  - Pointer-only: `MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys` (FileVersion not 2.0.4.0)
+  - Pointer-dead: `MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys` (FileVersion 2.0.2.0; installer refuses)
+  - Scroll candidate: `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion / DriverVer **2.0.4.0**)
+  - PATH-A ship-blocker: `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` (v1-binary-patch only)
 - Live HID 2026-08-30 21:23 MDT on Apr 30 MagicMouseFix (`AD5D244B`): **stay on the path HidBth delivers**
   - COL01 Input **0x12** is X/Y only (no Wheel usage 0x0038) — that is why pointer moves and scroll does not
   - COL02 `HidD_GetInputReport(0x90)` works: `bytes=[90 04 2F ...]` → 47% at `buf[2]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-08-31
+
+### Added
+
+- KMDF `MagicMouseDriver` source package in `v2-kmdf-driver/` (PID **0x0323 only**)
+- One-click `Install-KMDF.cmd`: first run registers SYSTEM tasks `MM-Kmdf-Install` and `MM-Kmdf-PostBoot`; later runs start the task with no UAC
+- Unattended SYSTEM path: test-signing, self-sign cert + catalog, `pnputil` install, sole `LowerFilters=MagicMouseDriver`, Bluetooth disable/enable bounce, reboot if required, post-boot verify
+- RID 0x12 / 0x27 → 6-byte RID 0x02 translation (optical X/Y + buttons + **vertical and horizontal surface scroll**) on ACL completions and IRP_MJ_READ
+- Installer refuses May 20 WDKTestCert SHA256 `559B136A…`; reuses `CN=MagicMouseFix` when present; Bluetooth bounce only if HID did not start
+- `MAGIC-TRAY.md`: tray PR #74 should pull this KMDF for 0323 and must not vendor it
+
+### Fixed
+
+- Live 2.0.2.0: HID started, pointer did not move — descriptor injection without matching X/Y reports
+
+### Removed / rejected
+
+- No `mm-dev.ps1 -Phase Full`
+- No dual-filter `MagicMouseDriver,applewirelessmouse`
+- No 030D / 0310 INF hardware IDs
+- v1 patched `applewirelessmouse.sys` marked ship-blocker (BSOD 0xD1)
+
 ## [1.0.0] - 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Magic Mouse v3 Windows Scroll Fix
 
-**STATUS: Production Ready v1.0.0**
+**0323 product: KMDF `MagicMouseDriver` in `v2-kmdf-driver/`.**  
+Double-click `v2-kmdf-driver/Install-KMDF.cmd`. First run: one Administrator prompt (registers a SYSTEM task). Later runs: no UAC. Result: `C:\ProgramData\MagicMouseDriver\RESULT.txt`.
 
-A Windows kernel driver patch that restores scroll functionality on Apple Magic Mouse v3 (2024) after Bluetooth reconnection.
+`magic-tray` should install **this** KMDF for PID 0323 (do not vendor the tree into the tray repo).
+
+The v1 `applewirelessmouse.sys` binary patch is a **ship-blocker** (BSOD 0xD1). Do not install it for 0323. Do not dual-filter it with MagicMouseDriver.
+
+---
+
+A Windows KMDF lower filter that presents a standard mouse to hidclass and translates Magic Mouse 2 USB-C (PID 0x0323) RID 0x12 reports so the pointer moves. Also addresses the v3 scroll-stop / DSM collection collapse the v1 patch was aimed at.
 
 ## What This Fixes
 
@@ -37,9 +44,19 @@ Apple Magic Mouse v3 on Windows 10/11 loses scroll capability after Bluetooth id
 - Administrator account for installation
 - Reboot access
 
-## Quick Install (3 Steps)
+## Quick Install (one click)
 
-### Step 1: Download & Verify
+1. Clone this repository on Windows.
+2. Double-click `v2-kmdf-driver\Install-KMDF.cmd`.
+3. Accept Administrator **once**. After that the SYSTEM task `MM-Kmdf-Install` runs unattended (sign, install, bind 0323 only, Bluetooth bounce, reboot if needed, post-boot test).
+
+Details and HVCI / test-signing notes: [`v2-kmdf-driver/README.md`](v2-kmdf-driver/README.md).
+
+## Legacy v1 binary patch (do not ship)
+
+The steps below install the old patched `applewirelessmouse.sys`. **Do not use this for 0323.** It is kept only as history.
+
+### Step 1: Download & Verify (v1 only — ship-blocker)
 
 ```powershell
 # Download v1.0.0 release
@@ -189,14 +206,7 @@ HKLM\SYSTEM\CurrentControlSet\Enum\BTHENUM\
 - Registry-based LowerFilters registration
 - Requires certificate trust
 
-**v2.0.0 (in progress):** KMDF filter driver rewrite.
-- From-scratch WDF source code
-- No Apple binary dependency
-- Cleaner driver signing process
-- Better Windows Defender SmartScreen integration
-- Windows 11 22H2+ target
-
-See `/v2-kmdf-driver/README.md` for v2 status.
+**v2.0.3 (this tree):** KMDF `MagicMouseDriver` for 0323 only — INF, vcxproj, source, and one-click SYSTEM-task installer. See `/v2-kmdf-driver/README.md`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,20 @@ Double-click `v2-kmdf-driver/Install-KMDF.cmd`. First run: one Administrator pro
 
 `magic-tray` should install **this** KMDF for PID 0323 (do not vendor the tree into the tray repo).
 
-The v1 `applewirelessmouse.sys` binary patch is a **ship-blocker** (BSOD 0xD1). Do not install it for 0323. Do not dual-filter it with MagicMouseDriver. No PATH-A.
+The v1 PATH-A package is **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`** (BSOD 0xD1). It is **not** the 0323 product. Never name it `MagicMouseDriver.sys`. Windows would still load it as `applewirelessmouse.sys` — do not install it for 0323. Do not dual-filter. No PATH-A.
+
+## Artifact names (do not mix these up)
+
+Windows install names stay **`MagicMouseDriver.sys`** (KMDF service) and **`applewirelessmouse.sys`** (PATH-A service). Package / backup / version labels are different:
+
+| Package / backup filename | FileVersion | What it is |
+|---------------------------|-------------|------------|
+| **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** | **not** 2.0.4.0 (live MagicMouseFix `AD5D244B`) | **Pointer-only** baseline. Scroll dead. Leave on the Apr 30 PC. |
+| **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`** | 2.0.2.0 | **Pointer-dead.** Installer refuses this SHA. |
+| **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** | **2.0.4.0** | **Scroll candidate.** Hash after a Windows WDK build. INF still copies it as `MagicMouseDriver.sys`. |
+| **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`** | PATH-A v1 | **SHIP-BLOCKER** (BSOD 0xD1). Stays in `v1-binary-patch/`. Never the 0323 product. |
+
+Linux cannot produce a `.sys`. Do not merge until hardware proves scroll. Do not install 2.0.4 on the Apr 30 PC yet.
 
 ---
 
@@ -56,7 +69,7 @@ Details and HVCI / test-signing notes: [`v2-kmdf-driver/README.md`](v2-kmdf-driv
 
 ## Legacy v1 binary patch (do not ship)
 
-The steps below install the old patched `applewirelessmouse.sys`. **Do not use this for 0323.** It is kept only as history.
+The steps below install the old PATH-A package `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` (Windows dest: `applewirelessmouse.sys`). **Do not use this for 0323.** It is kept only as history.
 
 ### Step 1: Download & Verify (v1 only — ship-blocker)
 
@@ -65,7 +78,7 @@ The steps below install the old patched `applewirelessmouse.sys`. **Do not use t
 # Extract to C:\Program Files\MagicMousePatch\
 
 # Verify binary integrity (mandatory)
-$sys = "C:\Program Files\MagicMousePatch\v1-binary-patch\applewirelessmouse.sys"
+$sys = "C:\Program Files\MagicMousePatch\v1-binary-patch\applewirelessmouse-patched-pathA-SHIPBLOCKER.sys"
 (Get-FileHash $sys -Algorithm SHA256).Hash
 # Expected: 370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
 ```
@@ -203,12 +216,12 @@ HKLM\SYSTEM\CurrentControlSet\Enum\BTHENUM\
 ## Roadmap
 
 **v1.0.0 (current):** Binary patch of Apple firmware via WDM lower filter.
-- Patched applewirelessmouse.sys (66 KB)
+- PATH-A `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` (66 KB; installs as `applewirelessmouse.sys`)
 - PowerShell installer + uninstaller
 - Registry-based LowerFilters registration
 - Requires certificate trust
 
-**v2.0.3 (this tree):** KMDF `MagicMouseDriver` for 0323 only — INF, vcxproj, source, and one-click SYSTEM-task installer. See `/v2-kmdf-driver/README.md`.
+**v2.0.4 (this tree):** KMDF scroll candidate `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion / DriverVer **2.0.4.0**). INF still installs as `MagicMouseDriver.sys`. See `/v2-kmdf-driver/README.md`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 **0323 product: KMDF `MagicMouseDriver` in `v2-kmdf-driver/`.**  
 Double-click `v2-kmdf-driver/Install-KMDF.cmd`. First run: one Administrator prompt (registers a SYSTEM task). Later runs: no UAC. Result: `C:\ProgramData\MagicMouseDriver\RESULT.txt`.
 
+**Do not install on the live Apr 30 PC yet** (MagicMouseFix `AD5D244B` stays). Linux cannot produce a `.sys`. **Do not merge until hardware proves scroll.**
+
 `magic-tray` should install **this** KMDF for PID 0323 (do not vendor the tree into the tray repo).
 
-The v1 `applewirelessmouse.sys` binary patch is a **ship-blocker** (BSOD 0xD1). Do not install it for 0323. Do not dual-filter it with MagicMouseDriver.
+The v1 `applewirelessmouse.sys` binary patch is a **ship-blocker** (BSOD 0xD1). Do not install it for 0323. Do not dual-filter it with MagicMouseDriver. No PATH-A.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ If you discover a security vulnerability in this driver patch, please report it 
 This security policy covers only this driver patch repository and its distributed binaries/scripts.
 
 **In scope:**
-- applewirelessmouse.sys kernel driver
+- PATH-A `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` (installs as `applewirelessmouse.sys`) and KMDF `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (installs as `MagicMouseDriver.sys`)
 - PowerShell installer and uninstaller scripts
 - Registry modifications made by installer/uninstaller
 - Certificate installation process
@@ -52,7 +52,7 @@ This security policy covers only this driver patch repository and its distribute
 
 1. **Verify binary integrity:** Always run the SHA256 hash check before installation
    ```powershell
-   (Get-FileHash "applewirelessmouse.sys" -Algorithm SHA256).Hash
+   (Get-FileHash "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys" -Algorithm SHA256).Hash
    # Expected: 370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
    ```
 

--- a/v1-binary-patch/README.md
+++ b/v1-binary-patch/README.md
@@ -1,6 +1,12 @@
 # v1.0.0 — Binary Patch Installer
 
-**STATUS: Production Ready**
+**SHIP-BLOCKER for PID 0323.** The patched `applewirelessmouse.sys` has caused BSOD 0xD1 (`DRIVER_IRQL_NOT_LESS_OR_EQUAL`). It is **not** the 0323 product.
+
+Use **`../v2-kmdf-driver/Install-KMDF.cmd`** (KMDF `MagicMouseDriver`, sole LowerFilters, 0323 only). Do not dual-filter this binary with MagicMouseDriver.
+
+---
+
+**STATUS: Historical only — do not ship**
 
 This directory contains the PATH-A binary patch approach: a pre-built, patched applewirelessmouse.sys kernel driver and PowerShell installer/uninstaller.
 

--- a/v1-binary-patch/README.md
+++ b/v1-binary-patch/README.md
@@ -1,14 +1,14 @@
 # v1.0.0 — Binary Patch Installer
 
-**SHIP-BLOCKER for PID 0323.** The patched `applewirelessmouse.sys` has caused BSOD 0xD1 (`DRIVER_IRQL_NOT_LESS_OR_EQUAL`). It is **not** the 0323 product.
+**SHIP-BLOCKER for PID 0323.** The package file is **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`**. It has caused BSOD 0xD1 (`DRIVER_IRQL_NOT_LESS_OR_EQUAL`). It is **not** the 0323 product. Never name it `MagicMouseDriver.sys`. Windows would still copy it to `applewirelessmouse.sys` if someone ran this historical installer.
 
-Use **`../v2-kmdf-driver/Install-KMDF.cmd`** (KMDF `MagicMouseDriver`, sole LowerFilters, 0323 only). Do not dual-filter this binary with MagicMouseDriver.
+Use **`../v2-kmdf-driver/Install-KMDF.cmd`** (KMDF artifact `MagicMouseDriver-kmdf-2.0.4-scroll.sys`, INF dest `MagicMouseDriver.sys`, sole LowerFilters, 0323 only). Do not dual-filter this binary with MagicMouseDriver.
 
 ---
 
 **STATUS: Historical only — do not ship**
 
-This directory contains the PATH-A binary patch approach: a pre-built, patched applewirelessmouse.sys kernel driver and PowerShell installer/uninstaller.
+This directory contains the PATH-A binary patch approach: a pre-built, patched kernel driver packaged as `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` and PowerShell installer/uninstaller. The Windows service name remains `applewirelessmouse.sys`.
 
 ## Quick Start
 
@@ -39,7 +39,7 @@ Open Device Manager and locate your Magic Mouse:
    cd "C:\Program Files\MagicMousePatch\v1-binary-patch"
    
    # Check the SHA256 hash
-   (Get-FileHash "applewirelessmouse.sys" -Algorithm SHA256).Hash
+   (Get-FileHash "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys" -Algorithm SHA256).Hash
    ```
    
    **Expected output:**
@@ -51,7 +51,7 @@ Open Device Manager and locate your Magic Mouse:
 
 3. **Verify certificate thumbprint** (optional but recommended):
    ```powershell
-   $cert = Get-AuthenticodeSignature "applewirelessmouse.sys"
+   $cert = Get-AuthenticodeSignature "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys"
    $cert.SignerCertificate.Thumbprint
    ```
    
@@ -182,7 +182,7 @@ After reboot, your system will be back to its original state before the patch wa
 **Fix:**
 ```powershell
 # Try installing certificate manually
-$cert = Get-AuthenticodeSignature "applewirelessmouse.sys"
+$cert = Get-AuthenticodeSignature "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys"
 # If this shows no signer, the binary is corrupted
 
 # Try importing certificate directly
@@ -252,12 +252,12 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 ```
 v1-binary-patch/
 ├── README.md (this file)
-├── applewirelessmouse.sys (patched driver binary, 66 KB)
+├── applewirelessmouse-patched-pathA-SHIPBLOCKER.sys (PATH-A package, 66 KB; never MagicMouseDriver.sys)
 ├── MagicMouseFix.cer (code-signing certificate)
 ├── installer/
 │   ├── Install-MagicMousePatch.ps1 (main installer)
 │   ├── Uninstall-MagicMousePatch.ps1 (uninstaller)
-│   └── applewirelessmouse.sys (copy for installer reference)
+│   └── applewirelessmouse-patched-pathA-SHIPBLOCKER.sys (optional copy; Windows dest remains applewirelessmouse.sys)
 ├── docs/
 │   ├── bug-analysis.md (detailed problem explanation)
 │   └── architecture.md (how the filter driver works)
@@ -265,7 +265,7 @@ v1-binary-patch/
 
 ## For v2 Users (Future)
 
-v2.0.0 will be a from-scratch KMDF driver rewrite. Until then, v1.0.0 (this binary patch) is the current production release.
+v1.0.0 (this PATH-A binary) is **not** the 0323 product. The 0323 product is KMDF `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion 2.0.4.0; INF dest `MagicMouseDriver.sys`).
 
 See `/v2-kmdf-driver/README.md` for v2 status and roadmap.
 

--- a/v1-binary-patch/installer/Install-MagicMousePatch.ps1
+++ b/v1-binary-patch/installer/Install-MagicMousePatch.ps1
@@ -5,8 +5,10 @@
 Installs the Magic Mouse v3 scroll fix (PATH-A binary patch) on Windows.
 
 .DESCRIPTION
-Installs a lower-filter kernel driver (applewirelessmouse.sys) that restores scroll
-functionality on Apple Magic Mouse v3 (PID 0x0323) when paired over Bluetooth.
+Installs a lower-filter kernel driver. Package file is
+applewirelessmouse-patched-pathA-SHIPBLOCKER.sys. Windows still loads
+applewirelessmouse.sys. This is a SHIP-BLOCKER (BSOD 0xD1), not the 0323
+KMDF product, and must never be named MagicMouseDriver.sys.
 
 Logic is extracted from the production-tested install route
 (PATHA-V5-DIRECTCOPY-INSTALL) and adapted for a pre-signed public binary.
@@ -16,7 +18,7 @@ Workflow:
   2. HiberbootEnabled (Fast Startup) must be 0
   3. Test Signing mode must be ON (self-signed kernel driver)
   4. HVCI / Memory Integrity warning (Win11 22H2+ blocks self-signed drivers)
-  5. SHA256 + size verify of shipped applewirelessmouse.sys
+  5. SHA256 + size verify of applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
   6. Import MagicMouseFix.cer to LocalMachine\TrustedPublisher (NOT Root)
   7. Backup existing driver to C:\ProgramData\MagicMousePatch\backup\
   8. Detect v3 device via BTHENUM PID&0323
@@ -48,9 +50,17 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 }
 
 $ScriptRoot   = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$DriverSrc    = Join-Path $ScriptRoot "applewirelessmouse.sys"
+$PackageName  = "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys"
+$DriverSrc    = @(
+    (Join-Path (Split-Path -Parent $ScriptRoot) $PackageName),
+    (Join-Path $ScriptRoot $PackageName)
+) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+if (-not $DriverSrc) {
+    $DriverSrc = Join-Path (Split-Path -Parent $ScriptRoot) $PackageName
+}
 $CertPath     = Join-Path $ScriptRoot "MagicMouseFix.cer"
 $BackupDir    = "C:\ProgramData\MagicMousePatch\backup"
+# Windows service / ImagePath name — do not change.
 $TargetDriver = "C:\Windows\System32\drivers\applewirelessmouse.sys"
 $ServiceName  = "applewirelessmouse"
 
@@ -161,7 +171,7 @@ function Test-HvciState {
 function Test-DriverBinary {
     Write-Section "Verifying shipped driver binary..."
     if (-not (Test-Path $DriverSrc)) {
-        Write-Status "Driver binary not found: $DriverSrc" "ERROR"
+        Write-Status "PATH-A package not found: $DriverSrc (expected $PackageName; Windows still installs as applewirelessmouse.sys). Never use MagicMouseDriver.sys." "ERROR"
         return $false
     }
     $size = (Get-Item $DriverSrc).Length
@@ -236,7 +246,7 @@ function Backup-ExistingDriver {
         New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null
     }
     $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
-    $dst   = Join-Path $BackupDir "applewirelessmouse_$stamp.sys"
+    $dst   = Join-Path $BackupDir "applewirelessmouse-pre-pathA_$stamp.sys"
     Copy-Item -Path $TargetDriver -Destination $dst -Force
     Write-Status "Backed up to $dst" "OK"
     return $true

--- a/v1-binary-patch/installer/SHA256SUMS.txt
+++ b/v1-binary-patch/installer/SHA256SUMS.txt
@@ -1,7 +1,10 @@
-# SHA256 checksums for Magic Mouse v3 Windows Fix v1.0.0
+# SHA256 checksums for Magic Mouse v3 PATH-A ship-blocker (historical only).
+# Package filename: applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
+# Windows still installs that payload as applewirelessmouse.sys.
+# Never name this MagicMouseDriver.sys. Never treat it as the 0323 KMDF product.
 # Verify with: certutil -hashfile <file> SHA256  (Windows)
 #              sha256sum <file>                   (Linux/macOS)
 
-370a5555aebf673c3156ea5b5fbabd8030f2ee7a3a6bd0fcb1b4b6c93fa56a03  applewirelessmouse.sys
+370a5555aebf673c3156ea5b5fbabd8030f2ee7a3a6bd0fcb1b4b6c93fa56a03  applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
 # MagicMouseFix.cer checksum — fill in after cert export
 # <sha256>  MagicMouseFix.cer

--- a/v1-binary-patch/installer/Uninstall-MagicMousePatch.ps1
+++ b/v1-binary-patch/installer/Uninstall-MagicMousePatch.ps1
@@ -128,7 +128,8 @@ function Restore-DriverBackup {
         }
         return
     }
-    $backups = Get-ChildItem -Path $BackupDir -Filter "applewirelessmouse_*.sys" -ErrorAction SilentlyContinue |
+    $backups = @(Get-ChildItem -Path $BackupDir -Filter "applewirelessmouse-pre-pathA_*.sys" -ErrorAction SilentlyContinue) +
+               @(Get-ChildItem -Path $BackupDir -Filter "applewirelessmouse_*.sys" -ErrorAction SilentlyContinue) |
                Sort-Object LastWriteTime -Descending
     if (-not $backups) {
         Write-Status "No backup files found; removing patched driver instead" "WARN"

--- a/v2-kmdf-driver/AclTranslate.c
+++ b/v2-kmdf-driver/AclTranslate.c
@@ -8,7 +8,10 @@
 // completion the buffer is a Bluetooth HID interrupt payload:
 //   raw:        12 <MOUSE2...>
 //   HID DATA:   A1 12 <MOUSE2...>
-// We replace that with Descriptor C's RID 0x02 (6 bytes, optional 0xA1).
+//
+// Live HID 2026-08-30 21:23 MDT: COL01 Input 0x12 is X/Y only (no 0x0038).
+// Stay on 0x12 and fill Wheel / AC Pan. Do not convert to RID 0x02.
+// RID 0x90 (COL02 battery Input) is passed through.
 
 #include "AclTranslate.h"
 #include "GestureEngine.h"
@@ -26,7 +29,19 @@ TranslateAclHidReport(
 {
     *newLen = len;
 
-    if (buf == NULL || ctx == NULL || len < 6)
+    if (buf == NULL || ctx == NULL || len < 1)
+    {
+        return FALSE;
+    }
+
+    // Battery: live HidD_GetInputReport(0x90) on COL02. Do not rewrite.
+    if (buf[0] == MM_REPORT_ID_BATTERY ||
+        (buf[0] == HID_MSG_DATA_INPUT && len >= 2 && buf[1] == MM_REPORT_ID_BATTERY))
+    {
+        return FALSE;
+    }
+
+    if (len < 6)
     {
         return FALSE;
     }
@@ -35,20 +50,14 @@ TranslateAclHidReport(
     ULONG  reportLen = len;
     BOOLEAN hidHdr = FALSE;
 
-    // RID 0x02 is the Apr 30 pointer path — do not rewrite it.
-    if (buf[0] == 0x02 || (buf[0] == HID_MSG_DATA_INPUT && len >= 2 && buf[1] == 0x02))
-    {
-        return FALSE;
-    }
-
     if (buf[0] == HID_MSG_DATA_INPUT && len >= 7 &&
-        (buf[1] == 0x12 || buf[1] == 0x27))
+        (buf[1] == MM_REPORT_ID_MOUSE || buf[1] == 0x27))
     {
         hidHdr = TRUE;
         report = buf + 1;
         reportLen = len - 1;
     }
-    else if (buf[0] != 0x12 && buf[0] != 0x27)
+    else if (buf[0] != MM_REPORT_ID_MOUSE && buf[0] != 0x27)
     {
         return FALSE;
     }
@@ -61,6 +70,8 @@ TranslateAclHidReport(
         return FALSE;
     }
 
+    // May grow a 6-byte native X/Y-only 0x12 to 8 bytes (Wheel/AC Pan).
+    // ACL buffers are far larger than 8; BufferSize is the received length.
     if (hidHdr)
     {
         buf[0] = HID_MSG_DATA_INPUT;

--- a/v2-kmdf-driver/AclTranslate.c
+++ b/v2-kmdf-driver/AclTranslate.c
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+//
+// Rewrite Magic Mouse 0x12 reports on the L2CAP ACL path HidBth uses.
+//
+// HidBth sits above this filter. hidclass IRP_MJ_READ stops at HidBth, so
+// EvtIoRead is not the live pointer path. HidBth posts BRB_L2CA_ACL_TRANSFER
+// (IOCTL_INTERNAL_BTH_SUBMIT_BRB) down through us to BthEnum. On IN
+// completion the buffer is a Bluetooth HID interrupt payload:
+//   raw:        12 <MOUSE2...>
+//   HID DATA:   A1 12 <MOUSE2...>
+// We replace that with Descriptor C's RID 0x02 (6 bytes, optional 0xA1).
+
+#include "AclTranslate.h"
+#include "GestureEngine.h"
+
+#ifndef HID_MSG_DATA_INPUT
+#define HID_MSG_DATA_INPUT 0xA1
+#endif
+
+BOOLEAN
+TranslateAclHidReport(
+    _Inout_updates_bytes_(len) PUCHAR buf,
+    _In_ ULONG len,
+    _Out_ PULONG newLen,
+    _Inout_ PDEVICE_CONTEXT ctx)
+{
+    *newLen = len;
+
+    if (buf == NULL || ctx == NULL || len < 6)
+    {
+        return FALSE;
+    }
+
+    PUCHAR report = buf;
+    ULONG  reportLen = len;
+    BOOLEAN hidHdr = FALSE;
+
+    // RID 0x02 is the Apr 30 pointer path — do not rewrite it.
+    if (buf[0] == 0x02 || (buf[0] == HID_MSG_DATA_INPUT && len >= 2 && buf[1] == 0x02))
+    {
+        return FALSE;
+    }
+
+    if (buf[0] == HID_MSG_DATA_INPUT && len >= 7 &&
+        (buf[1] == 0x12 || buf[1] == 0x27))
+    {
+        hidHdr = TRUE;
+        report = buf + 1;
+        reportLen = len - 1;
+    }
+    else if (buf[0] != 0x12 && buf[0] != 0x27)
+    {
+        return FALSE;
+    }
+
+    UCHAR translated[MM_MOUSE_REPORT_LEN];
+    ULONG translatedLen = sizeof(translated);
+    NTSTATUS ts = TranslateMouse2ToHid(report, reportLen, translated, &translatedLen, ctx);
+    if (!NT_SUCCESS(ts) || translatedLen != MM_MOUSE_REPORT_LEN)
+    {
+        return FALSE;
+    }
+
+    if (hidHdr)
+    {
+        buf[0] = HID_MSG_DATA_INPUT;
+        RtlCopyMemory(buf + 1, translated, MM_MOUSE_REPORT_LEN);
+        *newLen = 1 + MM_MOUSE_REPORT_LEN;
+    }
+    else
+    {
+        RtlCopyMemory(buf, translated, MM_MOUSE_REPORT_LEN);
+        *newLen = MM_MOUSE_REPORT_LEN;
+    }
+    return TRUE;
+}

--- a/v2-kmdf-driver/AclTranslate.h
+++ b/v2-kmdf-driver/AclTranslate.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "Driver.h"
+
+// TRUE if buf looks like a Bluetooth HID input carrying MOUSE2 RID 0x12
+// (raw 0x12 or HID DATA+INPUT 0xA1 0x12). On TRUE, *newLen is the rewritten
+// length (6 or 7). Buffer is mutated in place.
+BOOLEAN
+TranslateAclHidReport(
+    _Inout_updates_bytes_(len) PUCHAR buf,
+    _In_ ULONG len,
+    _Out_ PULONG newLen,
+    _Inout_ PDEVICE_CONTEXT ctx);

--- a/v2-kmdf-driver/AclTranslate.h
+++ b/v2-kmdf-driver/AclTranslate.h
@@ -5,7 +5,7 @@
 
 // TRUE if buf looks like a Bluetooth HID input carrying MOUSE2 RID 0x12
 // (raw 0x12 or HID DATA+INPUT 0xA1 0x12). On TRUE, *newLen is the rewritten
-// length (6 or 7). Buffer is mutated in place.
+// length (8, or 9 with 0xA1). Buffer is mutated in place. 0x90 is not rewritten.
 BOOLEAN
 TranslateAclHidReport(
     _Inout_updates_bytes_(len) PUCHAR buf,

--- a/v2-kmdf-driver/BUILDING.md
+++ b/v2-kmdf-driver/BUILDING.md
@@ -1,8 +1,10 @@
-# Building MagicMouseDriver.sys
+# Building MagicMouseDriver-kmdf-2.0.4-scroll.sys
 
 Linux cannot produce a `.sys`. Build on Windows 10/11 x64 with Visual Studio + WDK, or a mounted Enterprise WDK.
 
-Do **not** install a build on the live Apr 30 PC (`AD5D244B`, pointer OK / scroll dead) until you are ready to prove 2.0.4 scroll. Do not merge until hardware proves pointer **and** scroll.
+`msbuild` / INF still emit **`MagicMouseDriver.sys`** (Windows service name). Copy or let the installer label the artifact **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`**. FileVersion / DriverVer is **2.0.4.0**.
+
+Do **not** install a build on the live Apr 30 PC (`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`, pointer OK / scroll dead) until you are ready to prove 2.0.4 scroll. Do not merge until hardware proves pointer **and** scroll. Never name a KMDF build `applewirelessmouse*.sys`.
 
 ## WDK / Visual Studio
 
@@ -10,7 +12,7 @@ Do **not** install a build on the live Apr 30 PC (`AD5D244B`, pointer OK / scrol
 msbuild MagicMouseDriver.vcxproj /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off
 ```
 
-Output is typically `x64\Release\MagicMouseDriver.sys` (or a WDK subfolder). Copy it next to `MagicMouseDriver.inf` if you want the one-click task to skip compile.
+Output is typically `x64\Release\MagicMouseDriver.sys` (INF name). The installer copies it to `MagicMouseDriver-kmdf-2.0.4-scroll.sys` next to the INF. You can also drop that labeled file next to the INF to skip compile.
 
 `SignMode=Off` is required: WDK's inline sign task often deletes the `.sys` when `signtool` wants `/fd sha256`. The SYSTEM installer signs afterwards.
 

--- a/v2-kmdf-driver/BUILDING.md
+++ b/v2-kmdf-driver/BUILDING.md
@@ -2,6 +2,8 @@
 
 Linux cannot produce a `.sys`. Build on Windows 10/11 x64 with Visual Studio + WDK, or a mounted Enterprise WDK.
 
+Do **not** install a build on the live Apr 30 PC (`AD5D244B`, pointer OK / scroll dead) until you are ready to prove 2.0.4 scroll. Do not merge until hardware proves pointer **and** scroll.
+
 ## WDK / Visual Studio
 
 ```bat

--- a/v2-kmdf-driver/BUILDING.md
+++ b/v2-kmdf-driver/BUILDING.md
@@ -1,0 +1,25 @@
+# Building MagicMouseDriver.sys
+
+Linux cannot produce a `.sys`. Build on Windows 10/11 x64 with Visual Studio + WDK, or a mounted Enterprise WDK.
+
+## WDK / Visual Studio
+
+```bat
+msbuild MagicMouseDriver.vcxproj /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off
+```
+
+Output is typically `x64\Release\MagicMouseDriver.sys` (or a WDK subfolder). Copy it next to `MagicMouseDriver.inf` if you want the one-click task to skip compile.
+
+`SignMode=Off` is required: WDK's inline sign task often deletes the `.sys` when `signtool` wants `/fd sha256`. The SYSTEM installer signs afterwards.
+
+## Enterprise WDK ISO
+
+1. Mount the EWDK ISO.
+2. Run `LaunchBuildEnv.cmd` (or `BuildEnv\SetupBuildEnv.cmd`).
+3. `msbuild` the vcxproj as above.
+
+The SYSTEM task (`MM-Kmdf-Install`) can see WDK on `C:\Program Files*`. It **cannot** see an ISO you mounted only in your interactive session (Session 0). Prefer an installed WDK, or place a prebuilt `.sys` in the package folder.
+
+## After the `.sys` exists
+
+Double-click `Install-KMDF.cmd`. Do not run a pile of helper scripts by hand.

--- a/v2-kmdf-driver/Driver.c
+++ b/v2-kmdf-driver/Driver.c
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: MIT
+#include "Driver.h"
+#include "InputHandler.h"
+#include "GestureEngine.h"
+#include "AclTranslate.h"
+
+// BRB_L2CA_ACL_TRANSFER field offsets on x64 (bthddi.h / Win10+).
+// BRB_HEADER.Type is at +0x16. ACL Buffer/Size follow the 0x70-byte header
+// + BTH_ADDR + ChannelHandle. Validated against WDK 10.0.14393 bthddi.h.
+#define MM_BRB_LENGTH_OFFSET  0x10
+#define MM_BRB_TYPE_OFFSET    0x16
+#define MM_ACL_FLAGS_OFFSET   0x80
+#define MM_ACL_BUFSIZE_OFFSET 0x84
+#define MM_ACL_BUFFER_OFFSET  0x88
+#define MM_ACL_MDL_OFFSET     0x90
+#define MM_ACL_MIN_BRB_LEN    0x98
+
+static VOID
+ForwardPassthrough(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target)
+{
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WDF_REQUEST_SEND_OPTIONS opts;
+    WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+    if (!WdfRequestSend(Request, Target, &opts))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+static VOID
+ForwardSdpWithCompletion(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target, _In_ PDEVICE_CONTEXT ctx)
+{
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->IoctlInterceptCount++;
+    WdfSpinLockRelease(ctx->Lock);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, OnSdpQueryComplete, ctx);
+    if (!WdfRequestSend(Request, Target, WDF_NO_SEND_OPTIONS))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+NTSTATUS
+DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
+{
+    WDF_DRIVER_CONFIG config;
+    WDF_DRIVER_CONFIG_INIT(&config, EvtDeviceAdd);
+    return WdfDriverCreate(DriverObject, RegistryPath, WDF_NO_OBJECT_ATTRIBUTES,
+                           &config, WDF_NO_HANDLE);
+}
+
+NTSTATUS
+EvtDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT DeviceInit)
+{
+    UNREFERENCED_PARAMETER(Driver);
+
+    WdfFdoInitSetFilter(DeviceInit);
+
+    WDF_OBJECT_ATTRIBUTES reqAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&reqAttr, MM_REQUEST_CONTEXT);
+    WdfDeviceInitSetRequestAttributes(DeviceInit, &reqAttr);
+
+    WDF_OBJECT_ATTRIBUTES devAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&devAttr, DEVICE_CONTEXT);
+
+    WDFDEVICE device;
+    NTSTATUS status = WdfDeviceCreate(&DeviceInit, &devAttr, &device);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+
+    WDF_OBJECT_ATTRIBUTES lockAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&lockAttr);
+    lockAttr.ParentObject = device;
+    status = WdfSpinLockCreate(&lockAttr, &ctx->Lock);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    ctx->EnableInjection = TRUE;
+    {
+        WDFKEY paramsKey = NULL;
+        NTSTATUS ks = WdfDriverOpenParametersRegistryKey(
+            Driver, KEY_READ, WDF_NO_OBJECT_ATTRIBUTES, &paramsKey);
+        if (NT_SUCCESS(ks) && paramsKey != NULL)
+        {
+            ULONG val = 1;
+            UNICODE_STRING valName;
+            RtlInitUnicodeString(&valName, L"EnableInjection");
+            if (NT_SUCCESS(WdfRegistryQueryULong(paramsKey, &valName, &val)))
+            {
+                ctx->EnableInjection = (val != 0);
+            }
+            WdfRegistryClose(paramsKey);
+        }
+    }
+
+    ctx->ProductId = 0;
+    {
+        PDEVICE_OBJECT pdo = WdfDeviceWdmGetPhysicalDevice(device);
+        if (pdo != NULL)
+        {
+            WCHAR hwIdBuf[256] = { 0 };
+            ULONG retLen = 0;
+            NTSTATUS pidStatus = IoGetDeviceProperty(
+                pdo,
+                DevicePropertyHardwareID,
+                sizeof(hwIdBuf) - sizeof(WCHAR),
+                hwIdBuf,
+                &retLen);
+
+            if (NT_SUCCESS(pidStatus) && retLen >= sizeof(WCHAR))
+            {
+                ULONG wcharCount = retLen / sizeof(WCHAR);
+                for (ULONG i = 0; i + 8 <= wcharCount; i++)
+                {
+                    if (hwIdBuf[i]     == L'P' &&
+                        hwIdBuf[i + 1] == L'I' &&
+                        hwIdBuf[i + 2] == L'D' &&
+                        hwIdBuf[i + 3] == L'&')
+                    {
+                        USHORT pid = 0;
+                        for (ULONG j = i + 4; j < wcharCount && j < i + 8; j++)
+                        {
+                            WCHAR  c      = hwIdBuf[j];
+                            USHORT nibble = 0;
+                            if      (c >= L'0' && c <= L'9') { nibble = (USHORT)(c - L'0'); }
+                            else if (c >= L'A' && c <= L'F') { nibble = (USHORT)(c - L'A' + 10); }
+                            else if (c >= L'a' && c <= L'f') { nibble = (USHORT)(c - L'a' + 10); }
+                            else { break; }
+                            pid = (USHORT)((pid << 4) | nibble);
+                        }
+                        ctx->ProductId = pid;
+                        break;
+                    }
+                }
+            }
+        }
+        DbgPrint("MM: AddDevice ProductId=0x%04X EnableInjection=%d\n",
+                 ctx->ProductId, ctx->EnableInjection);
+    }
+
+    WDF_TIMER_CONFIG timerCfg;
+    WDF_TIMER_CONFIG_INIT_PERIODIC(&timerCfg, MmDiagTimerFunc, 1000);
+    WDF_OBJECT_ATTRIBUTES timerAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&timerAttr);
+    timerAttr.ParentObject = device;
+    status = WdfTimerCreate(&timerCfg, &timerAttr, &ctx->DiagTimer);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    WDF_WORKITEM_CONFIG wiCfg;
+    WDF_WORKITEM_CONFIG_INIT(&wiCfg, MmDiagWorkItemFunc);
+    WDF_OBJECT_ATTRIBUTES wiAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&wiAttr);
+    wiAttr.ParentObject = device;
+    status = WdfWorkItemCreate(&wiCfg, &wiAttr, &ctx->DiagWorkItem);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    WdfTimerStart(ctx->DiagTimer, WDF_REL_TIMEOUT_IN_MS(1000));
+
+    WDF_IO_QUEUE_CONFIG qCfg;
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&qCfg, WdfIoQueueDispatchParallel);
+    qCfg.EvtIoDeviceControl         = EvtIoDeviceControl;
+    qCfg.EvtIoInternalDeviceControl = EvtIoInternalDeviceControl;
+    qCfg.EvtIoRead                  = EvtIoRead;
+    qCfg.EvtIoDefault               = EvtIoDefault;
+
+    WDFQUEUE queue;
+    return WdfIoQueueCreate(device, &qCfg, WDF_NO_OBJECT_ATTRIBUTES, &queue);
+}
+
+VOID
+EvtIoInternalDeviceControl(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request,
+                            _In_ size_t OutputBufferLength, _In_ size_t InputBufferLength,
+                            _In_ ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE       device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx    = GetDeviceContext(device);
+    WDFIOTARGET     target = WdfDeviceGetIoTarget(device);
+
+    if (IoControlCode == IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        ForwardSdpWithCompletion(Request, target, ctx);
+        return;
+    }
+
+    if (IoControlCode == IOCTL_INTERNAL_BTH_SUBMIT_BRB &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        PIRP irp = WdfRequestWdmGetIrp(Request);
+        PIO_STACK_LOCATION sl = IoGetCurrentIrpStackLocation(irp);
+        PUCHAR brb = (PUCHAR)sl->Parameters.Others.Argument1;
+
+        if (brb != NULL)
+        {
+            USHORT type = 0;
+            ULONG  brbLen = 0;
+            RtlCopyMemory(&brbLen, brb + MM_BRB_LENGTH_OFFSET, sizeof(ULONG));
+            RtlCopyMemory(&type, brb + MM_BRB_TYPE_OFFSET, sizeof(USHORT));
+
+            if (type == (USHORT)BRB_L2CA_ACL_TRANSFER && brbLen >= MM_ACL_MIN_BRB_LEN)
+            {
+                ULONG flags = 0;
+                RtlCopyMemory(&flags, brb + MM_ACL_FLAGS_OFFSET, sizeof(ULONG));
+                if ((flags & ACL_TRANSFER_DIRECTION_IN) != 0)
+                {
+                    PMM_REQUEST_CONTEXT reqCtx = GetRequestContext(Request);
+                    reqCtx->Brb = brb;
+
+                    WdfSpinLockAcquire(ctx->Lock);
+                    ctx->AclInterceptCount++;
+                    WdfSpinLockRelease(ctx->Lock);
+
+                    WdfRequestFormatRequestUsingCurrentType(Request);
+                    WdfRequestSetCompletionRoutine(Request, OnAclTransferComplete, ctx);
+                    if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+                    {
+                        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    ForwardPassthrough(Request, target);
+}
+
+VOID
+EvtIoDeviceControl(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request,
+                   _In_ size_t OutputBufferLength, _In_ size_t InputBufferLength,
+                   _In_ ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE       device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx    = GetDeviceContext(device);
+    WDFIOTARGET     target = WdfDeviceGetIoTarget(device);
+
+    if (IoControlCode == IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        ForwardSdpWithCompletion(Request, target, ctx);
+        return;
+    }
+
+    ForwardPassthrough(Request, target);
+}
+
+VOID
+EvtIoDefault(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request)
+{
+    ForwardPassthrough(Request, WdfDeviceGetIoTarget(WdfIoQueueGetDevice(Queue)));
+}
+
+VOID
+EvtIoRead(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request, _In_ size_t Length)
+{
+    UNREFERENCED_PARAMETER(Length);
+
+    WDFDEVICE       device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx    = GetDeviceContext(device);
+    WDFIOTARGET     target = WdfDeviceGetIoTarget(device);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, OnReadComplete, ctx);
+    if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+VOID
+OnAclTransferComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+                      _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+    PMM_REQUEST_CONTEXT reqCtx = GetRequestContext(Request);
+    PUCHAR brb = (reqCtx != NULL) ? (PUCHAR)reqCtx->Brb : NULL;
+
+    if (NT_SUCCESS(status) && ctx != NULL && brb != NULL)
+    {
+        ULONG brbLen = 0;
+        RtlCopyMemory(&brbLen, brb + MM_BRB_LENGTH_OFFSET, sizeof(ULONG));
+        if (brbLen >= MM_ACL_MIN_BRB_LEN)
+        {
+            ULONG  bufSize = 0;
+            PVOID  buffer  = NULL;
+            PMDL   mdl     = NULL;
+            RtlCopyMemory(&bufSize, brb + MM_ACL_BUFSIZE_OFFSET, sizeof(ULONG));
+            RtlCopyMemory(&buffer,  brb + MM_ACL_BUFFER_OFFSET,  sizeof(PVOID));
+            RtlCopyMemory(&mdl,     brb + MM_ACL_MDL_OFFSET,     sizeof(PMDL));
+
+            PUCHAR payload = (PUCHAR)buffer;
+            if (payload == NULL && mdl != NULL)
+            {
+                payload = (PUCHAR)MmGetSystemAddressForMdlSafe(mdl, NormalPagePriority);
+            }
+
+            if (payload != NULL && bufSize >= 6)
+            {
+                ULONG newLen = bufSize;
+                __try
+                {
+                    if (TranslateAclHidReport(payload, bufSize, &newLen, ctx) &&
+                        newLen > 0 && newLen <= bufSize)
+                    {
+                        RtlCopyMemory(brb + MM_ACL_BUFSIZE_OFFSET, &newLen, sizeof(ULONG));
+                        WdfSpinLockAcquire(ctx->Lock);
+                        ctx->AclTranslateCount++;
+                        ctx->Rid12Count++;
+                        WdfSpinLockRelease(ctx->Lock);
+                    }
+                }
+                __except (EXCEPTION_EXECUTE_HANDLER)
+                {
+                    DbgPrint("MM: OnAclTransferComplete — buffer exception, passthrough\n");
+                }
+            }
+        }
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+VOID
+OnReadComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+               _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    PUCHAR buf    = NULL;
+    SIZE_T bufLen = 0;
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufLen)) || buf == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    SIZE_T bytesRead = Params->IoStatus.Information;
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->HidReadCount++;
+    if (bytesRead > 0 && bytesRead <= bufLen && (buf[0] == 0x12 || buf[0] == 0x27))
+    {
+        ctx->Rid12Count++;
+    }
+    WdfSpinLockRelease(ctx->Lock);
+
+    __try
+    {
+        if (bytesRead >= 6 && (buf[0] == 0x12 || buf[0] == 0x27) &&
+            (ctx->ProductId == 0 || ctx->ProductId == MM_PID_V3))
+        {
+            UCHAR  translated[MM_MOUSE_REPORT_LEN];
+            ULONG  translatedLen = sizeof(translated);
+            NTSTATUS ts = TranslateMouse2ToHid(buf, bytesRead, translated, &translatedLen, ctx);
+            if (NT_SUCCESS(ts) && translatedLen == MM_MOUSE_REPORT_LEN &&
+                bufLen >= MM_MOUSE_REPORT_LEN)
+            {
+                RtlCopyMemory(buf, translated, translatedLen);
+                WdfRequestSetInformation(Request, translatedLen);
+            }
+        }
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        DbgPrint("MM: OnReadComplete — buffer exception, passthrough\n");
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+VOID
+OnSdpQueryComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+                   _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    PVOID  buf         = NULL;
+    size_t bufAllocLen = 0;
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufAllocLen)) ||
+        buf == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    size_t sdpLen = Params->IoStatus.Information;
+    if (sdpLen == 0 || sdpLen > bufAllocLen)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->LastSdpBufSize = (ULONG)sdpLen;
+    ULONG snapLen = (sdpLen < 64) ? (ULONG)sdpLen : 64;
+    RtlCopyMemory(ctx->LastSdpBytes, buf, snapLen);
+    if (snapLen < 64) { RtlZeroMemory(ctx->LastSdpBytes + snapLen, 64 - snapLen); }
+    WdfSpinLockRelease(ctx->Lock);
+
+    // This INF binds 0323 only. Still refuse to rewrite if PID is a known
+    // other Magic Mouse (defense in depth — do not retarget 030D).
+    if (ctx->ProductId != 0 && ctx->ProductId != MM_PID_V3)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    ULONG    newLen      = (ULONG)sdpLen;
+    NTSTATUS patchStatus = SdpRewrite_Process((PUCHAR)buf, (ULONG)sdpLen, &newLen);
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->LastPatchStatus = (ULONG)patchStatus;
+    if (patchStatus == STATUS_SUCCESS)
+    {
+        ctx->SdpScanHits++;
+        ctx->SdpPatchSuccess++;
+    }
+    else if (patchStatus == STATUS_MORE_PROCESSING_REQUIRED)
+    {
+        ctx->SdpScanHits++;
+    }
+    WdfSpinLockRelease(ctx->Lock);
+
+    if (patchStatus == STATUS_SUCCESS && newLen != (ULONG)sdpLen)
+    {
+        WdfRequestSetInformation(Request, (ULONG_PTR)newLen);
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+VOID
+MmDiagTimerFunc(_In_ WDFTIMER Timer)
+{
+    WDFDEVICE device = (WDFDEVICE)WdfTimerGetParentObject(Timer);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    if (ctx != NULL && ctx->DiagWorkItem != NULL)
+    {
+        WdfWorkItemEnqueue(ctx->DiagWorkItem);
+    }
+}
+
+VOID
+MmDiagWorkItemFunc(_In_ WDFWORKITEM WorkItem)
+{
+    WDFDEVICE device = (WDFDEVICE)WdfWorkItemGetParentObject(WorkItem);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    if (ctx == NULL) { return; }
+
+    ULONG ictlCount, scanHits, patchOk, lastSize, lastStatus;
+    ULONG hidReads, rid12, aclN, aclX;
+    UCHAR lastBytes[64];
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ictlCount  = ctx->IoctlInterceptCount;
+    scanHits   = ctx->SdpScanHits;
+    patchOk    = ctx->SdpPatchSuccess;
+    lastSize   = ctx->LastSdpBufSize;
+    lastStatus = ctx->LastPatchStatus;
+    hidReads   = ctx->HidReadCount;
+    rid12      = ctx->Rid12Count;
+    aclN       = ctx->AclInterceptCount;
+    aclX       = ctx->AclTranslateCount;
+    RtlCopyMemory(lastBytes, ctx->LastSdpBytes, 64);
+    WdfSpinLockRelease(ctx->Lock);
+
+    UNICODE_STRING keyPath;
+    RtlInitUnicodeString(&keyPath,
+        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Services\\MagicMouseDriver\\Diag");
+    OBJECT_ATTRIBUTES attr;
+    InitializeObjectAttributes(&attr, &keyPath,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+    HANDLE key  = NULL;
+    ULONG  disp = 0;
+    if (!NT_SUCCESS(ZwCreateKey(&key, KEY_WRITE, &attr, 0, NULL,
+                                REG_OPTION_NON_VOLATILE, &disp)))
+    {
+        return;
+    }
+
+    UNICODE_STRING n;
+
+#define SET_DWORD(Name, Val) \
+    RtlInitUnicodeString(&n, Name); \
+    ZwSetValueKey(key, &n, 0, REG_DWORD, &(Val), sizeof(ULONG))
+
+    SET_DWORD(L"IoctlInterceptCount", ictlCount);
+    SET_DWORD(L"SdpScanHits",         scanHits);
+    SET_DWORD(L"SdpPatchSuccess",     patchOk);
+    SET_DWORD(L"LastSdpBufSize",      lastSize);
+    SET_DWORD(L"LastPatchStatusHex",  lastStatus);
+    SET_DWORD(L"HidReadCount",        hidReads);
+    SET_DWORD(L"Rid12Count",          rid12);
+    SET_DWORD(L"AclInterceptCount",   aclN);
+    SET_DWORD(L"AclTranslateCount",   aclX);
+
+#undef SET_DWORD
+
+    RtlInitUnicodeString(&n, L"LastSdpBytes");
+    ZwSetValueKey(key, &n, 0, REG_BINARY, lastBytes, 64);
+    ZwClose(key);
+}

--- a/v2-kmdf-driver/Driver.c
+++ b/v2-kmdf-driver/Driver.c
@@ -305,13 +305,15 @@ OnAclTransferComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
                 payload = (PUCHAR)MmGetSystemAddressForMdlSafe(mdl, NormalPagePriority);
             }
 
-            if (payload != NULL && bufSize >= 6)
+            if (payload != NULL && bufSize >= 1)
             {
                 ULONG newLen = bufSize;
                 __try
                 {
+                    // May grow 6-byte X/Y-only 0x12 to 8 (Wheel/AC Pan).
+                    // ACL allocations are larger than the received length.
                     if (TranslateAclHidReport(payload, bufSize, &newLen, ctx) &&
-                        newLen > 0 && newLen <= bufSize)
+                        newLen > 0 && newLen <= 256)
                     {
                         RtlCopyMemory(brb + MM_ACL_BUFSIZE_OFFSET, &newLen, sizeof(ULONG));
                         WdfSpinLockAcquire(ctx->Lock);
@@ -365,6 +367,7 @@ OnReadComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
 
     __try
     {
+        // 0x90 battery Input is passed through. 0x12 stays 0x12 (8 bytes).
         if (bytesRead >= 6 && (buf[0] == 0x12 || buf[0] == 0x27) &&
             (ctx->ProductId == 0 || ctx->ProductId == MM_PID_V3))
         {

--- a/v2-kmdf-driver/Driver.c
+++ b/v2-kmdf-driver/Driver.c
@@ -47,6 +47,8 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 {
     WDF_DRIVER_CONFIG config;
     WDF_DRIVER_CONFIG_INIT(&config, EvtDeviceAdd);
+    DbgPrint("MM: DriverEntry %s artifact %s (INF installs as MagicMouseDriver.sys)\n",
+             MM_FILE_VERSION_STR, MM_ARTIFACT_SYS_NAME);
     return WdfDriverCreate(DriverObject, RegistryPath, WDF_NO_OBJECT_ATTRIBUTES,
                            &config, WDF_NO_HANDLE);
 }

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+//
+// MagicMouseDriver — KMDF lower filter for Apple Magic Mouse PID 0x0323 only.
+//
+// Stack:
+//   hidclass.sys → HidBth.sys → [this filter] → BthEnum PDO
+//
+// Two jobs:
+//   1. SDP: rewrite HIDDescriptorList (0x0206) to Descriptor C (RID 0x02 mouse)
+//      so hidclass/mouhid bind a standard mouse. Same IOCTL Apple uses
+//      (IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE = 0x410210).
+//   2. Reports: Magic Mouse 2/USB-C (0323) sends MOUSE2_REPORT_ID 0x12, not
+//      RID 0x02. Live 2.0.2.0 injected the descriptor then left 0x12 untouched,
+//      so HID started and the pointer did not move. Translate 0x12 → 6-byte
+//      RID 0x02 (buttons, X, Y, AC Pan, Wheel) on:
+//        - IRP_MJ_READ completions (backup; hidclass reads usually stop at HidBth)
+//        - BRB_L2CA_ACL_TRANSFER completions (the path HidBth actually uses)
+//
+// Sole filter. Do not stack with applewirelessmouse (v1 binary is a 0xD1
+// ship-blocker). This package does not bind PID 0x030D / 0x0269.
+
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+#define MM_POOL_TAG 'DMgm'
+
+// Magic Mouse 2024 / Magic Mouse 2 USB-C — the only PID this package binds.
+#define MM_PID_V3  0x0323u
+
+// IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
+// CTL_CODE(FILE_DEVICE_BLUETOOTH=0x41, Function=0x84, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE 0x00410210UL
+
+// IOCTL_INTERNAL_BTH_SUBMIT_BRB (bthioctl.h) — METHOD_NEITHER.
+#ifndef IOCTL_INTERNAL_BTH_SUBMIT_BRB
+#define IOCTL_INTERNAL_BTH_SUBMIT_BRB 0x00410003UL
+#endif
+
+// BRB_L2CA_ACL_TRANSFER (bthddi.h). Defined here so the source builds against
+// a WDK that has bthddi.h and so reviewers can see the constant without
+// opening the SDK.
+#ifndef BRB_L2CA_ACL_TRANSFER
+#define BRB_L2CA_ACL_TRANSFER 0x0105
+#endif
+
+#ifndef ACL_TRANSFER_DIRECTION_IN
+#define ACL_TRANSFER_DIRECTION_IN 0x00000001UL
+#endif
+
+// Injected RID 0x02 report: [RID][buttons][X][Y][AC Pan][Wheel] = 6 bytes.
+#define MM_MOUSE_REPORT_LEN 6
+
+#define MM_TOUCH_SLOTS 16
+
+typedef struct _DEVICE_CONTEXT
+{
+    WDFSPINLOCK Lock;
+
+    BOOLEAN EnableInjection;
+    USHORT  ProductId;          // 0x0323, or 0 if HardwareId could not be read
+
+    ULONG   IoctlInterceptCount;
+    ULONG   SdpScanHits;
+    ULONG   SdpPatchSuccess;
+    ULONG   LastSdpBufSize;
+    ULONG   LastPatchStatus;
+    UCHAR   LastSdpBytes[64];
+
+    ULONG   HidReadCount;
+    ULONG   Rid12Count;
+    ULONG   AclInterceptCount;
+    ULONG   AclTranslateCount;
+
+    // Surface-scroll anchors (Linux hid-magicmouse emit_touch style).
+    INT16   TouchAnchorY[MM_TOUCH_SLOTS];
+    INT16   TouchAnchorX[MM_TOUCH_SLOTS];
+    BOOLEAN TouchAnchorValid[MM_TOUCH_SLOTS];
+
+    WDFTIMER    DiagTimer;
+    WDFWORKITEM DiagWorkItem;
+
+} DEVICE_CONTEXT, *PDEVICE_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext)
+
+// Per-request stash so BRB completion uses the same PBRB HidBth submitted
+// (do not re-read the IRP stack in the completion routine).
+typedef struct _MM_REQUEST_CONTEXT
+{
+    PVOID Brb;   // PBRB, typed as PVOID so Driver.h does not include bthddi.h
+} MM_REQUEST_CONTEXT, *PMM_REQUEST_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(MM_REQUEST_CONTEXT, GetRequestContext)
+
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_DEVICE_ADD               EvtDeviceAdd;
+EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL EvtIoInternalDeviceControl;
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL      EvtIoDeviceControl;
+EVT_WDF_IO_QUEUE_IO_DEFAULT             EvtIoDefault;
+EVT_WDF_IO_QUEUE_IO_READ                EvtIoRead;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnSdpQueryComplete;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnReadComplete;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnAclTransferComplete;
+EVT_WDF_TIMER                           MmDiagTimerFunc;
+EVT_WDF_WORKITEM                        MmDiagWorkItemFunc;

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -31,6 +31,10 @@
 
 #define MM_POOL_TAG 'DMgm'
 
+// FileVersion / package label for this source. INF still copies MagicMouseDriver.sys.
+#define MM_FILE_VERSION_STR     "2.0.4.0"
+#define MM_ARTIFACT_SYS_NAME    "MagicMouseDriver-kmdf-2.0.4-scroll.sys"
+
 // Magic Mouse 2024 / Magic Mouse 2 USB-C — the only PID this package binds.
 #define MM_PID_V3  0x0323u
 

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -6,15 +6,20 @@
 //   hidclass.sys → HidBth.sys → [this filter] → BthEnum PDO
 //
 // Two jobs:
-//   1. SDP: rewrite HIDDescriptorList (0x0206) to Descriptor C (RID 0x02 mouse)
-//      so hidclass/mouhid bind a standard mouse. Same IOCTL Apple uses
+//   1. SDP: rewrite HIDDescriptorList (0x0206) so COL01 RID 0x12 exposes
+//      Wheel (GD 0x38) and AC Pan (Consumer 0x0238). Live HID 2026-08-30
+//      21:23 MDT (Apr 30 MagicMouseFix AD5D244B): COL01 Input 0x12 is X/Y
+//      only — that is why the pointer moves and scroll does not. HidBth
+//      delivers 0x12. Descriptor C (RID 0x02 + Feat 0x47) is not what
+//      hidclass bound. Same IOCTL Apple uses
 //      (IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE = 0x410210).
-//   2. Reports: Magic Mouse 2/USB-C (0323) sends MOUSE2_REPORT_ID 0x12, not
-//      RID 0x02. Live 2.0.2.0 injected the descriptor then left 0x12 untouched,
-//      so HID started and the pointer did not move. Translate 0x12 → 6-byte
-//      RID 0x02 (buttons, X, Y, AC Pan, Wheel) on:
-//        - IRP_MJ_READ completions (backup; hidclass reads usually stop at HidBth)
+//   2. Reports: stay on RID 0x12. Fill Wheel/AC Pan from the 14+8*N touch
+//      block (Linux hid-magicmouse MOUSE2). Do not convert to 0x02.
+//      Battery is RID 0x90 Input on COL02 (HidD_GetInputReport; percent
+//      at byte[2]). Feat 0x47 fails on COL01 and COL02.
+//      Paths:
 //        - BRB_L2CA_ACL_TRANSFER completions (the path HidBth actually uses)
+//        - IRP_MJ_READ completions (backup; hidclass reads usually stop at HidBth)
 //
 // Sole filter. Do not stack with applewirelessmouse (v1 binary is a 0xD1
 // ship-blocker). This package does not bind PID 0x030D / 0x0269.
@@ -49,8 +54,9 @@
 #define ACL_TRANSFER_DIRECTION_IN 0x00000001UL
 #endif
 
-// Injected RID 0x02 report: [RID][buttons][X][Y][AC Pan][Wheel] = 6 bytes.
-#define MM_MOUSE_REPORT_LEN 6
+// Injected RID 0x12 report:
+//   [RID 0x12][buttons][X i16][Y i16][AC Pan][Wheel] = 8 bytes.
+#define MM_MOUSE_REPORT_LEN 8
 
 #define MM_TOUCH_SLOTS 16
 

--- a/v2-kmdf-driver/GestureEngine.c
+++ b/v2-kmdf-driver/GestureEngine.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+// GestureEngine.c — MOUSE2_REPORT_ID (0x12) → Descriptor C RID 0x02.
+//
+// Optical X/Y and buttons come from the 0x12 header (Linux hid-magicmouse.c
+// magicmouse_raw_event, MOUSE2 case). Surface scroll is a simplified port of
+// magicmouse_emit_touch() TOUCH_STATE_DRAG handling.
+#include "GestureEngine.h"
+
+#define MM2_BTN_MASK      0x03
+#define TOUCH_STATE_MASK  0xF0
+#define TOUCH_STATE_START 0x30
+#define TOUCH_STATE_DRAG  0x40
+
+static __forceinline CHAR
+ClampI8(_In_ INT value)
+{
+    if (value > 127)  { return (CHAR)127; }
+    if (value < -127) { return (CHAR)-127; }
+    return (CHAR)value;
+}
+
+// Linux: x = (int)((data[3] << 24) | (data[2] << 16)) >> 16
+static __forceinline INT16
+ReadI16Le(_In_reads_(2) const UCHAR* p)
+{
+    USHORT raw = (USHORT)p[0] | (USHORT)((USHORT)p[1] << 8);
+    return (INT16)raw;
+}
+
+// Linux: x = (tdata[1] << 28 | tdata[0] << 20) >> 20  (signed 12-bit)
+static __forceinline INT
+ReadI12Le(_In_reads_(2) const UCHAR* p)
+{
+    INT v = (INT)(((ULONG)p[1] << 28) | ((ULONG)p[0] << 20));
+    return v >> 20;
+}
+
+static VOID
+AccumulateSurfaceScroll(
+    _In_reads_bytes_(inLen) PUCHAR in,
+    _In_ SIZE_T inLen,
+    _Inout_ PDEVICE_CONTEXT ctx,
+    _Out_ PINT outWheel,
+    _Out_ PINT outHWheel)
+{
+    *outWheel  = 0;
+    *outHWheel = 0;
+
+    if (inLen < MM2_HEADER_LEN) { return; }
+
+    ULONG nTouches = (ULONG)((inLen - MM2_HEADER_LEN) / MM2_TOUCH_BYTES);
+    if (nTouches == 0) { return; }
+
+    WdfSpinLockAcquire(ctx->Lock);
+
+    for (ULONG i = 0; i < nTouches; i++)
+    {
+        ULONG off = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES;
+        if (off + MM2_TOUCH_BYTES > inLen) { break; }
+
+        PUCHAR t = in + off;
+        ULONG id = ((ULONG)t[6] << 2 | ((ULONG)t[5] >> 6)) & 0xFu;
+        if (id >= MM_TOUCH_SLOTS) { continue; }
+
+        // Linux magicmouse_emit_touch (Magic Mouse / Mouse 2 / 0323):
+        //   x = (tdata[1] << 28 | tdata[0] << 20) >> 20
+        //   y = -((tdata[2] << 24 | tdata[1] << 16) >> 20)
+        INT x = ReadI12Le(t + 0);
+        INT yPacked = (INT)(((ULONG)t[2] << 24) | ((ULONG)t[1] << 16));
+        INT y = -(yPacked >> 20);
+        UCHAR state = (UCHAR)(t[7] & TOUCH_STATE_MASK);
+
+        if (state == TOUCH_STATE_START)
+        {
+            ctx->TouchAnchorX[id] = (INT16)x;
+            ctx->TouchAnchorY[id] = (INT16)y;
+            ctx->TouchAnchorValid[id] = TRUE;
+            continue;
+        }
+
+        if (state != TOUCH_STATE_DRAG || !ctx->TouchAnchorValid[id])
+        {
+            if (state == 0x00) { ctx->TouchAnchorValid[id] = FALSE; }
+            continue;
+        }
+
+        INT stepY = (INT)ctx->TouchAnchorY[id] - y;
+        INT stepX = (INT)ctx->TouchAnchorX[id] - x;
+
+        if (stepY >= MM_SCROLL_STEP || stepY <= -MM_SCROLL_STEP)
+        {
+            *outWheel += (stepY > 0) ? 1 : -1;
+            ctx->TouchAnchorY[id] = (INT16)y;
+        }
+        if (stepX >= MM_SCROLL_STEP || stepX <= -MM_SCROLL_STEP)
+        {
+            *outHWheel += (stepX > 0) ? -1 : 1;
+            ctx->TouchAnchorX[id] = (INT16)x;
+        }
+    }
+
+    WdfSpinLockRelease(ctx->Lock);
+}
+
+NTSTATUS
+TranslateMouse2ToHid(
+    _In_reads_bytes_(inLen)     PUCHAR in,
+    _In_                        SIZE_T inLen,
+    _Out_writes_bytes_all_(MM_MOUSE_REPORT_LEN) PUCHAR out,
+    _Inout_                     PULONG outLen,
+    _Inout_                     PDEVICE_CONTEXT ctx)
+{
+    *outLen = 0;
+
+    if (in == NULL || out == NULL || ctx == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (inLen < 6 || (in[0] != 0x12 && in[0] != 0x27))
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    // Compact (8) or full (14 + 8*N). Still accept >=6 so a short header
+    // yields buttons + X/Y rather than a dropped report.
+    BOOLEAN sizedOk =
+        (inLen == MM2_COMPACT_LEN) ||
+        (inLen >= MM2_HEADER_LEN && ((inLen - MM2_HEADER_LEN) % MM2_TOUCH_BYTES) == 0) ||
+        (inLen >= 6 && inLen < MM2_HEADER_LEN);
+    if (!sizedOk)
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    UCHAR buttons = (UCHAR)(in[1] & MM2_BTN_MASK);
+    INT16 x16 = (inLen >= 4) ? ReadI16Le(in + 2) : 0;
+    INT16 y16 = (inLen >= 6) ? ReadI16Le(in + 4) : 0;
+
+    INT wheel  = 0;
+    INT hwheel = 0;
+    if (inLen >= MM2_HEADER_LEN)
+    {
+        AccumulateSurfaceScroll(in, inLen, ctx, &wheel, &hwheel);
+    }
+
+    out[0] = 0x02;
+    out[1] = buttons;
+    out[2] = (UCHAR)ClampI8((INT)x16);
+    out[3] = (UCHAR)ClampI8((INT)y16);
+    out[4] = (UCHAR)ClampI8(hwheel);
+    out[5] = (UCHAR)ClampI8(wheel);
+
+    *outLen = MM_MOUSE_REPORT_LEN;
+    return STATUS_SUCCESS;
+}

--- a/v2-kmdf-driver/GestureEngine.c
+++ b/v2-kmdf-driver/GestureEngine.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-// GestureEngine.c — MOUSE2_REPORT_ID (0x12) → Descriptor C RID 0x02.
+// GestureEngine.c — stay on MOUSE2_REPORT_ID 0x12; add Wheel / AC Pan.
 //
 // Optical X/Y and buttons come from the 0x12 header (Linux hid-magicmouse.c
 // magicmouse_raw_event, MOUSE2 case). Surface scroll is a simplified port of
-// magicmouse_emit_touch() TOUCH_STATE_DRAG handling.
+// magicmouse_emit_touch() TOUCH_STATE_DRAG handling for 0323 / Mouse 2.
 #include "GestureEngine.h"
 
 #define MM2_BTN_MASK      0x03
@@ -25,6 +25,16 @@ ReadI16Le(_In_reads_(2) const UCHAR* p)
 {
     USHORT raw = (USHORT)p[0] | (USHORT)((USHORT)p[1] << 8);
     return (INT16)raw;
+}
+
+static VOID
+WriteI16Le(
+    _Out_writes_bytes_(2) PUCHAR p,
+    _In_ INT16 value
+    )
+{
+    p[0] = (UCHAR)((USHORT)value & 0xFF);
+    p[1] = (UCHAR)(((USHORT)value >> 8) & 0xFF);
 }
 
 // Linux: x = (tdata[1] << 28 | tdata[0] << 20) >> 20  (signed 12-bit)
@@ -116,7 +126,7 @@ TranslateMouse2ToHid(
     {
         return STATUS_INVALID_PARAMETER;
     }
-    if (inLen < 6 || (in[0] != 0x12 && in[0] != 0x27))
+    if (inLen < 6 || (in[0] != MM_REPORT_ID_MOUSE && in[0] != 0x27))
     {
         return STATUS_NO_MORE_ENTRIES;
     }
@@ -142,13 +152,19 @@ TranslateMouse2ToHid(
     {
         AccumulateSurfaceScroll(in, inLen, ctx, &wheel, &hwheel);
     }
+    else if (inLen >= 8)
+    {
+        // Compact 0x12: preserve any wheel bytes already present.
+        hwheel = (CHAR)in[6];
+        wheel  = (CHAR)in[7];
+    }
 
-    out[0] = 0x02;
+    out[0] = MM_REPORT_ID_MOUSE;
     out[1] = buttons;
-    out[2] = (UCHAR)ClampI8((INT)x16);
-    out[3] = (UCHAR)ClampI8((INT)y16);
-    out[4] = (UCHAR)ClampI8(hwheel);
-    out[5] = (UCHAR)ClampI8(wheel);
+    WriteI16Le(out + 2, x16);
+    WriteI16Le(out + 4, y16);
+    out[6] = (UCHAR)ClampI8(hwheel);
+    out[7] = (UCHAR)ClampI8(wheel);
 
     *outLen = MM_MOUSE_REPORT_LEN;
     return STATUS_SUCCESS;

--- a/v2-kmdf-driver/GestureEngine.h
+++ b/v2-kmdf-driver/GestureEngine.h
@@ -1,10 +1,24 @@
 // SPDX-License-Identifier: MIT
 //
-// RID 0x12 (MOUSE2_REPORT_ID) → RID 0x02 standard mouse report.
+// Stay on RID 0x12 (MOUSE2_REPORT_ID). Do not convert to RID 0x02.
+//
+// Live HID 2026-08-30 21:23 MDT (Apr 30 MagicMouseFix AD5D244B):
+//   COL01 Input 0x12 is X/Y only. No Wheel usage 0x0038.
+//   That is why the pointer moves and scroll does not.
+//   HidBth delivers 0x12. Product battery is RID 0x90 Input on COL02,
+//   not Feature 0x47 (fails on COL01 and COL02).
+//
 // Layout from Linux drivers/hid/hid-magicmouse.c (GPL-2.0-or-later):
-//   magicmouse_raw_event() MOUSE2_REPORT_ID case
-//   magicmouse_emit_touch() surface-scroll
-// Windows output matches the injected Descriptor C (HidDescriptor.c).
+//   magicmouse_raw_event() MOUSE2_REPORT_ID — size 8 or (14 + 8*N)
+//   magicmouse_emit_touch() surface-scroll (0323 uses the Mouse 2 path)
+//
+// Output (8 bytes) matches the injected COL01 0x12 descriptor:
+//   [0] RID 0x12
+//   [1] buttons (bit0 left, bit1 right)
+//   [2..3] X INT16 LE  — native / Linux MOUSE2 optical (keep pointer)
+//   [4..5] Y INT16 LE
+//   [6] AC Pan INT8    — horizontal surface scroll
+//   [7] Wheel INT8     — vertical surface scroll (usage 0x0038)
 #pragma once
 #include "Driver.h"
 
@@ -14,25 +28,18 @@
 #define MM2_COMPACT_LEN 8
 #define MM2_TOUCH_BYTES 8
 
+#define MM_REPORT_ID_MOUSE    0x12
+#define MM_REPORT_ID_BATTERY  0x90
+
 // Surface drag distance (touch units) per Wheel detent. Conservative start;
 // Linux uses (64 - scroll_speed) * scroll_accel with defaults ~224.
 #define MM_SCROLL_STEP 64
 
 // TranslateMouse2ToHid
 //
-// Accepts RID 0x12 (MOUSE2) or RID 0x27 (Descriptor C touch, 46-byte payload
-// = 14-byte header + 4×8-byte fingers). Always produces a 6-byte RID 0x02:
-
-//   [0] RID 0x02
-//   [1] buttons (bit0 left, bit1 right)
-//   [2] X INT8   — optical delta from data[2..3] (LE int16, clamped)
-//   [3] Y INT8   — optical delta from data[4..5] (LE int16, clamped)
-//   [4] AC Pan   — horizontal surface scroll
-//   [5] Wheel    — vertical surface scroll
-//
-// 2.0.2.0 only emitted this report for 2-finger scroll and used the wrong
-// 5-byte X_lo/X_hi/Wheel layout — pointer stayed dead even when translation
-// ran. This function always copies optical X/Y.
+// Accepts RID 0x12 (MOUSE2) or RID 0x27. Always produces an 8-byte RID 0x12
+// with Wheel / AC Pan filled from the 14+8*N touch block when present.
+// Optical X/Y stay INT16 so the Apr 30 pointer path is not clamped to INT8.
 NTSTATUS TranslateMouse2ToHid(
     _In_reads_bytes_(inLen)     PUCHAR in,
     _In_                        SIZE_T inLen,

--- a/v2-kmdf-driver/GestureEngine.h
+++ b/v2-kmdf-driver/GestureEngine.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+//
+// RID 0x12 (MOUSE2_REPORT_ID) → RID 0x02 standard mouse report.
+// Layout from Linux drivers/hid/hid-magicmouse.c (GPL-2.0-or-later):
+//   magicmouse_raw_event() MOUSE2_REPORT_ID case
+//   magicmouse_emit_touch() surface-scroll
+// Windows output matches the injected Descriptor C (HidDescriptor.c).
+#pragma once
+#include "Driver.h"
+
+// 1-byte RID + 13-byte header = 14 bytes with zero touch points.
+// Linux also accepts a compact 8-byte MOUSE2 report (no touch block).
+#define MM2_HEADER_LEN 14
+#define MM2_COMPACT_LEN 8
+#define MM2_TOUCH_BYTES 8
+
+// Surface drag distance (touch units) per Wheel detent. Conservative start;
+// Linux uses (64 - scroll_speed) * scroll_accel with defaults ~224.
+#define MM_SCROLL_STEP 64
+
+// TranslateMouse2ToHid
+//
+// Accepts RID 0x12 (MOUSE2) or RID 0x27 (Descriptor C touch, 46-byte payload
+// = 14-byte header + 4×8-byte fingers). Always produces a 6-byte RID 0x02:
+
+//   [0] RID 0x02
+//   [1] buttons (bit0 left, bit1 right)
+//   [2] X INT8   — optical delta from data[2..3] (LE int16, clamped)
+//   [3] Y INT8   — optical delta from data[4..5] (LE int16, clamped)
+//   [4] AC Pan   — horizontal surface scroll
+//   [5] Wheel    — vertical surface scroll
+//
+// 2.0.2.0 only emitted this report for 2-finger scroll and used the wrong
+// 5-byte X_lo/X_hi/Wheel layout — pointer stayed dead even when translation
+// ran. This function always copies optical X/Y.
+NTSTATUS TranslateMouse2ToHid(
+    _In_reads_bytes_(inLen)     PUCHAR in,
+    _In_                        SIZE_T inLen,
+    _Out_writes_bytes_all_(MM_MOUSE_REPORT_LEN) PUCHAR out,
+    _Inout_                     PULONG outLen,
+    _Inout_                     PDEVICE_CONTEXT ctx
+);

--- a/v2-kmdf-driver/HidDescriptor.c
+++ b/v2-kmdf-driver/HidDescriptor.c
@@ -1,31 +1,36 @@
 // SPDX-License-Identifier: MIT
 //
-// HID report descriptor injected into SDP attribute 0x0206 (HIDDescriptorList).
+// HID report descriptor injected into SDP attribute 0x0206.
 //
-// Source: Apple applewirelessmouse.sys SHA-256 08F33D7E... offset 0xA850,
-// 116 bytes, plus 19-byte valid vendor Feature padding so the SDP blob stays
-// the native size (in-place swap). Verified 2026-04-30 via Ghidra of
-// FUN_14000A440.
+// Live HID 2026-08-30 21:23 MDT on Apr 30 MagicMouseFix (AD5D244B):
+//   COL01 Input 0x12 = X/Y only. Usage Wheel 0x0038 is ABSENT.
+//   That is why the pointer moves and scroll does not.
+//   COL02 HidD_GetInputReport(0x90) = [90 04 2F ...] → 47% at byte[2].
+//   Feature 0x47 fails on COL01 and COL02. Product battery is RID 0x90.
 //
-// RID 0x02 input (5 data bytes after Report ID):
-//   [1] 2 buttons + pad
-//   [2] X INT8 relative
-//   [3] Y INT8 relative
-//   [4] AC Pan INT8 relative
-//   [5] Wheel INT8 relative
+// HidBth delivers RID 0x12 to hidclass. Descriptor C (RID 0x02 + Feat 0x47)
+// is not what the live stack bound. This blob stays on 0x12 / 0x90 and ADDS
+// Wheel (GD 0x38) and AC Pan (Consumer 0x0238) to the 0x12 collection so
+// mouhid can see scroll on the same reports HidBth already forwards.
 //
-// Do NOT pad with 0x00. hidparse.sys returns STATUS_ILLEGAL_INSTRUCTION
-// (0xC000001D) for reserved Main-item tag 0 — that was the 2.0.0.0
-// CM_PROB_FAILED_START. 2.0.2.0 fixed parse; this package adds report
-// translation so the pointer actually moves.
+// 0x12 report after injection (8 bytes):
+//   [0] RID 0x12
+//   [1] buttons
+//   [2..3] X INT16 LE   — same offsets as native / Linux MOUSE2
+//   [4..5] Y INT16 LE
+//   [6] AC Pan INT8     — synthesized from surface
+//   [7] Wheel INT8      — synthesized from surface
+//
+// Do NOT pad with 0x00 (hidparse STATUS_ILLEGAL_INSTRUCTION).
 
 #include "HidDescriptor.h"
 
 const UCHAR g_HidDescriptor[] = {
+    // ---- COL01: Mouse, Report ID 0x12 (what HidBth actually delivers) ----
     0x05, 0x01,             // Usage Page (Generic Desktop)
     0x09, 0x02,             // Usage (Mouse)
     0xA1, 0x01,             // Collection (Application)
-    0x85, 0x02,             //   Report ID (2)
+    0x85, 0x12,             //   Report ID (0x12)
 
     0x05, 0x09,             //   Usage Page (Button)
     0x19, 0x01,             //   Usage Minimum (Button 1)
@@ -34,71 +39,53 @@ const UCHAR g_HidDescriptor[] = {
     0x25, 0x01,             //   Logical Maximum (1)
     0x95, 0x02,             //   Report Count (2)
     0x75, 0x01,             //   Report Size (1)
-    0x81, 0x02,             //   Input (Data, Var, Abs)
-
+    0x81, 0x02,             //   Input (Data, Var, Abs)          — 2 bits
     0x95, 0x01,             //   Report Count (1)
-    0x75, 0x05,             //   Report Size (5)
-    0x81, 0x03,             //   Input (Constant)
-
-    0x06, 0x02, 0xFF,       //   Usage Page (Vendor 0xFF02)
-    0x09, 0x20,             //   Usage (0x20)
-    0x95, 0x01,             //   Report Count (1)
-    0x75, 0x01,             //   Report Size (1)
-    0x81, 0x03,             //   Input (Constant)
+    0x75, 0x06,             //   Report Size (6)
+    0x81, 0x03,             //   Input (Constant)                — pad to 8 bits
 
     0x05, 0x01,             //   Usage Page (Generic Desktop)
     0x09, 0x01,             //   Usage (Pointer)
     0xA1, 0x00,             //   Collection (Physical)
-    0x15, 0x81,             //     Logical Minimum (-127)
-    0x25, 0x7F,             //     Logical Maximum (127)
+    0x16, 0x00, 0x80,       //     Logical Minimum (-32768)
+    0x26, 0xFF, 0x7F,       //     Logical Maximum (32767)
     0x09, 0x30,             //     Usage (X)
     0x09, 0x31,             //     Usage (Y)
-    0x75, 0x08,             //     Report Size (8)
+    0x75, 0x10,             //     Report Size (16)
     0x95, 0x02,             //     Report Count (2)
-    0x81, 0x06,             //     Input (Data, Var, Rel)
+    0x81, 0x06,             //     Input (Data, Var, Rel)        — 4 bytes
 
+    0x15, 0x81,             //     Logical Minimum (-127)
+    0x25, 0x7F,             //     Logical Maximum (127)
     0x05, 0x0C,             //     Usage Page (Consumer)
-    0x0A, 0x38, 0x02,       //     Usage (AC Pan)
+    0x0A, 0x38, 0x02,       //     Usage (AC Pan 0x0238)
     0x75, 0x08,             //     Report Size (8)
     0x95, 0x01,             //     Report Count (1)
-    0x81, 0x06,             //     Input (Data, Var, Rel)
+    0x81, 0x06,             //     Input (Data, Var, Rel)        — byte[6]
 
     0x05, 0x01,             //     Usage Page (Generic Desktop)
-    0x09, 0x38,             //     Usage (Wheel)
+    0x09, 0x38,             //     Usage (Wheel 0x0038)
     0x75, 0x08,             //     Report Size (8)
     0x95, 0x01,             //     Report Count (1)
-    0x81, 0x06,             //     Input (Data, Var, Rel)
+    0x81, 0x06,             //     Input (Data, Var, Rel)        — byte[7]
     0xC0,                   //   End Collection (Physical)
+    0xC0,                   // End Collection (Application)
 
-    0x05, 0x06,             //   Usage Page (Generic Device Controls)
-    0x09, 0x20,             //   Usage (Battery Strength)
-    0x85, 0x47,             //   Report ID (0x47)
-    0x15, 0x00,             //   Logical Minimum (0)
-    0x25, 0x64,             //   Logical Maximum (100)
+    // ---- COL02: Battery, Report ID 0x90 Input (live: [90 04 2F ...] = 47%) ----
+    0x05, 0x01,             // Usage Page (Generic Desktop)
+    0x09, 0x06,             // Usage (Keyboard) — unused; TLC tag only
+    0x05, 0x06,             // Usage Page (Generic Device Controls)
+    0x09, 0x20,             // Usage (Battery Strength)
+    0xA1, 0x01,             // Collection (Application)
+    0x85, 0x90,             //   Report ID (0x90)
     0x75, 0x08,             //   Report Size (8)
     0x95, 0x01,             //   Report Count (1)
-    0xB1, 0xA2,             //   Feature (Data, Var, Abs, NoPreferred)
-
-    0x05, 0x06,             //   Usage Page (Generic Device Controls)
-    0x09, 0x01,             //   Usage (0x01)
-    0x85, 0x27,             //   Report ID (0x27)
-    0x15, 0x01,             //   Logical Minimum (1)
-    0x25, 0x41,             //   Logical Maximum (65)
-    0x75, 0x08,             //   Report Size (8)
-    0x95, 0x2E,             //   Report Count (46)
-    0x81, 0x06,             //   Input (Data, Var, Rel)
-
-    // 19-byte vendor Feature — keeps total 135 bytes. Valid HID items only.
-    0x06, 0x00, 0xFF,       //   Usage Page (Vendor 0xFF00)
-    0x09, 0x01,             //   Usage (0x01)
-    0x09, 0x02,             //   Usage (0x02)
-    0x85, 0x67,             //   Report ID (0x67)
+    0x81, 0x03,             //   Input (Constant)                — byte[1] = 0x04 live
     0x15, 0x00,             //   Logical Minimum (0)
-    0x25, 0xFF,             //   Logical Maximum (255)
-    0x95, 0x07,             //   Report Count (7)
-    0x75, 0x08,             //   Report Size (8)
-    0xB1, 0x03,             //   Feature (Constant)
-
+    0x25, 0x64,             //   Logical Maximum (100)
+    0x09, 0x20,             //   Usage (Battery Strength)
+    0x95, 0x01,             //   Report Count (1)
+    0x81, 0x02,             //   Input (Data, Var, Abs)          — byte[2] percent
     0xC0,                   // End Collection
 };
 

--- a/v2-kmdf-driver/HidDescriptor.c
+++ b/v2-kmdf-driver/HidDescriptor.c
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+//
+// HID report descriptor injected into SDP attribute 0x0206 (HIDDescriptorList).
+//
+// Source: Apple applewirelessmouse.sys SHA-256 08F33D7E... offset 0xA850,
+// 116 bytes, plus 19-byte valid vendor Feature padding so the SDP blob stays
+// the native size (in-place swap). Verified 2026-04-30 via Ghidra of
+// FUN_14000A440.
+//
+// RID 0x02 input (5 data bytes after Report ID):
+//   [1] 2 buttons + pad
+//   [2] X INT8 relative
+//   [3] Y INT8 relative
+//   [4] AC Pan INT8 relative
+//   [5] Wheel INT8 relative
+//
+// Do NOT pad with 0x00. hidparse.sys returns STATUS_ILLEGAL_INSTRUCTION
+// (0xC000001D) for reserved Main-item tag 0 — that was the 2.0.0.0
+// CM_PROB_FAILED_START. 2.0.2.0 fixed parse; this package adds report
+// translation so the pointer actually moves.
+
+#include "HidDescriptor.h"
+
+const UCHAR g_HidDescriptor[] = {
+    0x05, 0x01,             // Usage Page (Generic Desktop)
+    0x09, 0x02,             // Usage (Mouse)
+    0xA1, 0x01,             // Collection (Application)
+    0x85, 0x02,             //   Report ID (2)
+
+    0x05, 0x09,             //   Usage Page (Button)
+    0x19, 0x01,             //   Usage Minimum (Button 1)
+    0x29, 0x02,             //   Usage Maximum (Button 2)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0x01,             //   Logical Maximum (1)
+    0x95, 0x02,             //   Report Count (2)
+    0x75, 0x01,             //   Report Size (1)
+    0x81, 0x02,             //   Input (Data, Var, Abs)
+
+    0x95, 0x01,             //   Report Count (1)
+    0x75, 0x05,             //   Report Size (5)
+    0x81, 0x03,             //   Input (Constant)
+
+    0x06, 0x02, 0xFF,       //   Usage Page (Vendor 0xFF02)
+    0x09, 0x20,             //   Usage (0x20)
+    0x95, 0x01,             //   Report Count (1)
+    0x75, 0x01,             //   Report Size (1)
+    0x81, 0x03,             //   Input (Constant)
+
+    0x05, 0x01,             //   Usage Page (Generic Desktop)
+    0x09, 0x01,             //   Usage (Pointer)
+    0xA1, 0x00,             //   Collection (Physical)
+    0x15, 0x81,             //     Logical Minimum (-127)
+    0x25, 0x7F,             //     Logical Maximum (127)
+    0x09, 0x30,             //     Usage (X)
+    0x09, 0x31,             //     Usage (Y)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x02,             //     Report Count (2)
+    0x81, 0x06,             //     Input (Data, Var, Rel)
+
+    0x05, 0x0C,             //     Usage Page (Consumer)
+    0x0A, 0x38, 0x02,       //     Usage (AC Pan)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x01,             //     Report Count (1)
+    0x81, 0x06,             //     Input (Data, Var, Rel)
+
+    0x05, 0x01,             //     Usage Page (Generic Desktop)
+    0x09, 0x38,             //     Usage (Wheel)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x01,             //     Report Count (1)
+    0x81, 0x06,             //     Input (Data, Var, Rel)
+    0xC0,                   //   End Collection (Physical)
+
+    0x05, 0x06,             //   Usage Page (Generic Device Controls)
+    0x09, 0x20,             //   Usage (Battery Strength)
+    0x85, 0x47,             //   Report ID (0x47)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0x64,             //   Logical Maximum (100)
+    0x75, 0x08,             //   Report Size (8)
+    0x95, 0x01,             //   Report Count (1)
+    0xB1, 0xA2,             //   Feature (Data, Var, Abs, NoPreferred)
+
+    0x05, 0x06,             //   Usage Page (Generic Device Controls)
+    0x09, 0x01,             //   Usage (0x01)
+    0x85, 0x27,             //   Report ID (0x27)
+    0x15, 0x01,             //   Logical Minimum (1)
+    0x25, 0x41,             //   Logical Maximum (65)
+    0x75, 0x08,             //   Report Size (8)
+    0x95, 0x2E,             //   Report Count (46)
+    0x81, 0x06,             //   Input (Data, Var, Rel)
+
+    // 19-byte vendor Feature — keeps total 135 bytes. Valid HID items only.
+    0x06, 0x00, 0xFF,       //   Usage Page (Vendor 0xFF00)
+    0x09, 0x01,             //   Usage (0x01)
+    0x09, 0x02,             //   Usage (0x02)
+    0x85, 0x67,             //   Report ID (0x67)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0xFF,             //   Logical Maximum (255)
+    0x95, 0x07,             //   Report Count (7)
+    0x75, 0x08,             //   Report Size (8)
+    0xB1, 0x03,             //   Feature (Constant)
+
+    0xC0,                   // End Collection
+};
+
+const ULONG g_HidDescriptorSize = sizeof(g_HidDescriptor);

--- a/v2-kmdf-driver/HidDescriptor.h
+++ b/v2-kmdf-driver/HidDescriptor.h
@@ -2,7 +2,9 @@
 #pragma once
 #include "Driver.h"
 
-// Descriptor C: RID 0x02 mouse (X/Y/AC Pan/Wheel) + RID 0x47 battery Feature
-// + RID 0x27 touch Input. Injected into SDP attribute 0x0206.
+// Live-aligned descriptor (2026-08-30 HID on Apr 30 MagicMouseFix):
+//   COL01 Input RID 0x12 — buttons, X, Y, AC Pan, Wheel
+//   COL02 Input RID 0x90 — battery (HidD_GetInputReport; percent at byte[2])
+// Do not inject RID 0x02 / Feature 0x47 — hidclass never bound those.
 extern const UCHAR g_HidDescriptor[];
 extern const ULONG g_HidDescriptorSize;

--- a/v2-kmdf-driver/HidDescriptor.h
+++ b/v2-kmdf-driver/HidDescriptor.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Driver.h"
+
+// Descriptor C: RID 0x02 mouse (X/Y/AC Pan/Wheel) + RID 0x47 battery Feature
+// + RID 0x27 touch Input. Injected into SDP attribute 0x0206.
+extern const UCHAR g_HidDescriptor[];
+extern const ULONG g_HidDescriptorSize;

--- a/v2-kmdf-driver/InputHandler.c
+++ b/v2-kmdf-driver/InputHandler.c
@@ -3,7 +3,8 @@
 // SdpRewrite — SDP attribute 0x0206 (HIDDescriptorList) descriptor injection.
 //
 // Called from OnSdpQueryComplete after IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
-// (0x410210) completes. Replaces the HID report descriptor with Descriptor C.
+// (0x410210) completes. Replaces the HID report descriptor with the
+// live-aligned blob (COL01 RID 0x12 + Wheel/AC Pan, COL02 RID 0x90 Input).
 //
 // SDP DataElement (Bluetooth Core Spec Vol 3 Part B §3.3):
 //   09 02 06    UINT16 attribute ID = 0x0206

--- a/v2-kmdf-driver/InputHandler.c
+++ b/v2-kmdf-driver/InputHandler.c
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+//
+// SdpRewrite — SDP attribute 0x0206 (HIDDescriptorList) descriptor injection.
+//
+// Called from OnSdpQueryComplete after IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
+// (0x410210) completes. Replaces the HID report descriptor with Descriptor C.
+//
+// SDP DataElement (Bluetooth Core Spec Vol 3 Part B §3.3):
+//   09 02 06    UINT16 attribute ID = 0x0206
+//   35 LL       outer SEQUENCE
+//     35 LL     inner SEQUENCE
+//       08 22   UINT8 HID Report Descriptor type
+//       25 NN   TEXT_STRING length
+//         <NN bytes>
+//
+// Plus the top-level AttributeLists sequence after the 8-byte
+// BTH_SDP_STREAM_RESPONSE header.
+
+#include "InputHandler.h"
+#include "HidDescriptor.h"
+
+#define SDP_TYPE_UINT8   0x08
+#define SDP_TYPE_UINT16  0x09
+#define SDP_SEQ_1B       0x35
+#define SDP_SEQ_2B       0x36
+#define SDP_STR_1B       0x25
+
+#define HID_DESC_ATTR_HI  0x02
+#define HID_DESC_ATTR_LO  0x06
+#define HID_RPT_DESC_TYPE 0x22
+
+#define SDP_SCAN_MATCH_LEN 11
+#define SDP_DESC_MAX_LEN  512
+
+static BOOLEAN
+ScanForSdpHidDescriptor(
+    _In_reads_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG    bufSize,
+    _Out_ PULONG   descOffset,
+    _Out_ PULONG   descLen)
+{
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN) { return FALSE; }
+    ULONG limit = bufSize - SDP_SCAN_MATCH_LEN;
+
+    for (ULONG i = 0; i <= limit; i++)
+    {
+        if (buf[i]     != SDP_TYPE_UINT16)  { continue; }
+        if (buf[i + 1] != HID_DESC_ATTR_HI) { continue; }
+        if (buf[i + 2] != HID_DESC_ATTR_LO) { continue; }
+
+        if (buf[i + 3] != SDP_SEQ_1B) { continue; }
+        UCHAR outerLen = buf[i + 4];
+        if (outerLen < 4) { continue; }
+        if ((ULONG)(i + 5) + outerLen > bufSize) { continue; }
+
+        if (buf[i + 5] != SDP_SEQ_1B) { continue; }
+        UCHAR innerLen = buf[i + 6];
+        if (innerLen < 4) { continue; }
+        if ((ULONG)(i + 7) + innerLen > bufSize) { continue; }
+
+        if (buf[i + 7] != SDP_TYPE_UINT8)    { continue; }
+        if (buf[i + 8] != HID_RPT_DESC_TYPE) { continue; }
+
+        if (buf[i + 9] != SDP_STR_1B) { continue; }
+        UCHAR nd = buf[i + 10];
+        if (nd == 0 || nd > SDP_DESC_MAX_LEN) { continue; }
+        if ((ULONG)(i + 11) + nd > bufSize) { continue; }
+
+        *descOffset = i + 11;
+        *descLen    = (ULONG)nd;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static NTSTATUS
+PatchSdpHidDescriptor(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG    bufSize,
+    _In_  ULONG    descOffset,
+    _In_  ULONG    descLen,
+    _Out_ PULONG   newBufUsed)
+{
+    ASSERT(descOffset >= 11);
+    if (g_HidDescriptorSize == 0) { return STATUS_INVALID_PARAMETER; }
+
+    ULONG newDescLen   = g_HidDescriptorSize;
+    ULONG innerPayload = 2 + 2 + newDescLen;
+    ULONG outerPayload = 2 + innerPayload;
+
+    if (newDescLen   > 0xFF) { return STATUS_INVALID_PARAMETER; }
+    if (innerPayload > 0xFF) { return STATUS_INVALID_PARAMETER; }
+    if (outerPayload > 0xFF) { return STATUS_INVALID_PARAMETER; }
+
+    ULONG tailOffset = descOffset + descLen;
+    if (tailOffset > bufSize) { return STATUS_INVALID_PARAMETER; }
+    ULONG tailBytes  = bufSize - tailOffset;
+    ULONG needed     = descOffset + newDescLen + tailBytes;
+    if (needed > bufSize) { return STATUS_BUFFER_TOO_SMALL; }
+
+    if (newDescLen != descLen && tailBytes > 0)
+    {
+        ULONG newTailOffset = descOffset + newDescLen;
+        RtlMoveMemory(buf + newTailOffset, buf + tailOffset, tailBytes);
+    }
+
+    if (newDescLen < descLen)
+    {
+        ULONG gapStart = descOffset + newDescLen + tailBytes;
+        ULONG gapLen   = descLen - newDescLen;
+        RtlZeroMemory(buf + gapStart, gapLen);
+    }
+
+    RtlCopyMemory(buf + descOffset, g_HidDescriptor, newDescLen);
+
+    buf[descOffset - 1] = (UCHAR)newDescLen;
+    buf[descOffset - 5] = (UCHAR)innerPayload;
+    buf[descOffset - 7] = (UCHAR)outerPayload;
+
+    // buf[0..7] = BTH_SDP_STREAM_RESPONSE; buf[8] is AttributeLists tag.
+    LONG delta = (LONG)newDescLen - (LONG)descLen;
+    if (delta != 0 && bufSize >= 11 && buf[8] == SDP_SEQ_1B)
+    {
+        LONG newTop = (LONG)(UCHAR)buf[9] + delta;
+        if (newTop >= 0 && newTop <= 0xFF)
+        {
+            buf[9] = (UCHAR)newTop;
+        }
+
+        ULONG respSize;
+        RtlCopyMemory(&respSize, buf + 4, sizeof(ULONG));
+        LONG newResp = (LONG)respSize + delta;
+        if (newResp > 0)
+        {
+            respSize = (ULONG)newResp;
+            RtlCopyMemory(buf + 4, &respSize, sizeof(ULONG));
+        }
+    }
+    else if (delta != 0 && bufSize >= 12 && buf[8] == SDP_SEQ_2B)
+    {
+        USHORT top    = (USHORT)(((USHORT)buf[9] << 8) | (USHORT)buf[10]);
+        LONG   newTop = (LONG)top + delta;
+        if (newTop >= 0 && newTop <= 0xFFFF)
+        {
+            buf[9]  = (UCHAR)((USHORT)newTop >> 8);
+            buf[10] = (UCHAR)((USHORT)newTop & 0xFF);
+        }
+
+        ULONG respSize;
+        RtlCopyMemory(&respSize, buf + 4, sizeof(ULONG));
+        LONG newResp = (LONG)respSize + delta;
+        if (newResp > 0)
+        {
+            respSize = (ULONG)newResp;
+            RtlCopyMemory(buf + 4, &respSize, sizeof(ULONG));
+        }
+    }
+
+    *newBufUsed = needed;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen)
+{
+    *newLen = bufSize;
+
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    ULONG descOffset = 0, descLen = 0;
+    if (!ScanForSdpHidDescriptor(buf, bufSize, &descOffset, &descLen))
+    {
+        return STATUS_NOT_FOUND;
+    }
+
+    DbgPrint("MM: SDP 0x0206 at buf[%lu], existing=%lu B, injecting %lu B\n",
+             descOffset, descLen, g_HidDescriptorSize);
+
+    ULONG    used = 0;
+    NTSTATUS s    = PatchSdpHidDescriptor(buf, bufSize, descOffset, descLen, &used);
+    if (!NT_SUCCESS(s))
+    {
+        DbgPrint("MM: PatchSdpHidDescriptor 0x%08X — passthrough\n", s);
+        return STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
+    DbgPrint("MM: Patch OK — SDP buffer %lu -> %lu bytes\n", bufSize, used);
+    *newLen = used;
+    return STATUS_SUCCESS;
+}

--- a/v2-kmdf-driver/InputHandler.h
+++ b/v2-kmdf-driver/InputHandler.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+// Scan an SDP attribute response for HIDDescriptorList (0x0206) and replace
+// the embedded report descriptor with g_HidDescriptor[].
+//
+// Returns:
+//   STATUS_SUCCESS                   — patched; *newLen = new byte count
+//   STATUS_NOT_FOUND                 — 0x0206 not present (normal)
+//   STATUS_MORE_PROCESSING_REQUIRED  — pattern found, patch rejected
+//   STATUS_INVALID_PARAMETER         — buf NULL or too small
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen);

--- a/v2-kmdf-driver/Install-KMDF.cmd
+++ b/v2-kmdf-driver/Install-KMDF.cmd
@@ -1,0 +1,10 @@
+@echo off
+REM One click. First time: accept the Administrator prompt (registers a SYSTEM task).
+REM Later clicks: no prompt — the task just runs.
+cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Install-KMDF.ps1"
+echo.
+echo Result file: C:\ProgramData\MagicMouseDriver\RESULT.txt
+echo Log:         C:\ProgramData\MagicMouseDriver\install.log
+echo.
+pause

--- a/v2-kmdf-driver/Install-KMDF.ps1
+++ b/v2-kmdf-driver/Install-KMDF.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+One click for a non-technical user: register a SYSTEM task and install MagicMouseDriver for PID 0323.
+
+.DESCRIPTION
+Double-click Install-KMDF.cmd. The first run asks for Administrator once so it can
+register MM-Kmdf-Install and MM-Kmdf-PostBoot as SYSTEM. After that, this script
+only starts the task — no UAC.
+
+The SYSTEM task builds if needed, self-signs, installs, binds 0323 only
+(LowerFilters=MagicMouseDriver, no applewirelessmouse, no 030D), bounces
+Bluetooth, reboots if test signing just changed, then post-boot verifies.
+
+Results: C:\ProgramData\MagicMouseDriver\RESULT.txt
+Logs:    C:\ProgramData\MagicMouseDriver\install.log
+
+.PARAMETER Uninstall
+Remove the SYSTEM tasks, unbind 0323, delete the KMDF package.
+
+.PARAMETER NoElevate
+Internal. Set when relaunched via UAC so we do not loop.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Uninstall,
+    [switch]$NoElevate
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $Here 'scripts\Kmdf-Common.ps1')
+
+function Start-KmdfInstallTask {
+    Write-Host ""
+    Write-Host "Starting SYSTEM task '$script:KmdfTaskInstall' (no approval prompt)..." -ForegroundColor Cyan
+    & schtasks.exe /run /tn $script:KmdfTaskInstall
+    if ($LASTEXITCODE -ne 0) { return $false }
+    Write-Host "The installer is running in the background as SYSTEM." -ForegroundColor Green
+    Write-Host "Watch:  $script:KmdfResult" -ForegroundColor Yellow
+    Write-Host "Log:    $script:KmdfLog" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "The PC may reboot by itself if test signing was just turned on." -ForegroundColor Yellow
+    Write-Host "After reboot, RESULT.txt is the pass/fail." -ForegroundColor Yellow
+    return $true
+}
+
+function Copy-KmdfPackageToProgramFiles {
+    Initialize-KmdfDataDir
+    if (-not (Test-Path -LiteralPath $script:KmdfInstallDir)) {
+        New-Item -ItemType Directory -Path $script:KmdfInstallDir -Force | Out-Null
+    }
+    Write-Host "Copying KMDF package to $script:KmdfInstallDir" -ForegroundColor Gray
+    Copy-Item -Path (Join-Path $Here '*') -Destination $script:KmdfInstallDir -Recurse -Force
+    icacls.exe "$script:KmdfInstallDir" /inheritance:r /grant 'SYSTEM:(OI)(CI)F' /grant 'Administrators:(OI)(CI)F' /grant 'Users:(OI)(CI)RX' | Out-Null
+}
+
+function Register-KmdfSystemTasks {
+    $installPs1  = Join-Path $script:KmdfInstallDir 'scripts\Invoke-KmdfInstall.ps1'
+    $postBootPs1 = Join-Path $script:KmdfInstallDir 'scripts\Invoke-KmdfPostBoot.ps1'
+    if (-not (Test-Path -LiteralPath $installPs1))  { throw "Missing $installPs1" }
+    if (-not (Test-Path -LiteralPath $postBootPs1)) { throw "Missing $postBootPs1" }
+
+    $installAction = New-ScheduledTaskAction -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$installPs1`" -PackageRoot `"$script:KmdfInstallDir`""
+    $postAction = New-ScheduledTaskAction -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$postBootPs1`""
+
+    $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+
+    $installSettings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 30) `
+        -MultipleInstances IgnoreNew `
+        -Hidden
+
+    $postSettings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 15) `
+        -MultipleInstances IgnoreNew `
+        -Hidden
+
+    $startup = New-ScheduledTaskTrigger -AtStartup
+    $startup.Delay = 'PT45S'
+
+    Register-ScheduledTask -TaskName $script:KmdfTaskInstall `
+        -Action $installAction `
+        -Principal $principal `
+        -Settings $installSettings `
+        -Description 'MagicMouseDriver KMDF one-click install (PID 0323 only). Trigger with schtasks /run — no UAC after first register.' `
+        -Force | Out-Null
+
+    Register-ScheduledTask -TaskName $script:KmdfTaskPostBoot `
+        -Action $postAction `
+        -Principal $principal `
+        -Settings $postSettings `
+        -Trigger $startup `
+        -Description 'MagicMouseDriver KMDF post-boot verify (PID 0323 stack + service).' `
+        -Force | Out-Null
+
+    Write-Host "Registered SYSTEM tasks: $script:KmdfTaskInstall , $script:KmdfTaskPostBoot" -ForegroundColor Green
+}
+
+function Unregister-KmdfSystemTasks {
+    foreach ($n in @($script:KmdfTaskInstall, $script:KmdfTaskPostBoot)) {
+        Unregister-ScheduledTask -TaskName $n -Confirm:$false -ErrorAction SilentlyContinue
+        Write-Host "Removed task $n" -ForegroundColor Gray
+    }
+}
+
+function Uninstall-KmdfPackage {
+    Write-Host "Unbinding PID 0323 and removing MagicMouseDriver..." -ForegroundColor Yellow
+    $mice = @(Get-Kmdf0323Device)
+    foreach ($m in $mice) {
+        $rp = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($m.InstanceId)"
+        try {
+            $lf = @((Get-ItemProperty -LiteralPath $rp -ErrorAction Stop).LowerFilters)
+            $new = @($lf | Where-Object { $_ -ne 'MagicMouseDriver' })
+            if ($new.Count -gt 0) {
+                Set-ItemProperty -LiteralPath $rp -Name LowerFilters -Value $new -Type MultiString
+            } else {
+                Remove-ItemProperty -LiteralPath $rp -Name LowerFilters -ErrorAction SilentlyContinue
+            }
+            & pnputil.exe /restart-device $m.InstanceId 2>&1 | Out-Null
+        } catch {
+            Write-Host "  $($m.InstanceId): $_" -ForegroundColor Yellow
+        }
+    }
+
+    $pnpRaw = & pnputil.exe /enum-drivers 2>$null | Out-String
+    $oems = ($pnpRaw -split '(?=Published Name:)') |
+        Where-Object { $_ -match 'MagicMouseDriver\.inf' } |
+        ForEach-Object { if ($_ -match 'Published Name:\s+(oem\d+\.inf)') { $Matches[1] } }
+    foreach ($oem in $oems) {
+        & pnputil.exe /delete-driver $oem /uninstall /force 2>&1 | Out-Null
+    }
+
+    & sc.exe stop MagicMouseDriver 2>&1 | Out-Null
+    & sc.exe delete MagicMouseDriver 2>&1 | Out-Null
+    Write-Host "Uninstall finished. Reboot if the mouse stack looks stuck." -ForegroundColor Green
+}
+
+# --- later clicks: task already there → no UAC ---
+if (-not $Uninstall) {
+    $existing = Get-ScheduledTask -TaskName $script:KmdfTaskInstall -ErrorAction SilentlyContinue
+    if ($existing) {
+        if (Start-KmdfInstallTask) { exit 0 }
+        Write-Host "Could not start the existing task (exit $LASTEXITCODE). Will elevate and repair registration." -ForegroundColor Yellow
+    }
+}
+
+if (-not (Test-KmdfIsAdmin) -and -not $NoElevate) {
+    Write-Host "First run needs Administrator once to register the SYSTEM task." -ForegroundColor Yellow
+    $relaunch = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath, '-NoElevate')
+    if ($Uninstall) { $relaunch += '-Uninstall' }
+    $proc = Start-Process -FilePath 'powershell.exe' -ArgumentList $relaunch -Verb RunAs -Wait -PassThru
+    exit $proc.ExitCode
+}
+
+if (-not (Test-KmdfIsAdmin)) {
+    Write-Host "Administrator approval was cancelled. Nothing was installed." -ForegroundColor Red
+    exit 2
+}
+
+if ($Uninstall) {
+    Unregister-KmdfSystemTasks
+    Uninstall-KmdfPackage
+    Write-KmdfResult -Status 'FAIL' -Detail 'Uninstalled by user.'
+    exit 0
+}
+
+Copy-KmdfPackageToProgramFiles
+Register-KmdfSystemTasks
+if (-not (Start-KmdfInstallTask)) {
+    Write-Host "schtasks /run failed after registration." -ForegroundColor Red
+    exit 1
+}
+exit 0

--- a/v2-kmdf-driver/MAGIC-TRAY.md
+++ b/v2-kmdf-driver/MAGIC-TRAY.md
@@ -1,0 +1,17 @@
+# magic-tray: install this KMDF for 0323
+
+`LesleyMurfin/magic-tray` PR #74 should treat **this repo / `v2-kmdf-driver/`** as the 0323 driver.
+
+## Do
+
+- Offer **Install KMDF** that clones or downloads `magic-mouse-v3-windows-fix` and starts `v2-kmdf-driver/Install-KMDF.cmd` (or `schtasks /run /tn MM-Kmdf-Install` after first register).
+- Bind **PID 0323 only**.
+- Keep `LowerFilters=MagicMouseDriver` **sole**.
+
+## Do not
+
+- Vendor this tree into `magic-tray/driver/`.
+- Default 0323 to `sbagirici/apple-magic-mouse-scroll-fix-windows` or Boot Camp `applewirelessmouse.sys`.
+- Dual-filter with `applewirelessmouse` (v1 binary is a BSOD 0xD1 ship-blocker).
+- Retarget 030D / 0269 with this INF.
+- Call leftover `mm-dev.ps1 -Phase Full`.

--- a/v2-kmdf-driver/MAGIC-TRAY.md
+++ b/v2-kmdf-driver/MAGIC-TRAY.md
@@ -17,5 +17,9 @@
 - Call leftover `mm-dev.ps1 -Phase Full`.
 - Install a May 20 / PATH-A / dual-filter binary.
 - Treat this PR as merge-ready before a Windows-built `.sys` proves pointer **and** scroll on hardware.
+- Ship or install `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` as `MagicMouseDriver.sys`.
+- Ship May 20 as `MagicMouseDriver-kmdf-2.0.4-scroll.sys`.
+
+Tray SELECT for 0323 should pull **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** (FileVersion 2.0.4.0; INF dest `MagicMouseDriver.sys`). Leave **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** as the pointer-only baseline. Refuse **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`**. PATH-A stays in `v1-binary-patch/` as **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`**.
 
 Live HID 2026-08-30 21:23 MDT (Apr 30 `AD5D244B`, do not replace that `.sys` yet): battery is RID **0x90** Input on COL02; Feat **0x47** fails; COL01 Input **0x12** is X/Y only (no `0x0038`). Tray should ship the 2.0.4 source that stays on that 0x12 path.

--- a/v2-kmdf-driver/MAGIC-TRAY.md
+++ b/v2-kmdf-driver/MAGIC-TRAY.md
@@ -15,3 +15,7 @@
 - Dual-filter with `applewirelessmouse` (v1 binary is a BSOD 0xD1 ship-blocker).
 - Retarget 030D / 0269 with this INF.
 - Call leftover `mm-dev.ps1 -Phase Full`.
+- Install a May 20 / PATH-A / dual-filter binary.
+- Treat this PR as merge-ready before a Windows-built `.sys` proves pointer **and** scroll on hardware.
+
+Live HID 2026-08-30 21:23 MDT (Apr 30 `AD5D244B`, do not replace that `.sys` yet): battery is RID **0x90** Input on COL02; Feat **0x47** fails; COL01 Input **0x12** is X/Y only (no `0x0038`). Tray should ship the 2.0.4 source that stays on that 0x12 path.

--- a/v2-kmdf-driver/MagicMouseDriver.inf
+++ b/v2-kmdf-driver/MagicMouseDriver.inf
@@ -6,6 +6,11 @@
 ;
 ; Stack: HidBth → MagicMouseDriver → BthEnum
 ;
+; Live HID 2026-08-30 21:23 MDT (Apr 30 MagicMouseFix AD5D244B):
+;   COL01 Input 0x12 = X/Y only (no Wheel 0x0038) — pointer OK, scroll dead.
+;   COL02 Input 0x90 = battery (HidD_GetInputReport; percent at byte[2]).
+;   Feature 0x47 fails on COL01/COL02. Product is 0x12+wheel / 0x90, not 0x02/0x47.
+;
 ; Sole filter. Do NOT install alongside applewirelessmouse
 ; (that binary is a BSOD 0xD1 ship-blocker on this PID).
 ; This INF does not bind 0x030D / 0x0269 / 0x0310.
@@ -20,7 +25,7 @@ ClassGUID   = {745A17A0-74D3-11D0-B6FE-00A0C90F57DA}
 Provider    = %ManufacturerName%
 DriverPackageDisplayName = %DeviceDesc%
 DriverPackageType = PlugAndPlay
-DriverVer   = 08/31/2026,2.0.3.0
+DriverVer   = 08/31/2026,2.0.4.0
 CatalogFile = MagicMouseDriver.cat
 PnpLockdown = 1
 

--- a/v2-kmdf-driver/MagicMouseDriver.inf
+++ b/v2-kmdf-driver/MagicMouseDriver.inf
@@ -1,0 +1,77 @@
+; MagicMouseDriver.inf
+; SPDX-License-Identifier: MIT
+;
+; KMDF lower filter for Apple Magic Mouse PID 0x0323 only
+; (2024 / Magic Mouse 2 USB-C over Bluetooth).
+;
+; Stack: HidBth → MagicMouseDriver → BthEnum
+;
+; Sole filter. Do NOT install alongside applewirelessmouse
+; (that binary is a BSOD 0xD1 ship-blocker on this PID).
+; This INF does not bind 0x030D / 0x0269 / 0x0310.
+;
+; Install: double-click Install-KMDF.cmd (registers a SYSTEM task).
+; Manual:  pnputil /add-driver MagicMouseDriver.inf /install
+
+[Version]
+Signature   = "$WINDOWS NT$"
+Class       = HIDClass
+ClassGUID   = {745A17A0-74D3-11D0-B6FE-00A0C90F57DA}
+Provider    = %ManufacturerName%
+DriverPackageDisplayName = %DeviceDesc%
+DriverPackageType = PlugAndPlay
+DriverVer   = 08/31/2026,2.0.3.0
+CatalogFile = MagicMouseDriver.cat
+PnpLockdown = 1
+
+[DestinationDirs]
+DefaultDestDir = 12
+
+[Manufacturer]
+%ManufacturerName% = MagicMouseDriver, NTamd64
+
+[MagicMouseDriver.NTamd64]
+; PID 0x0323 only — VID 0x004C (Apple Bluetooth)
+%DeviceDesc% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+
+[MagicMouseDriver_Install.NT]
+Include   = hidbth.inf
+Needs     = HIDBTH_Inst.NT
+CopyFiles = MagicMouseDriver_Copy
+
+[MagicMouseDriver_Copy]
+MagicMouseDriver.sys
+
+[MagicMouseDriver_Install.NT.HW]
+AddReg  = MagicMouseDriver_AddReg
+Include = input.inf
+Needs   = HID_Inst.NT.HW
+
+[MagicMouseDriver_AddReg]
+; 0x00010000 = FLG_ADDREG_TYPE_MULTI_SZ — replaces any previous LowerFilters.
+HKR,,"LowerFilters",0x00010000,"MagicMouseDriver"
+HKLM,"SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Parameters","EnableInjection",0x00010001,1
+
+[MagicMouseDriver_Install.NT.Services]
+Include    = hidbth.inf
+Needs      = HIDBTH_Inst.NT.Services
+AddService = MagicMouseDriver, , MagicMouseDriver_Service_Inst
+
+[MagicMouseDriver_Service_Inst]
+DisplayName   = %ServiceDesc%
+ServiceType   = 1
+StartType     = 3
+ErrorControl  = 1
+ServiceBinary = %12%\MagicMouseDriver.sys
+
+[SourceDisksNames]
+1 = %DiskName%,,,""
+
+[SourceDisksFiles]
+MagicMouseDriver.sys = 1,,
+
+[Strings]
+ManufacturerName = "Magic Mouse Driver"
+DeviceDesc       = "Apple Magic Mouse (PID 0323) KMDF filter"
+ServiceDesc      = "MagicMouseDriver (0323 KMDF lower filter)"
+DiskName         = "Magic Mouse Driver Installation Disk"

--- a/v2-kmdf-driver/MagicMouseDriver.inf
+++ b/v2-kmdf-driver/MagicMouseDriver.inf
@@ -17,6 +17,13 @@
 ;
 ; Install: double-click Install-KMDF.cmd (registers a SYSTEM task).
 ; Manual:  pnputil /add-driver MagicMouseDriver.inf /install
+;
+; Windows / INF / service file name is MagicMouseDriver.sys (do not change).
+; Package artifact for this DriverVer is MagicMouseDriver-kmdf-2.0.4-scroll.sys
+; (FileVersion 2.0.4.0). Do not confuse with:
+;   MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys     pointer-only
+;   MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys pointer-dead
+;   applewirelessmouse-patched-pathA-SHIPBLOCKER.sys     PATH-A, not this product
 
 [Version]
 Signature   = "$WINDOWS NT$"

--- a/v2-kmdf-driver/MagicMouseDriver.rc
+++ b/v2-kmdf-driver/MagicMouseDriver.rc
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+//
+// FileVersion 2.0.4.0 — KMDF scroll candidate only.
+// Package / artifact name: MagicMouseDriver-kmdf-2.0.4-scroll.sys
+// Windows / INF install name stays MagicMouseDriver.sys (do not change).
+//
+// Distinct from:
+//   MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys   pointer-only (not 2.0.4.0)
+//   MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys  FileVersion 2.0.2.0, refuse
+//   applewirelessmouse-patched-pathA-SHIPBLOCKER.sys   PATH-A, never this product
+
+#include <windows.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    2,0,4,0
+ PRODUCTVERSION 2,0,4,0
+ FILEFLAGSMASK  0x3fL
+#ifdef _DEBUG
+ FILEFLAGS      0x1L
+#else
+ FILEFLAGS      0x0L
+#endif
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_DRV
+ FILESUBTYPE    VFT2_DRV_SYSTEM
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName",      "Magic Mouse Driver"
+            VALUE "FileDescription",  "KMDF 2.0.4 scroll candidate (PID 0323). Installs as MagicMouseDriver.sys."
+            VALUE "FileVersion",      "2.0.4.0"
+            VALUE "InternalName",     "MagicMouseDriver-kmdf-2.0.4-scroll"
+            VALUE "LegalCopyright",   "MIT"
+            VALUE "OriginalFilename", "MagicMouseDriver-kmdf-2.0.4-scroll.sys"
+            VALUE "ProductName",      "MagicMouseDriver KMDF 2.0.4 scroll"
+            VALUE "ProductVersion",   "2.0.4.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/v2-kmdf-driver/MagicMouseDriver.sln
+++ b/v2-kmdf-driver/MagicMouseDriver.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MagicMouseDriver", "MagicMouseDriver.vcxproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/v2-kmdf-driver/MagicMouseDriver.vcxproj
+++ b/v2-kmdf-driver/MagicMouseDriver.vcxproj
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  KMDF MagicMouseDriver — PID 0x0323 only.
+
+  Build (Windows + WDK or mounted EWDK):
+    msbuild MagicMouseDriver.vcxproj /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off
+
+  Or double-click Install-KMDF.cmd — it builds if a .sys is missing and EWDK/WDK exists.
+
+  Linux cannot produce MagicMouseDriver.sys. Ship the source package; sign+install on Windows.
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <TargetName>MagicMouseDriver</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <DriverType>KMDF</DriverType>
+    <KmdfVersionMajor>1</KmdfVersionMajor>
+    <KmdfVersionMinor>33</KmdfVersionMinor>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+      <Driver>WDM</Driver>
+      <AdditionalDependencies>wdmguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="Driver.c" />
+    <ClCompile Include="GestureEngine.c" />
+    <ClCompile Include="HidDescriptor.c" />
+    <ClCompile Include="InputHandler.c" />
+    <ClCompile Include="AclTranslate.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Driver.h" />
+    <ClInclude Include="GestureEngine.h" />
+    <ClInclude Include="HidDescriptor.h" />
+    <ClInclude Include="InputHandler.h" />
+    <ClInclude Include="AclTranslate.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Inf Include="MagicMouseDriver.inf" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(WDKContentRoot)\build\WindowsDriver.targets"
+          Condition="Exists('$(WDKContentRoot)\build\WindowsDriver.targets')" />
+
+</Project>

--- a/v2-kmdf-driver/MagicMouseDriver.vcxproj
+++ b/v2-kmdf-driver/MagicMouseDriver.vcxproj
@@ -7,7 +7,9 @@
 
   Or double-click Install-KMDF.cmd — it builds if a .sys is missing and EWDK/WDK exists.
 
-  Linux cannot produce MagicMouseDriver.sys. Ship the source package; sign+install on Windows.
+  Linux cannot produce a .sys. WDK output is MagicMouseDriver.sys (INF/service name).
+  Copy the artifact to MagicMouseDriver-kmdf-2.0.4-scroll.sys (FileVersion 2.0.4.0).
+  Never name a KMDF build applewirelessmouse*.sys.
 -->
 <Project DefaultTargets="Build" ToolsVersion="15.0"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -85,6 +87,7 @@
 
   <ItemGroup>
     <Inf Include="MagicMouseDriver.inf" />
+    <ResourceCompile Include="MagicMouseDriver.rc" />
   </ItemGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/v2-kmdf-driver/README.md
+++ b/v2-kmdf-driver/README.md
@@ -2,9 +2,18 @@
 
 **This is the 0323 product.** Double-click `Install-KMDF.cmd`. Success is **pointer and vertical/horizontal surface scroll**.
 
-**Do not install this tree on the live Apr 30 PC yet.** Linux cannot produce a `.sys`. Do not merge until hardware proves scroll. Do not replace the live Apr 30 `MagicMouseDriver.sys` (`AD5D244B`) by hand.
+**Do not install this tree on the live Apr 30 PC yet.** Linux cannot produce a `.sys`. Do not merge until hardware proves scroll. Do not replace the live Apr 30 pointer-only binary by hand.
 
-Do not install the v1 `applewirelessmouse.sys` binary patch (BSOD 0xD1). Do not install the May 20 WDKTestCert 2.0.2.0 (pointer-dead). Do not stack filters. No PATH-A. No dual-filter.
+Windows still installs KMDF as **`MagicMouseDriver.sys`**. Package names are different so they cannot be mixed with PATH-A:
+
+| Package / backup filename | FileVersion | Role |
+|---------------------------|-------------|------|
+| **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** | not 2.0.4.0 | **Pointer-only.** SHA `AD5D244B…`. Scroll dead. Leave on the live PC. |
+| **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`** | 2.0.2.0 | **Pointer-dead.** Installer refuses this SHA. |
+| **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** | **2.0.4.0** | **Scroll candidate** from this source. Hash after Windows WDK build. |
+| **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`** | PATH-A v1 | **SHIP-BLOCKER.** Lives in `v1-binary-patch/`. Never this product. Never `MagicMouseDriver.sys`. |
+
+Do not install PATH-A. Do not install May 20. Do not stack filters. No dual-filter.
 
 `magic-tray` PR #74 should **pull and install this package** for 0323. Do not vendor the KMDF tree into `magic-tray`.
 
@@ -14,7 +23,7 @@ Do not install the v1 `applewirelessmouse.sys` binary patch (BSOD 0xD1). Do not 
 2. Double-click **`v2-kmdf-driver/Install-KMDF.cmd`**.
 3. The **first** run asks for Administrator **once**. That registers two SYSTEM scheduled tasks (`MM-Kmdf-Install`, `MM-Kmdf-PostBoot`). Later clicks only run the task — **no UAC**.
 4. The SYSTEM task then, unattended:
-   - Builds `MagicMouseDriver.sys` if it is missing and a WDK/EWDK is installed
+   - Builds `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion 2.0.4.0) if it is missing and a WDK/EWDK is installed, then stages it as `MagicMouseDriver.sys` for INF
    - Turns on test signing if needed
    - Creates a local `CN=MagicMouseDriver` certificate, signs `.sys` + `.cat`, trusts the publisher
    - `pnputil` installs the package
@@ -30,13 +39,13 @@ Uninstall: double-click `Uninstall-KMDF.cmd`.
 
 | Topic | What actually happens |
 |-------|------------------------|
-| **No `.sys` on GitHub** | This environment cannot compile a kernel driver. The repo ships **source + INF + vcxproj + the one-click scripts**. On a Windows machine with WDK or Enterprise WDK, the SYSTEM task builds; or drop a built `MagicMouseDriver.sys` next to the INF and click again. |
+| **No `.sys` on GitHub** | This environment cannot compile a kernel driver. The repo ships **source + INF + vcxproj + the one-click scripts**. On Windows + WDK the SYSTEM task builds `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion 2.0.4.0) and INF copies it as `MagicMouseDriver.sys`. |
 | **Test signing** | A self-signed `.sys` will not load until `bcdedit /set testsigning on` and a reboot. A "Test Mode" watermark on the desktop is expected. |
 | **HVCI / Memory Integrity** | Windows 11 Core isolation **blocks** self-signed kernel drivers. The task **fails** with a clear RESULT if HVCI is on. Turn Memory integrity **off**, reboot, click again. There is no Microsoft-signed binary in this repo yet. |
-| **Apr 30 live KMDF** | `MagicMouseDriver.sys` 24536 bytes, SHA256 `AD5D244B…`, `CN=MagicMouseFix` thumb `B902C286…`. **Pointer moves, scroll does not.** Keep installed. Do not replace until a 2.0.4 `.sys` from this source is built on Windows WDK. |
+| **Apr 30 live KMDF** | Package name **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`**. Installed as `MagicMouseDriver.sys`, 24536 bytes, SHA256 `AD5D244B…`, `CN=MagicMouseFix` thumb `B902C286…`. **Pointer-only.** Keep installed. FileVersion is **not** 2.0.4.0. |
 | **Live HID 2026-08-30 21:23 MDT** | On that Apr 30 binary: `HidD_GetInputReport(0x90)` on **COL02** works (`[90 04 2F …]` → 47% at `buf[2]`). **Feat 0x47 fails** on COL01 and COL02. **COL01 Input 0x12 is X/Y only** — no Wheel usage `0x0038`. All other InRpt/Feat fail. Product battery = RID **0x90**, not 0x47. Product scroll = Wheel/AC Pan on the **0x12** path HidBth delivers, not a convert-to-0x02. |
-| **May 20 WDKTestCert** | 29184 bytes, SHA256 `559B136A…`, version 2.0.2.0. HID started, **pointer dead**. The one-click task **refuses** to install it. |
-| **v1 applewirelessmouse.sys** | PATH-A patch. **SHIP-BLOCKER** (BSOD 0xD1). Not the 0323 product. |
+| **May 20 WDKTestCert** | Package name **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`**. 29184 bytes, SHA256 `559B136A…`, FileVersion **2.0.2.0**. HID started, **pointer dead**. The one-click task **refuses** it. |
+| **PATH-A** | Package name **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`**. Windows name `applewirelessmouse.sys`. **SHIP-BLOCKER** (BSOD 0xD1). Not the 0323 product. |
 
 ## What magic-tray should install
 

--- a/v2-kmdf-driver/README.md
+++ b/v2-kmdf-driver/README.md
@@ -1,287 +1,67 @@
-# v2.0.0 — KMDF Driver (Work in Progress)
+# MagicMouseDriver (KMDF) — PID 0x0323 only
 
-**STATUS: WORK IN PROGRESS — NOT PRODUCTION READY**
+**This is the 0323 product.** Double-click `Install-KMDF.cmd`. Success is **pointer and vertical/horizontal surface scroll**.
 
-This directory contains the roadmap and architecture for v2.0.0, a from-scratch KMDF (Kernel Mode Driver Framework) filter driver implementation. v2 replaces the v1 binary patch with native source code, eliminating dependency on Apple firmware patching.
+Do not install the v1 `applewirelessmouse.sys` binary patch (BSOD 0xD1). Do not install the May 20 WDKTestCert 2.0.2.0 (pointer-dead). Do not stack filters. Do not ask anyone to hand-replace a working Apr 30 `.sys` — the SYSTEM task installs from this tree.
 
-## Why v2?
+`magic-tray` PR #74 should **pull and install this package** for 0323. Do not vendor the KMDF tree into `magic-tray`.
 
-### v1 Limitations
+## One click
 
-| Issue | v1 Binary Patch | v2 KMDF Source |
-|-------|---|---|
-| Transparency | Binary only (opaque) | Full source code |
-| Apple dependency | Patches Apple firmware | Independent implementation |
-| Signing | Self-signed cert | Windows-signed (future) |
-| Maintainability | Requires re-patching firmware | Direct source modifications |
-| SmartScreen | Warnings on new systems | Better reputation over time |
-| Compliance | Custom certificate trust | Standard driver signing |
+1. Clone this repo on Windows.
+2. Double-click **`v2-kmdf-driver/Install-KMDF.cmd`**.
+3. The **first** run asks for Administrator **once**. That registers two SYSTEM scheduled tasks (`MM-Kmdf-Install`, `MM-Kmdf-PostBoot`). Later clicks only run the task — **no UAC**.
+4. The SYSTEM task then, unattended:
+   - Builds `MagicMouseDriver.sys` if it is missing and a WDK/EWDK is installed
+   - Turns on test signing if needed
+   - Creates a local `CN=MagicMouseDriver` certificate, signs `.sys` + `.cat`, trusts the publisher
+   - `pnputil` installs the package
+   - Binds **PID 0323 only**, `LowerFilters=MagicMouseDriver` **sole** (never `applewirelessmouse`, never 030D)
+   - Bounces Bluetooth (disable then enable the radio, then restart the 0323 node)
+   - Reboots if test signing just changed or PnP asked for it
+   - After boot, `MM-Kmdf-PostBoot` checks: service Running, stack `HidBth` / `MagicMouseDriver`, HID started
+5. Read **`C:\ProgramData\MagicMouseDriver\RESULT.txt`** — `PASS` or `FAIL`.
 
-### v2 Advantages
+Uninstall: double-click `Uninstall-KMDF.cmd`.
 
-1. **Open source:** Full implementation visible for audit and modification
-2. **No Apple dependency:** Standalone KMDF driver, no firmware patching
-3. **Better signing:** Compatible with Microsoft code signing and certification
-4. **Cleaner deployment:** No custom certificate imports, standard Windows driver model
-5. **Long-term support:** Source code can be maintained across Windows versions
-6. **Transparency:** Security research and third-party review possible
+## Honest limits
 
-## Architecture
+| Topic | What actually happens |
+|-------|------------------------|
+| **No `.sys` on GitHub** | This environment cannot compile a kernel driver. The repo ships **source + INF + vcxproj + the one-click scripts**. On a Windows machine with WDK or Enterprise WDK, the SYSTEM task builds; or drop a built `MagicMouseDriver.sys` next to the INF and click again. |
+| **Test signing** | A self-signed `.sys` will not load until `bcdedit /set testsigning on` and a reboot. A "Test Mode" watermark on the desktop is expected. |
+| **HVCI / Memory Integrity** | Windows 11 Core isolation **blocks** self-signed kernel drivers. The task **fails** with a clear RESULT if HVCI is on. Turn Memory integrity **off**, reboot, click again. There is no Microsoft-signed binary in this repo yet. |
+| **Apr 30 live KMDF** | `MagicMouseDriver.sys` 24536 bytes, SHA256 `AD5D244B…`, `CN=MagicMouseFix` thumb `B902C286…`. Lesley confirmed **pointer moves**, **scroll does not**. That binary stays the pointer baseline. This tree adds 0323 surface → Wheel / AC Pan. |
+| **May 20 WDKTestCert** | 29184 bytes, SHA256 `559B136A…`, version 2.0.2.0. HID started, **pointer dead**. The one-click task **refuses** to install it. |
+| **v1 applewirelessmouse.sys** | PATH-A patch. **SHIP-BLOCKER** (BSOD 0xD1). Not the 0323 product. |
 
-### KMDF vs WDM
+## What magic-tray should install
 
-| Aspect | v1 (WDM Lower Filter) | v2 (KMDF Filter) |
-|--------|---|---|
-| Framework | Windows Driver Model (WDM) | Kernel Mode Driver Framework (KMDF) |
-| Code size | ~66 KB binary | ~150 KB source (compiled similar size) |
-| Complexity | Direct IRP handling | Object-oriented framework |
-| Debuggability | Standard kernel debugging | KMDF-aware tools |
-| Best practice | Older, but functional | Modern Windows driver development |
+For **0323** (live USB-C Magic Mouse):
 
-### File Structure
+- Source of truth: `LesleyMurfin/magic-mouse-v3-windows-fix` / `v2-kmdf-driver/`
+- User action in the tray: same as `Install-KMDF.cmd` (register/start `MM-Kmdf-Install`), **or** download this folder and run that cmd
+- Do **not** default 0323 to `sbagirici` / Boot Camp `applewirelessmouse.sys`
+- Do **not** copy this tree into `magic-tray/driver/`
+
+## Layout
 
 ```
 v2-kmdf-driver/
-├── README.md (this file)
-├── src/
-│   ├── main.c            # DriverEntry, device creation
-│   ├── filter.c          # Filter dispatch routines
-│   ├── magic_mouse.c     # Magic Mouse-specific logic
-│   ├── ioctl_handlers.c  # Device I/O control handling
-│   └── common.h          # Shared definitions
-├── inc/
-│   ├── filter.h
-│   ├── magic_mouse.h
-│   └── version.h
-├── magic_mouse_v3.vcxproj    # Visual Studio project
-├── magic_mouse_v3.sln        # Visual Studio solution
-├── build.cmd                 # Build script
-├── BUILDING.md               # Build instructions
-└── docs/
-    ├── KMDF_MIGRATION.md     # Migration notes from WDM
-    └── TEST_PLAN.md          # Comprehensive test plan
+  Install-KMDF.cmd          ← one click
+  Install-KMDF.ps1          ← register/start SYSTEM task (UAC once)
+  Uninstall-KMDF.cmd
+  MagicMouseDriver.inf      ← 0323 only
+  MagicMouseDriver.vcxproj
+  Driver.c / GestureEngine.c / AclTranslate.c / ...
+  scripts/
+    Invoke-KmdfInstall.ps1  ← runs as SYSTEM
+    Invoke-KmdfPostBoot.ps1
+    Kmdf-Common.ps1
 ```
 
-## Development Status
+There is **no** `mm-dev.ps1` and **no** `Phase=Full` that `sc delete`s MagicMouseDriver globally or sets a dual filter.
 
-### Completed
+## Manual build (optional)
 
-- [ ] Architecture design (pending)
-- [ ] KMDF framework skeleton (pending)
-- [ ] Magic Mouse PID detection (pending)
-- [ ] IRP filtering logic (pending)
-- [ ] DynamicCachedServices interception (pending)
-- [ ] Error handling (pending)
-- [ ] Unit tests (pending)
-- [ ] Integration tests (pending)
-- [ ] Code review (pending)
-
-### In Progress
-
-- KMDF initialization
-- Device enumeration and filtering
-
-### Planned
-
-- IRP interception and validation
-- Registry manipulation safeguards
-- Comprehensive testing (all 6 test scenarios)
-- Public source code release
-- Microsoft signing certification
-
-## Building v2 (When Available)
-
-### Prerequisites
-
-- Windows Driver Kit (WDK) 10.0 or later
-- Visual Studio 2019 or later
-- .NET Framework 4.7+ (for build tools)
-
-### Build Steps
-
-```powershell
-# Open Visual Studio as Administrator
-# File → Open Solution → magic_mouse_v3.sln
-# Build → Build Solution (F7)
-# Output: magic_mouse_v3.sys in output directory
-
-# Or command-line:
-msbuild magic_mouse_v3.sln /p:Configuration=Release /p:Platform=x64
-```
-
-### Signing (Pre-Release)
-
-```powershell
-# Test-sign for development
-signtool sign /f MagicMouseFix.pfx /p password /t http://timestamp.server.com ^
-  magic_mouse_v3.sys
-
-# Production (pending Microsoft certification)
-# Will be signed by Revive Business Solutions' code signing certificate
-```
-
-## Testing (When Available)
-
-v2 will be tested with the same 6-scenario test suite as v1:
-
-1. **Power off/on:** Scroll persists
-2. **69-minute idle:** Scroll stable after extended idle
-3. **pnputil rescan:** Device rescan compatible
-4. **Sleep/wake:** Cache integrity maintained
-5. **UsoClient force-DSM:** DSM property scan blocked
-6. **Cold reboot:** Multiple DSM runs don't trigger collapse
-
-See `docs/TEST_PLAN.md` for detailed procedures.
-
-## Deployment Roadmap
-
-### Phase 1: Internal Testing (Target: Q3 2026)
-
-- Complete source implementation
-- Run all 6 test scenarios
-- Code review and security audit
-- Document building and testing process
-
-### Phase 2: Beta Release (Target: Q4 2026)
-
-- Source code published to GitHub (this repo)
-- Beta version for experienced users
-- Feedback collection
-- Bug fixes based on testing
-
-### Phase 3: Production Release (Target: Q1 2027)
-
-- Microsoft code signing certification
-- v2.0.0 final release
-- v1.0.0 marked as deprecated (still supported)
-- Migration guide for v1 → v2
-
-## Design Principles
-
-### v2 KMDF Implementation Will Follow:
-
-1. **Minimal interception:** Only intercept critical DSM property queries, pass all others through
-2. **Fast path:** No complex algorithms, early exit for non-Magic Mouse devices
-3. **Error safety:** If uncertainty exists, allow request (fail-open for stability)
-4. **Logging:** Debug tracing for issue diagnosis without performance penalty
-5. **Isolation:** Device-specific filtering (PID 0x0323 only), no impact on other HID devices
-6. **Compliance:** Follow Windows Driver Frameworks best practices
-
-## Comparison: v1 vs v2
-
-### v1 (Binary Patch) — Current Production
-
-**Use v1 if:**
-- You need a fix now (before v2 is available)
-- You're comfortable with binary patches
-- You're not concerned about certificate trust prompts
-
-**Install:** See `/v1-binary-patch/README.md`
-
-### v2 (KMDF Source) — Future
-
-**Use v2 when:**
-- You want to audit the source code
-- You prefer open-source drivers
-- Microsoft-signed binaries become available
-- You're building a derivative project
-
-**Timeline:** v2 becomes available Q3 2026 (beta), Q1 2027 (production)
-
-## Migration Path: v1 → v2
-
-When v2.0.0 is released:
-
-1. **v1 continues to work:** v1.0.0 will remain available and supported
-2. **Side-by-side installation:** v1 and v2 can coexist (though only one should be active)
-3. **Migration script:** Uninstall v1, install v2 (simple PowerShell script)
-4. **No breaking changes:** v2 maintains same functionality and registry interface
-
-## Contributing
-
-v2 development will welcome contributions for:
-- Code implementation (KMDF driver skeleton, dispatch routines, etc.)
-- Testing on additional hardware configurations
-- Documentation improvements
-- Code review and security audit
-
-**Process:**
-1. Fork this repository
-2. Create feature branch: `git checkout -b ai/v2-feature-name`
-3. Implement feature + tests
-4. Open pull request with test evidence
-5. Code review before merge
-
-See `CONTRIBUTING.md` for details.
-
-## FAQ
-
-### Q: Why not release v2 now?
-
-A: KMDF driver development requires:
-- WDK environment setup
-- Driver architecture design
-- IRP routing and interception logic
-- Comprehensive testing on multiple Windows versions
-- Security audit before public release
-
-Releasing an untested driver would be irresponsible.
-
-### Q: When will v2 be ready?
-
-A: Target timeline:
-- **Architecture & design:** May–June 2026
-- **Implementation:** July–August 2026
-- **Testing:** September 2026
-- **Beta release:** October 2026
-- **Production release:** January 2027
-
-### Q: Can I help build v2?
-
-A: Yes! Contributors welcome once the source skeleton is available. See `CONTRIBUTING.md`.
-
-### Q: Will v1 stop working when v2 is released?
-
-A: No. v1 will continue to work and be supported. v2 is an alternative, not a replacement. You choose which to install.
-
-### Q: What about Windows 12 / ARM64?
-
-A: v2 architecture will support:
-- Windows 11 22H2+
-- Windows 10 build 14393+ (best-effort)
-- x64 architecture (primary target)
-- ARM64 (secondary, pending testing)
-
-v1 works on these now; v2 will maintain same compatibility.
-
-## Current Users (v1.0.0)
-
-If you've installed v1.0.0 and it's working, **no action is required**. v1 remains production-ready and fully supported.
-
-When v2 becomes available, you can optionally upgrade by:
-1. Uninstalling v1 (`Uninstall-MagicMousePatch.ps1`)
-2. Installing v2 (PowerShell or WiX installer)
-3. Rebooting
-
----
-
-## Resources
-
-### Windows Driver Development
-
-- [Microsoft Windows Driver Kit](https://learn.microsoft.com/en-us/windows-hardware/drivers/)
-- [KMDF Documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/wdf/kmdf-version-history)
-- [Windows Driver Samples](https://github.com/microsoft/Windows-driver-samples)
-
-### Related Projects
-
-- [WDF Filter Driver Sample](https://github.com/microsoft/Windows-driver-samples/tree/master/general/filter)
-- [HID Class Driver](https://github.com/microsoft/Windows-driver-samples/tree/master/input/hid)
-
----
-
-**Document Version:** 1.0.0 (WIP)  
-**Last Updated:** 2026-05-18  
-**Status:** Not production ready — do not install on production systems  
-**Author:** Revive Business Solutions  
-**License:** MIT (when source is released)
+See `BUILDING.md`. Not required if you only use the one-click task on a machine that already has WDK.

--- a/v2-kmdf-driver/README.md
+++ b/v2-kmdf-driver/README.md
@@ -2,7 +2,9 @@
 
 **This is the 0323 product.** Double-click `Install-KMDF.cmd`. Success is **pointer and vertical/horizontal surface scroll**.
 
-Do not install the v1 `applewirelessmouse.sys` binary patch (BSOD 0xD1). Do not install the May 20 WDKTestCert 2.0.2.0 (pointer-dead). Do not stack filters. Do not ask anyone to hand-replace a working Apr 30 `.sys` — the SYSTEM task installs from this tree.
+**Do not install this tree on the live Apr 30 PC yet.** Linux cannot produce a `.sys`. Do not merge until hardware proves scroll. Do not replace the live Apr 30 `MagicMouseDriver.sys` (`AD5D244B`) by hand.
+
+Do not install the v1 `applewirelessmouse.sys` binary patch (BSOD 0xD1). Do not install the May 20 WDKTestCert 2.0.2.0 (pointer-dead). Do not stack filters. No PATH-A. No dual-filter.
 
 `magic-tray` PR #74 should **pull and install this package** for 0323. Do not vendor the KMDF tree into `magic-tray`.
 
@@ -31,7 +33,8 @@ Uninstall: double-click `Uninstall-KMDF.cmd`.
 | **No `.sys` on GitHub** | This environment cannot compile a kernel driver. The repo ships **source + INF + vcxproj + the one-click scripts**. On a Windows machine with WDK or Enterprise WDK, the SYSTEM task builds; or drop a built `MagicMouseDriver.sys` next to the INF and click again. |
 | **Test signing** | A self-signed `.sys` will not load until `bcdedit /set testsigning on` and a reboot. A "Test Mode" watermark on the desktop is expected. |
 | **HVCI / Memory Integrity** | Windows 11 Core isolation **blocks** self-signed kernel drivers. The task **fails** with a clear RESULT if HVCI is on. Turn Memory integrity **off**, reboot, click again. There is no Microsoft-signed binary in this repo yet. |
-| **Apr 30 live KMDF** | `MagicMouseDriver.sys` 24536 bytes, SHA256 `AD5D244B…`, `CN=MagicMouseFix` thumb `B902C286…`. Lesley confirmed **pointer moves**, **scroll does not**. That binary stays the pointer baseline. This tree adds 0323 surface → Wheel / AC Pan. |
+| **Apr 30 live KMDF** | `MagicMouseDriver.sys` 24536 bytes, SHA256 `AD5D244B…`, `CN=MagicMouseFix` thumb `B902C286…`. **Pointer moves, scroll does not.** Keep installed. Do not replace until a 2.0.4 `.sys` from this source is built on Windows WDK. |
+| **Live HID 2026-08-30 21:23 MDT** | On that Apr 30 binary: `HidD_GetInputReport(0x90)` on **COL02** works (`[90 04 2F …]` → 47% at `buf[2]`). **Feat 0x47 fails** on COL01 and COL02. **COL01 Input 0x12 is X/Y only** — no Wheel usage `0x0038`. All other InRpt/Feat fail. Product battery = RID **0x90**, not 0x47. Product scroll = Wheel/AC Pan on the **0x12** path HidBth delivers, not a convert-to-0x02. |
 | **May 20 WDKTestCert** | 29184 bytes, SHA256 `559B136A…`, version 2.0.2.0. HID started, **pointer dead**. The one-click task **refuses** to install it. |
 | **v1 applewirelessmouse.sys** | PATH-A patch. **SHIP-BLOCKER** (BSOD 0xD1). Not the 0323 product. |
 

--- a/v2-kmdf-driver/Uninstall-KMDF.cmd
+++ b/v2-kmdf-driver/Uninstall-KMDF.cmd
@@ -1,0 +1,5 @@
+@echo off
+cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Install-KMDF.ps1" -Uninstall
+echo.
+pause

--- a/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
@@ -288,12 +288,12 @@ try {
 
     $sys = Invoke-KmdfBuildIfNeeded
     if (Test-KmdfForbiddenSys -Path $sys) {
-        throw "Chosen .sys is the May 20 pointer-dead WDKTestCert. Build 2.0.3 from this tree instead."
+        throw "Chosen .sys is the May 20 pointer-dead WDKTestCert. Build 2.0.4 from this tree instead."
     }
     $sha = Get-KmdfFileSha256 -Path $sys
     Write-KmdfLog -Message "Installing $sys SHA256=$sha" -Level 'INFO'
     if ($sha -eq $script:KmdfShaPointerOk) {
-        Write-KmdfLog -Message "This is the Apr 30 MagicMouseFix binary (pointer OK, scroll dead). Prefer a 2.0.3 build from this source for surface scroll. Installing only because no other .sys is available." -Level 'WARN'
+        Write-KmdfLog -Message "This is the Apr 30 MagicMouseFix binary (pointer OK, scroll dead). Prefer a 2.0.4 build from this source for surface scroll. Installing only because no other .sys is available." -Level 'WARN'
     }
 
     $cert = Get-KmdfSigningCert

--- a/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
@@ -42,28 +42,91 @@ function Get-KmdfFileSha256 {
 
 function Test-KmdfForbiddenSys {
     param([Parameter(Mandatory)][string]$Path)
+    $name = [System.IO.Path]::GetFileName($Path)
+    if ($name -like '*may20-pointerdead*' -or $name -eq $script:KmdfArtifactMay20) {
+        Write-KmdfLog -Message "Refusing labeled May 20 pointer-dead artifact $name — installer never installs this SHA." -Level 'ERROR'
+        return $true
+    }
+    if ($name -like 'applewirelessmouse*') {
+        Write-KmdfLog -Message "Refusing PATH-A package $name — never install as MagicMouseDriver.sys / 0323 product." -Level 'ERROR'
+        return $true
+    }
     $sha = Get-KmdfFileSha256 -Path $Path
     if ($sha -eq $script:KmdfShaPointerDead) {
-        Write-KmdfLog -Message "Refusing May 20 WDKTestCert MagicMouseDriver.sys ($sha) — pointer-dead. Will not install it." -Level 'ERROR'
+        Write-KmdfLog -Message "Refusing May 20 WDKTestCert ($script:KmdfArtifactMay20 / $sha) — pointer-dead. Will not install it." -Level 'ERROR'
         return $true
     }
     return $false
 }
 
+function Get-KmdfArtifactLabel {
+    param([Parameter(Mandatory)][string]$Path)
+    $sha = Get-KmdfFileSha256 -Path $Path
+    $name = [System.IO.Path]::GetFileName($Path)
+    if ($sha -eq $script:KmdfShaPointerDead -or $name -eq $script:KmdfArtifactMay20) {
+        return $script:KmdfArtifactMay20
+    }
+    if ($sha -eq $script:KmdfShaPointerOk -or $name -eq $script:KmdfArtifactApr30) {
+        return $script:KmdfArtifactApr30
+    }
+    if ($name -eq $script:KmdfArtifactScroll -or $name -like 'MagicMouseDriver-kmdf-2.0.4-scroll*') {
+        return $script:KmdfArtifactScroll
+    }
+    return $script:KmdfArtifactScroll
+}
+
 function Find-KmdfSys {
     $hints = @(
-        (Join-Path $PackageRoot 'MagicMouseDriver.sys'),
-        (Join-Path $PackageRoot 'x64\Release\MagicMouseDriver.sys'),
-        (Join-Path $PackageRoot 'x64\Release\MagicMouseDriver\MagicMouseDriver.sys'),
-        (Join-Path $PackageRoot 'x64\Debug\MagicMouseDriver.sys')
+        (Join-Path $PackageRoot $script:KmdfArtifactScroll),
+        (Join-Path $PackageRoot "x64\Release\$($script:KmdfArtifactScroll)"),
+        (Join-Path $PackageRoot $script:KmdfInstallSysName),
+        (Join-Path $PackageRoot "x64\Release\$($script:KmdfInstallSysName)"),
+        (Join-Path $PackageRoot "x64\Release\MagicMouseDriver\$($script:KmdfInstallSysName)"),
+        (Join-Path $PackageRoot "x64\Debug\$($script:KmdfInstallSysName)"),
+        (Join-Path $PackageRoot $script:KmdfArtifactApr30)
     )
+    $apr30 = $null
     foreach ($h in $hints) {
         if (-not (Test-Path -LiteralPath $h)) { continue }
         $full = (Resolve-Path -LiteralPath $h).Path
         if (Test-KmdfForbiddenSys -Path $full) { continue }
+        $sha = Get-KmdfFileSha256 -Path $full
+        if ($sha -eq $script:KmdfShaPointerOk) {
+            if (-not $apr30) { $apr30 = $full }
+            continue
+        }
         return $full
     }
+    if ($apr30) {
+        Write-KmdfLog -Message "Only $($script:KmdfArtifactApr30) is available (pointer OK, scroll dead). Prefer $($script:KmdfArtifactScroll) FileVersion 2.0.4.0." -Level 'WARN'
+        return $apr30
+    }
     return $null
+}
+
+function Backup-KmdfLiveSys {
+    $live = Join-Path $env:SystemRoot "System32\drivers\$($script:KmdfInstallSysName)"
+    if (-not (Test-Path -LiteralPath $live)) { return }
+    if (-not (Test-Path -LiteralPath $script:KmdfBackupDir)) {
+        New-Item -ItemType Directory -Path $script:KmdfBackupDir -Force | Out-Null
+    }
+    $label = Get-KmdfArtifactLabel -Path $live
+    $dst = Join-Path $script:KmdfBackupDir $label
+    Copy-Item -LiteralPath $live -Destination $dst -Force
+    Write-KmdfLog -Message "Backed up live $live as $dst (package name; Windows file stays $($script:KmdfInstallSysName))" -Level 'OK'
+}
+
+function Publish-KmdfScrollArtifact {
+    param([Parameter(Mandatory)][string]$SysPath)
+    $sha = Get-KmdfFileSha256 -Path $SysPath
+    if ($sha -eq $script:KmdfShaPointerOk -or $sha -eq $script:KmdfShaPointerDead) {
+        return
+    }
+    $labeled = Join-Path $PackageRoot $script:KmdfArtifactScroll
+    if ((Resolve-Path -LiteralPath $SysPath).Path -ne (Join-Path $PackageRoot $script:KmdfArtifactScroll)) {
+        Copy-Item -LiteralPath $SysPath -Destination $labeled -Force
+        Write-KmdfLog -Message "Labeled scroll artifact $labeled (FileVersion 2.0.4.0). INF still installs as $($script:KmdfInstallSysName)." -Level 'OK'
+    }
 }
 
 function Invoke-KmdfBuildIfNeeded {
@@ -80,7 +143,7 @@ function Invoke-KmdfBuildIfNeeded {
 
     $msbuild = Find-KmdfMsBuild
     if (-not $msbuild) {
-        throw "MagicMouseDriver.sys is not in the package and no WDK/EWDK MSBuild was found. Build on Windows with the WDK, copy MagicMouseDriver.sys next to the INF, then run Install-KMDF.cmd again."
+        throw "$($script:KmdfArtifactScroll) is not in the package and no WDK/EWDK MSBuild was found. Build on Windows with the WDK (FileVersion 2.0.4.0), copy $($script:KmdfArtifactScroll) next to the INF (INF still installs as $($script:KmdfInstallSysName)), then run Install-KMDF.cmd again."
     }
 
     Write-KmdfLog -Message "Building $proj ($msbuild)" -Level 'INFO'
@@ -99,8 +162,11 @@ function Invoke-KmdfBuildIfNeeded {
     }
 
     $sys = Find-KmdfSys
-    if (-not $sys) { throw "Build finished but MagicMouseDriver.sys was not produced." }
-    Write-KmdfLog -Message "Built $sys" -Level 'OK'
+    if (-not $sys) { throw "Build finished but $($script:KmdfInstallSysName) was not produced." }
+    Publish-KmdfScrollArtifact -SysPath $sys
+    $labeled = Find-KmdfSys
+    if ($labeled) { $sys = $labeled }
+    Write-KmdfLog -Message "Built $sys (artifact $($script:KmdfArtifactScroll), installs as $($script:KmdfInstallSysName))" -Level 'OK'
     return $sys
 }
 
@@ -288,13 +354,17 @@ try {
 
     $sys = Invoke-KmdfBuildIfNeeded
     if (Test-KmdfForbiddenSys -Path $sys) {
-        throw "Chosen .sys is the May 20 pointer-dead WDKTestCert. Build 2.0.4 from this tree instead."
+        throw "Chosen .sys is $($script:KmdfArtifactMay20) (May 20 pointer-dead WDKTestCert). Build $($script:KmdfArtifactScroll) FileVersion 2.0.4.0 from this tree instead."
     }
     $sha = Get-KmdfFileSha256 -Path $sys
-    Write-KmdfLog -Message "Installing $sys SHA256=$sha" -Level 'INFO'
+    $label = Get-KmdfArtifactLabel -Path $sys
+    Write-KmdfLog -Message "Installing $sys as $($script:KmdfInstallSysName) (package label $label) SHA256=$sha" -Level 'INFO'
     if ($sha -eq $script:KmdfShaPointerOk) {
-        Write-KmdfLog -Message "This is the Apr 30 MagicMouseFix binary (pointer OK, scroll dead). Prefer a 2.0.4 build from this source for surface scroll. Installing only because no other .sys is available." -Level 'WARN'
+        Write-KmdfLog -Message "This is $($script:KmdfArtifactApr30) (pointer OK, scroll dead). Prefer $($script:KmdfArtifactScroll) FileVersion 2.0.4.0. Installing only because no other .sys is available." -Level 'WARN'
+    } else {
+        Publish-KmdfScrollArtifact -SysPath $sys
     }
+    Backup-KmdfLiveSys
 
     $cert = Get-KmdfSigningCert
     Install-KmdfTrust -Cert $cert

--- a/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
@@ -1,0 +1,342 @@
+<#
+.SYNOPSIS
+Unattended KMDF install path. Run by the MM-Kmdf-Install SYSTEM task.
+
+.DESCRIPTION
+Does not prompt. Writes C:\ProgramData\MagicMouseDriver\install.log and RESULT.txt.
+
+  1. Optional build (WDK/EWDK on a fixed path — Session 0 cannot see a user-mounted ISO)
+  2. Enable test signing if needed
+  3. Create/reuse CN=MagicMouseFix (thumb B902C286…) code-signing cert
+  4. Catalog + sign .sys/.cat — refuse the May 20 WDKTestCert (pointer-dead)
+  5. pnputil install; LowerFilters=MagicMouseDriver sole on PID 0323 only
+  6. Bluetooth bounce only if 0323 HID did not start
+  7. Reboot if test signing just changed or pnputil asked for it
+  8. Otherwise verify now
+
+Never writes LowerFilters=MagicMouseDriver,applewirelessmouse.
+Never binds PID 030D.
+#>
+[CmdletBinding()]
+param(
+    [string]$PackageRoot = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+if (-not $PackageRoot) {
+    $PackageRoot = Split-Path -Parent $PSScriptRoot
+}
+
+. (Join-Path $PSScriptRoot 'Kmdf-Common.ps1')
+
+Initialize-KmdfDataDir
+Write-KmdfLog -Message "=== Invoke-KmdfInstall (SYSTEM unattended) ===" -Level 'HEAD'
+Write-KmdfLog -Message "PackageRoot=$PackageRoot User=$([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)" -Level 'INFO'
+
+function Get-KmdfFileSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToUpperInvariant()
+}
+
+function Test-KmdfForbiddenSys {
+    param([Parameter(Mandatory)][string]$Path)
+    $sha = Get-KmdfFileSha256 -Path $Path
+    if ($sha -eq $script:KmdfShaPointerDead) {
+        Write-KmdfLog -Message "Refusing May 20 WDKTestCert MagicMouseDriver.sys ($sha) — pointer-dead. Will not install it." -Level 'ERROR'
+        return $true
+    }
+    return $false
+}
+
+function Find-KmdfSys {
+    $hints = @(
+        (Join-Path $PackageRoot 'MagicMouseDriver.sys'),
+        (Join-Path $PackageRoot 'x64\Release\MagicMouseDriver.sys'),
+        (Join-Path $PackageRoot 'x64\Release\MagicMouseDriver\MagicMouseDriver.sys'),
+        (Join-Path $PackageRoot 'x64\Debug\MagicMouseDriver.sys')
+    )
+    foreach ($h in $hints) {
+        if (-not (Test-Path -LiteralPath $h)) { continue }
+        $full = (Resolve-Path -LiteralPath $h).Path
+        if (Test-KmdfForbiddenSys -Path $full) { continue }
+        return $full
+    }
+    return $null
+}
+
+function Invoke-KmdfBuildIfNeeded {
+    $sys = Find-KmdfSys
+    if ($sys) {
+        Write-KmdfLog -Message "Using existing .sys: $sys" -Level 'OK'
+        return $sys
+    }
+
+    $proj = Join-Path $PackageRoot 'MagicMouseDriver.vcxproj'
+    if (-not (Test-Path -LiteralPath $proj)) {
+        throw "MagicMouseDriver.vcxproj not found under $PackageRoot"
+    }
+
+    $msbuild = Find-KmdfMsBuild
+    if (-not $msbuild) {
+        throw "MagicMouseDriver.sys is not in the package and no WDK/EWDK MSBuild was found. Build on Windows with the WDK, copy MagicMouseDriver.sys next to the INF, then run Install-KMDF.cmd again."
+    }
+
+    Write-KmdfLog -Message "Building $proj ($msbuild)" -Level 'INFO'
+    $outDir = Join-Path $PackageRoot 'x64\Release'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    if ($msbuild -like 'EWDK:*') {
+        $setup = $msbuild.Substring(5)
+        $cmd = '"' + $setup + '" && msbuild "' + $proj + '" /m /nr:false /v:minimal /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off /p:RunCodeAnalysis=false'
+        & cmd.exe /c $cmd 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+        if ($LASTEXITCODE -ne 0) { throw "EWDK msbuild exited $LASTEXITCODE" }
+    } else {
+        & $msbuild $proj /m /nr:false /v:minimal /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off /p:RunCodeAnalysis=false 2>&1 |
+            ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+        if ($LASTEXITCODE -ne 0) { throw "msbuild exited $LASTEXITCODE" }
+    }
+
+    $sys = Find-KmdfSys
+    if (-not $sys) { throw "Build finished but MagicMouseDriver.sys was not produced." }
+    Write-KmdfLog -Message "Built $sys" -Level 'OK'
+    return $sys
+}
+
+function Get-KmdfSigningCert {
+    $byThumb = Get-ChildItem Cert:\LocalMachine\My |
+        Where-Object { $_.Thumbprint -eq $script:KmdfCertThumb -and $_.HasPrivateKey } |
+        Select-Object -First 1
+    if ($byThumb) {
+        Write-KmdfLog -Message "Reusing MagicMouseFix thumb $($byThumb.Thumbprint)" -Level 'OK'
+        return $byThumb
+    }
+    $existing = Get-ChildItem Cert:\LocalMachine\My |
+        Where-Object { $_.Subject -eq $script:KmdfCertSubject -and $_.HasPrivateKey } |
+        Select-Object -First 1
+    if ($existing) {
+        Write-KmdfLog -Message "Reusing cert $($existing.Subject) $($existing.Thumbprint)" -Level 'OK'
+        return $existing
+    }
+    Write-KmdfLog -Message "Creating $script:KmdfCertSubject code-signing certificate" -Level 'INFO'
+    $cert = New-SelfSignedCertificate `
+        -Type CodeSigningCert `
+        -Subject $script:KmdfCertSubject `
+        -CertStoreLocation Cert:\LocalMachine\My `
+        -KeyUsage DigitalSignature `
+        -NotAfter (Get-Date).AddYears(10)
+    Write-KmdfLog -Message "Created cert $($cert.Thumbprint)" -Level 'OK'
+    return $cert
+}
+
+function Install-KmdfTrust {
+    param($Cert)
+    $cer = Join-Path $script:KmdfDataDir 'MagicMouseDriver.cer'
+    Export-Certificate -Cert $Cert -FilePath $cer -Force | Out-Null
+    Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\TrustedPublisher | Out-Null
+    Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+    Write-KmdfLog -Message "Trusted $script:KmdfCertSubject in TrustedPublisher and Root" -Level 'OK'
+}
+
+function New-KmdfSignedPackage {
+    param(
+        [Parameter(Mandatory)][string]$SysPath,
+        $Cert
+    )
+    $stage = Join-Path $script:KmdfDataDir 'pkg'
+    if (Test-Path -LiteralPath $stage) { Remove-Item -LiteralPath $stage -Recurse -Force }
+    New-Item -ItemType Directory -Path $stage -Force | Out-Null
+
+    $infSrc = Join-Path $PackageRoot 'MagicMouseDriver.inf'
+    Copy-Item -LiteralPath $SysPath -Destination (Join-Path $stage 'MagicMouseDriver.sys') -Force
+    Copy-Item -LiteralPath $infSrc -Destination (Join-Path $stage 'MagicMouseDriver.inf') -Force
+
+    $cat = Join-Path $stage 'MagicMouseDriver.cat'
+    $inf2cat = Find-KmdfInf2Cat
+    if ($inf2cat) {
+        Write-KmdfLog -Message "inf2cat $stage" -Level 'INFO'
+        & $inf2cat /driver:$stage /os:10_X64 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+        if ($LASTEXITCODE -ne 0) { throw "inf2cat exited $LASTEXITCODE" }
+    } else {
+        Write-KmdfLog -Message "inf2cat not found — New-FileCatalog fallback" -Level 'WARN'
+        New-FileCatalog -Path $stage -CatalogFilePath $cat -CatalogVersion 2.0 | Out-Null
+    }
+    if (-not (Test-Path -LiteralPath $cat)) { throw "Catalog was not created." }
+
+    $signtool = Find-KmdfSignTool
+    $sysDst = Join-Path $stage 'MagicMouseDriver.sys'
+    if ($signtool) {
+        Write-KmdfLog -Message "signtool $signtool" -Level 'INFO'
+        foreach ($f in @($sysDst, $cat)) {
+            & $signtool sign /fd sha256 /sm /sha1 $Cert.Thumbprint /tr http://timestamp.digicert.com /td sha256 $f 2>&1 |
+                ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+            if ($LASTEXITCODE -ne 0) {
+                Write-KmdfLog -Message "Timestamped sign failed on $f — retry without timestamp" -Level 'WARN'
+                & $signtool sign /fd sha256 /sm /sha1 $Cert.Thumbprint $f 2>&1 |
+                    ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+                if ($LASTEXITCODE -ne 0) { throw "signtool failed on $f" }
+            }
+        }
+    } else {
+        Write-KmdfLog -Message "signtool not found — Set-AuthenticodeSignature" -Level 'WARN'
+        foreach ($f in @($sysDst, $cat)) {
+            $sig = Set-AuthenticodeSignature -FilePath $f -Certificate $Cert
+            Write-KmdfLog -Message "$f Authenticode=$($sig.Status)" -Level 'INFO'
+            if ($sig.Status -ne 'Valid' -and $sig.Status -ne 'UnknownError') {
+                # UnknownError is common without a trusted timestamp on a fresh cert.
+                Write-KmdfLog -Message "Signature status $($sig.Status) on $f (test signing will still load it)" -Level 'WARN'
+            }
+        }
+    }
+    return $stage
+}
+
+function Install-KmdfPnputil {
+    param([Parameter(Mandatory)][string]$StageDir)
+    $inf = Join-Path $StageDir 'MagicMouseDriver.inf'
+
+    $pnpRaw = & pnputil.exe /enum-drivers 2>$null | Out-String
+    $existing = ($pnpRaw -split '(?=Published Name:)') |
+        Where-Object { $_ -match 'MagicMouseDriver\.inf' } |
+        ForEach-Object { if ($_ -match 'Published Name:\s+(oem\d+\.inf)') { $Matches[1] } }
+    foreach ($oem in $existing) {
+        Write-KmdfLog -Message "Removing prior $oem" -Level 'INFO'
+        & pnputil.exe /delete-driver $oem /uninstall /force 2>&1 |
+            ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+    }
+
+    Write-KmdfLog -Message "pnputil /add-driver $inf /install" -Level 'INFO'
+    & pnputil.exe /add-driver $inf /install 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+    $rc = $LASTEXITCODE
+    if ($rc -eq 0) { return $false }
+    if ($rc -eq 3010) {
+        Write-KmdfLog -Message "pnputil 3010 — reboot required" -Level 'WARN'
+        return $true
+    }
+    throw "pnputil /add-driver exited $rc"
+}
+
+function Bind-Kmdf0323Only {
+    $mice = @(Get-Kmdf0323Device)
+    if ($mice.Count -eq 0) {
+        Write-KmdfLog -Message "PID 0323 not enumerated yet — package is staged. Pair the mouse; post-boot verify will bind." -Level 'WARN'
+        return
+    }
+    foreach ($m in $mice) {
+        Write-KmdfLog -Message "0323 instance $($m.InstanceId) status=$($m.Status)" -Level 'INFO'
+        Set-KmdfSoleLowerFilter -InstanceId $m.InstanceId | Out-Null
+    }
+}
+
+function Test-KmdfInstallNow {
+    $fail = @()
+    $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) {
+        $fail += 'service MagicMouseDriver missing'
+    } elseif ($svc.Status -ne 'Running') {
+        try { Start-Service -Name $script:KmdfServiceName -ErrorAction Stop } catch { $fail += "service not Running ($($svc.Status))" }
+        $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+        if ($svc -and $svc.Status -ne 'Running') { $fail += "service still $($svc.Status)" }
+    }
+
+    $mice = @(Get-Kmdf0323Device)
+    if ($mice.Count -eq 0) {
+        $fail += 'no BTHENUM PID&0323 device'
+    } else {
+        foreach ($m in $mice) {
+            $stack = Get-KmdfDeviceStack -InstanceId $m.InstanceId
+            Write-KmdfLog -Message "stack[$($m.InstanceId)]=$stack" -Level 'INFO'
+            if (-not $stack) {
+                $fail += "no DEVPKEY_Device_Stack for $($m.InstanceId)"
+                continue
+            }
+            if ($stack -notmatch 'HidBth') { $fail += 'stack missing HidBth' }
+            if ($stack -notmatch 'MagicMouseDriver') { $fail += 'stack missing MagicMouseDriver' }
+            if ($stack -match 'applewirelessmouse') { $fail += 'stack still has applewirelessmouse (dual-filter)' }
+            $lfPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($m.InstanceId)"
+            $lf = (Get-ItemProperty -LiteralPath $lfPath -ErrorAction SilentlyContinue).LowerFilters
+            $lfList = @($lf)
+            if ($lfList -contains 'applewirelessmouse') { $fail += 'LowerFilters still lists applewirelessmouse' }
+            if ($lfList.Count -ne 1 -or $lfList[0] -ne 'MagicMouseDriver') { $fail += "LowerFilters=$($lfList -join ',')" }
+            if ($m.Status -notmatch 'Started|OK') { $fail += "0323 status=$($m.Status)" }
+        }
+    }
+
+    if ($fail.Count -gt 0) {
+        Write-KmdfResult -Status 'FAIL' -Detail ($fail -join '; ')
+        return $false
+    }
+    Write-KmdfResult -Status 'PASS' -Detail 'Service Running; 0323 stack HidBth/MagicMouseDriver; sole LowerFilters; HID started.'
+    return $true
+}
+
+try {
+    $os = Get-CimInstance -ClassName Win32_OperatingSystem
+    if ([int]$os.BuildNumber -lt 14393) {
+        throw "Windows build 14393 or later required (got $($os.BuildNumber))"
+    }
+
+    if (Test-KmdfHvci) {
+        Write-KmdfLog -Message "HVCI / Memory Integrity is ON. Windows 11 will refuse this self-signed .sys. Turn it off: Settings → Privacy & security → Windows Security → Device security → Core isolation → Memory integrity OFF, then reboot and click Install-KMDF.cmd again." -Level 'ERROR'
+        Write-KmdfResult -Status 'FAIL' -Detail 'HVCI / Memory Integrity is enabled. Disable it, reboot, run Install-KMDF.cmd again.'
+        exit 2
+    }
+
+    $needReboot = $false
+    if (Enable-KmdfTestSigning) { $needReboot = $true }
+
+    $sys = Invoke-KmdfBuildIfNeeded
+    if (Test-KmdfForbiddenSys -Path $sys) {
+        throw "Chosen .sys is the May 20 pointer-dead WDKTestCert. Build 2.0.3 from this tree instead."
+    }
+    $sha = Get-KmdfFileSha256 -Path $sys
+    Write-KmdfLog -Message "Installing $sys SHA256=$sha" -Level 'INFO'
+    if ($sha -eq $script:KmdfShaPointerOk) {
+        Write-KmdfLog -Message "This is the Apr 30 MagicMouseFix binary (pointer OK, scroll dead). Prefer a 2.0.3 build from this source for surface scroll. Installing only because no other .sys is available." -Level 'WARN'
+    }
+
+    $cert = Get-KmdfSigningCert
+    Install-KmdfTrust -Cert $cert
+    $stage = New-KmdfSignedPackage -SysPath $sys -Cert $cert
+    if (Install-KmdfPnputil -StageDir $stage) { $needReboot = $true }
+    Bind-Kmdf0323Only
+
+    $hidStarted = $true
+    foreach ($m in @(Get-Kmdf0323Device)) {
+        if ($m.Status -notmatch 'Started|OK') { $hidStarted = $false }
+    }
+    if (-not $hidStarted) {
+        Write-KmdfLog -Message "0323 HID not started — Bluetooth bounce" -Level 'WARN'
+        Invoke-KmdfBluetoothBounce
+        Bind-Kmdf0323Only
+    } else {
+        Write-KmdfLog -Message "0323 HID started — skipping Bluetooth bounce" -Level 'OK'
+    }
+
+    Save-KmdfState -State @{
+        NeedReboot   = $needReboot
+        InstalledUtc = (Get-Date).ToUniversalTime().ToString('o')
+        SysPath      = $sys
+    }
+
+    if ($needReboot) {
+        Write-KmdfResult -Status 'PENDING' -Detail 'Driver staged. Rebooting so test signing / PnP can load MagicMouseDriver. Post-boot task MM-Kmdf-PostBoot will verify.'
+        Write-KmdfLog -Message "Rebooting in 15 seconds." -Level 'WARN'
+        & shutdown.exe /r /t 15 /c "MagicMouseDriver KMDF: reboot to load test-signed driver"
+        exit 0
+    }
+
+    if (Test-KmdfInstallNow) {
+        Write-KmdfLog -Message "Install verified without reboot." -Level 'OK'
+        exit 0
+    }
+    Write-KmdfLog -Message "Immediate verify failed — scheduling reboot so the stack can rebuild." -Level 'WARN'
+    Write-KmdfResult -Status 'PENDING' -Detail 'Install finished; verify failed before reboot. Rebooting for MM-Kmdf-PostBoot.'
+    & shutdown.exe /r /t 15 /c "MagicMouseDriver KMDF: reboot to rebuild 0323 stack"
+    exit 0
+} catch {
+    Write-KmdfLog -Message "$_" -Level 'ERROR'
+    Write-KmdfResult -Status 'FAIL' -Detail "$_"
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/Invoke-KmdfPostBoot.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfPostBoot.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+Post-boot verify for MagicMouseDriver. Run by MM-Kmdf-PostBoot (SYSTEM, AtStartup).
+
+.DESCRIPTION
+Waits for the Bluetooth stack, re-applies sole LowerFilters on PID 0323,
+bounces Bluetooth once if the stack is wrong, then writes RESULT.txt.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+. (Join-Path $PSScriptRoot 'Kmdf-Common.ps1')
+
+Initialize-KmdfDataDir
+Write-KmdfLog -Message "=== Invoke-KmdfPostBoot ===" -Level 'HEAD' -LogPath $script:KmdfVerifyLog
+Write-KmdfLog -Message "Waiting 45s for BTHENUM / HidBth..." -Level 'INFO' -LogPath $script:KmdfVerifyLog
+Start-Sleep -Seconds 45
+
+try {
+    $mice = @(Get-Kmdf0323Device)
+    foreach ($m in $mice) {
+        Set-KmdfSoleLowerFilter -InstanceId $m.InstanceId | Out-Null
+    }
+
+    $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+    $stackOk = $false
+    foreach ($m in $mice) {
+        $stack = Get-KmdfDeviceStack -InstanceId $m.InstanceId
+        Write-KmdfLog -Message "stack=$stack status=$($m.Status)" -Level 'INFO' -LogPath $script:KmdfVerifyLog
+        if ($stack -match 'HidBth' -and $stack -match 'MagicMouseDriver' -and $stack -notmatch 'applewirelessmouse') {
+            $stackOk = $true
+        }
+    }
+
+    if (-not $stackOk -or -not $svc -or $svc.Status -ne 'Running') {
+        Write-KmdfLog -Message "Stack/service not ready — Bluetooth bounce + rebind" -Level 'WARN' -LogPath $script:KmdfVerifyLog
+        Invoke-KmdfBluetoothBounce
+        Start-Sleep -Seconds 8
+        $mice = @(Get-Kmdf0323Device)
+        foreach ($m in $mice) { Set-KmdfSoleLowerFilter -InstanceId $m.InstanceId | Out-Null }
+    }
+
+    $fail = @()
+    $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) { $fail += 'service missing' }
+    elseif ($svc.Status -ne 'Running') { $fail += "service $($svc.Status)" }
+
+    $mice = @(Get-Kmdf0323Device)
+    if ($mice.Count -eq 0) { $fail += 'no PID 0323 device' }
+    foreach ($m in $mice) {
+        $stack = Get-KmdfDeviceStack -InstanceId $m.InstanceId
+        Write-KmdfLog -Message "final stack[$($m.InstanceId)]=$stack" -Level 'INFO' -LogPath $script:KmdfVerifyLog
+        if ($stack -notmatch 'HidBth') { $fail += 'stack missing HidBth' }
+        if ($stack -notmatch 'MagicMouseDriver') { $fail += 'stack missing MagicMouseDriver' }
+        if ($stack -match 'applewirelessmouse') { $fail += 'dual-filter applewirelessmouse still present' }
+        $lf = @((Get-ItemProperty -LiteralPath "HKLM:\SYSTEM\CurrentControlSet\Enum\$($m.InstanceId)" -ErrorAction SilentlyContinue).LowerFilters)
+        if ($lf -contains 'applewirelessmouse') { $fail += 'LowerFilters still has applewirelessmouse' }
+        if ($lf.Count -ne 1 -or $lf[0] -ne 'MagicMouseDriver') { $fail += "LowerFilters=$($lf -join ',')" }
+        if ($m.Status -notmatch 'Started|OK') { $fail += "HID status=$($m.Status)" }
+    }
+
+    if ($fail.Count -gt 0) {
+        Write-KmdfResult -Status 'FAIL' -Detail ($fail -join '; ')
+        exit 1
+    }
+    Write-KmdfResult -Status 'PASS' -Detail 'Post-boot: service Running; 0323 HidBth/MagicMouseDriver; sole filter; HID started. Confirm pointer AND vertical/horizontal surface scroll.'
+    exit 0
+} catch {
+    Write-KmdfLog -Message "$_" -Level 'ERROR' -LogPath $script:KmdfVerifyLog
+    Write-KmdfResult -Status 'FAIL' -Detail "$_"
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/Kmdf-Common.ps1
+++ b/v2-kmdf-driver/scripts/Kmdf-Common.ps1
@@ -1,0 +1,249 @@
+# Shared helpers for the KMDF one-click path.
+# Dot-sourced by Invoke-KmdfInstall.ps1 / Invoke-KmdfPostBoot.ps1 / Install-KMDF.ps1.
+# Not meant to be run directly.
+
+$script:KmdfDataDir    = 'C:\ProgramData\MagicMouseDriver'
+$script:KmdfInstallDir = 'C:\Program Files\MagicMouseDriver'
+$script:KmdfLog        = Join-Path $script:KmdfDataDir 'install.log'
+$script:KmdfVerifyLog  = Join-Path $script:KmdfDataDir 'verify.log'
+$script:KmdfResult     = Join-Path $script:KmdfDataDir 'RESULT.txt'
+$script:KmdfState      = Join-Path $script:KmdfDataDir 'state.json'
+$script:KmdfTaskInstall  = 'MM-Kmdf-Install'
+$script:KmdfTaskPostBoot = 'MM-Kmdf-PostBoot'
+$script:KmdfCertSubject  = 'CN=MagicMouseFix'
+$script:KmdfCertThumb    = 'B902C2864315E2DE359450024768CE7D01715C38'
+# Apr 30 live binary: pointer OK, scroll dead. Keep as fallback, do not treat as final product.
+$script:KmdfShaPointerOk = 'AD5D244B176D650961594EDED153C46F9A52004C424DABFD86E50844E447546B'
+# May 20 2.0.2.0 WDKTestCert — HID started, pointer dead. Never install.
+$script:KmdfShaPointerDead = '559B136AEB869D1B85EE21583BB7BFD72782A31EE476A2622014D87CE6762F30'
+$script:KmdfPidPattern   = 'BTHENUM\\\{00001124.*PID&0323'
+$script:KmdfServiceName  = 'MagicMouseDriver'
+
+function Initialize-KmdfDataDir {
+    if (-not (Test-Path -LiteralPath $script:KmdfDataDir)) {
+        New-Item -ItemType Directory -Path $script:KmdfDataDir -Force | Out-Null
+    }
+}
+
+function Write-KmdfLog {
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [ValidateSet('INFO', 'OK', 'WARN', 'ERROR', 'HEAD')]
+        [string]$Level = 'INFO',
+        [string]$LogPath = $script:KmdfLog
+    )
+    Initialize-KmdfDataDir
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][$Level] $Message"
+    Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8
+    $color = switch ($Level) {
+        'ERROR' { 'Red' }
+        'WARN'  { 'Yellow' }
+        'OK'    { 'Green' }
+        'HEAD'  { 'Cyan' }
+        default { 'Gray' }
+    }
+    Write-Host $line -ForegroundColor $color
+}
+
+function Write-KmdfResult {
+    param(
+        [Parameter(Mandatory)][ValidateSet('PASS', 'FAIL', 'PENDING')][string]$Status,
+        [Parameter(Mandatory)][string]$Detail
+    )
+    Initialize-KmdfDataDir
+    $body = @(
+        "MagicMouseDriver KMDF (PID 0323)"
+        "Status : $Status"
+        "Time   : $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+        "Detail : $Detail"
+        "Log    : $script:KmdfLog"
+        "Verify : $script:KmdfVerifyLog"
+    ) -join [Environment]::NewLine
+    Set-Content -LiteralPath $script:KmdfResult -Value $body -Encoding UTF8
+    Write-KmdfLog -Message "RESULT=$Status $Detail" -Level $(if ($Status -eq 'FAIL') { 'ERROR' } elseif ($Status -eq 'PASS') { 'OK' } else { 'WARN' })
+}
+
+function Test-KmdfIsAdmin {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-Kmdf0323Device {
+    $out = & pnputil.exe /enum-devices 2>&1 | Out-String
+    $blocks = $out -split '(?=Instance ID:)'
+    $found = @()
+    foreach ($block in $blocks) {
+        if ($block -notmatch $script:KmdfPidPattern) { continue }
+        $id = $null
+        if ($block -match 'Instance ID:\s+(\S+)') { $id = $Matches[1].Trim() }
+        if (-not $id) { continue }
+        $status = 'Unknown'
+        if ($block -match 'Status:\s+(\S.+)') { $status = $Matches[1].Trim() }
+        $found += [pscustomobject]@{ InstanceId = $id; Status = $status; Raw = $block }
+    }
+    return $found
+}
+
+function Get-KmdfDeviceStack {
+    param([Parameter(Mandatory)][string]$InstanceId)
+    $dev = Get-PnpDevice -InstanceId $InstanceId -ErrorAction SilentlyContinue
+    if (-not $dev) { return $null }
+    try {
+        $prop = Get-PnpDeviceProperty -InstanceId $InstanceId -KeyName 'DEVPKEY_Device_Stack' -ErrorAction Stop
+        return [string]$prop.Data
+    } catch {
+        return $null
+    }
+}
+
+function Set-KmdfSoleLowerFilter {
+    param([Parameter(Mandatory)][string]$InstanceId)
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$InstanceId"
+    if (-not (Test-Path -LiteralPath $regPath)) {
+        Write-KmdfLog -Message "Enum key missing: $regPath" -Level 'ERROR'
+        return $false
+    }
+    $existing = $null
+    try { $existing = (Get-ItemProperty -LiteralPath $regPath -ErrorAction Stop).LowerFilters } catch { $existing = $null }
+
+    $wanted = @($script:KmdfServiceName)
+    $same = $false
+    if ($existing -is [string]) {
+        $same = ($existing -eq $script:KmdfServiceName)
+    } elseif ($existing) {
+        $arr = @($existing)
+        $same = ($arr.Count -eq 1 -and $arr[0] -eq $script:KmdfServiceName)
+    }
+
+    if ($same) {
+        Write-KmdfLog -Message "LowerFilters already sole MagicMouseDriver on $InstanceId" -Level 'OK'
+        return $true
+    }
+
+    if ($existing) {
+        Write-KmdfLog -Message "Replacing LowerFilters '$($existing -join ',')' with MagicMouseDriver only" -Level 'WARN'
+    }
+    Set-ItemProperty -LiteralPath $regPath -Name 'LowerFilters' -Value $wanted -Type MultiString
+    Write-KmdfLog -Message "LowerFilters=MagicMouseDriver (sole) on $InstanceId" -Level 'OK'
+    return $true
+}
+
+function Test-KmdfHvci {
+    $key = 'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity'
+    if (Test-Path -LiteralPath $key) {
+        $enabled = (Get-ItemProperty -LiteralPath $key -Name 'Enabled' -ErrorAction SilentlyContinue).Enabled
+        if ($enabled -eq 1) { return $true }
+    }
+    return $false
+}
+
+function Test-KmdfTestSigning {
+    $out = & bcdedit.exe /enum '{current}' 2>&1 | Out-String
+    return [bool]($out -match '(?im)^\s*testsigning\s+Yes\s*$')
+}
+
+function Enable-KmdfTestSigning {
+    if (Test-KmdfTestSigning) {
+        Write-KmdfLog -Message "Test signing already ON" -Level 'OK'
+        return $false
+    }
+    Write-KmdfLog -Message "Enabling test signing (bcdedit /set testsigning on). Desktop watermark is expected. Reboot required before the self-signed .sys will load." -Level 'WARN'
+    & bcdedit.exe /set testsigning on | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-KmdfLog -Message "bcdedit testsigning failed (exit $LASTEXITCODE)" -Level 'ERROR'
+        throw "bcdedit /set testsigning on failed"
+    }
+    return $true
+}
+
+function Find-KmdfSignTool {
+    $candidates = @(
+        'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+        'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe',
+        'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64\signtool.exe',
+        'C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe'
+    )
+    foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+        $candidates += (Join-Path $drv.RootDirectory.FullName 'Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe')
+    }
+    foreach ($c in $candidates) {
+        if (Test-Path -LiteralPath $c) { return $c }
+    }
+    $found = Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin' -Filter 'signtool.exe' -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -match '\\x64$' } |
+        Select-Object -First 1
+    if ($found) { return $found.FullName }
+    return $null
+}
+
+function Find-KmdfInf2Cat {
+    $found = Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin' -Filter 'inf2cat.exe' -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -match '\\x86$|\\x64$' } |
+        Select-Object -First 1
+    if ($found) { return $found.FullName }
+    return $null
+}
+
+function Find-KmdfMsBuild {
+    $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+    if (Test-Path -LiteralPath $vswhere) {
+        $msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find 'MSBuild\**\Bin\MSBuild.exe' 2>$null |
+            Select-Object -First 1
+        if ($msbuild -and (Test-Path -LiteralPath $msbuild)) { return $msbuild }
+    }
+    foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+        $setup = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+        if (Test-Path -LiteralPath $setup) { return "EWDK:$setup" }
+    }
+    return $null
+}
+
+function Invoke-KmdfBluetoothBounce {
+    Write-KmdfLog -Message "Bouncing Bluetooth (disable then enable). This is required for HidBth to rebuild the 0323 stack around MagicMouseDriver." -Level 'HEAD'
+
+    $adapters = @(Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object {
+            $_.InterfaceDescription -match 'Bluetooth' -or $_.Name -match 'Bluetooth'
+        })
+    foreach ($a in $adapters) {
+        Write-KmdfLog -Message "Disable-NetAdapter $($a.Name)" -Level 'INFO'
+        try {
+            Disable-NetAdapter -Name $a.Name -Confirm:$false -ErrorAction Stop
+        } catch {
+            Write-KmdfLog -Message "Disable-NetAdapter $($a.Name): $_" -Level 'WARN'
+        }
+    }
+    Start-Sleep -Seconds 4
+    foreach ($a in $adapters) {
+        Write-KmdfLog -Message "Enable-NetAdapter $($a.Name)" -Level 'INFO'
+        try {
+            Enable-NetAdapter -Name $a.Name -Confirm:$false -ErrorAction Stop
+        } catch {
+            Write-KmdfLog -Message "Enable-NetAdapter $($a.Name): $_" -Level 'WARN'
+        }
+    }
+    Start-Sleep -Seconds 5
+
+    $mice = @(Get-Kmdf0323Device)
+    foreach ($m in $mice) {
+        Write-KmdfLog -Message "pnputil /restart-device $($m.InstanceId)" -Level 'INFO'
+        & pnputil.exe /restart-device $m.InstanceId 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+    }
+    Start-Sleep -Seconds 3
+}
+
+function Save-KmdfState {
+    param([hashtable]$State)
+    Initialize-KmdfDataDir
+    ($State | ConvertTo-Json -Compress) | Set-Content -LiteralPath $script:KmdfState -Encoding UTF8
+}
+
+function Read-KmdfState {
+    if (-not (Test-Path -LiteralPath $script:KmdfState)) { return @{} }
+    try {
+        return Get-Content -LiteralPath $script:KmdfState -Raw | ConvertFrom-Json
+    } catch {
+        return @{}
+    }
+}

--- a/v2-kmdf-driver/scripts/Kmdf-Common.ps1
+++ b/v2-kmdf-driver/scripts/Kmdf-Common.ps1
@@ -18,6 +18,13 @@ $script:KmdfShaPointerOk = 'AD5D244B176D650961594EDED153C46F9A52004C424DABFD86E5
 $script:KmdfShaPointerDead = '559B136AEB869D1B85EE21583BB7BFD72782A31EE476A2622014D87CE6762F30'
 $script:KmdfPidPattern   = 'BTHENUM\\\{00001124.*PID&0323'
 $script:KmdfServiceName  = 'MagicMouseDriver'
+# Windows / INF / service name — do not change. Package artifacts use the labels below.
+$script:KmdfInstallSysName = 'MagicMouseDriver.sys'
+$script:KmdfArtifactScroll = 'MagicMouseDriver-kmdf-2.0.4-scroll.sys'
+$script:KmdfArtifactApr30  = 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys'
+$script:KmdfArtifactMay20  = 'MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys'
+$script:KmdfPathAShipBlocker = 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys'
+$script:KmdfBackupDir    = Join-Path $script:KmdfDataDir 'backup'
 
 function Initialize-KmdfDataDir {
     if (-not (Test-Path -LiteralPath $script:KmdfDataDir)) {

--- a/v2-kmdf-driver/tests/validate-package.sh
+++ b/v2-kmdf-driver/tests/validate-package.sh
@@ -66,5 +66,36 @@ grep -q 'MM-Kmdf-Install' "$ROOT/scripts/Kmdf-Common.ps1" && ok "task name MM-Km
 grep -qi 'magic-tray' "$ROOT/MAGIC-TRAY.md" && ok "magic-tray pull note" || bad "magic-tray pull note"
 grep -q '559B136A' "$ROOT/scripts/Kmdf-Common.ps1" && ok "May 20 pointer-dead SHA banned" || bad "May 20 pointer-dead SHA banned"
 grep -q 'CN=MagicMouseFix' "$ROOT/scripts/Kmdf-Common.ps1" && ok "signs as MagicMouseFix" || bad "signs as MagicMouseFix"
+if grep -q 'ServiceBinary = %12%\\MagicMouseDriver.sys' "$ROOT/MagicMouseDriver.inf" && \
+   grep -q 'MagicMouseDriver.sys = 1' "$ROOT/MagicMouseDriver.inf"; then
+  ok "INF still installs MagicMouseDriver.sys"
+else
+  bad "INF still installs MagicMouseDriver.sys"
+fi
+grep -q 'MagicMouseDriver-kmdf-2.0.4-scroll.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "scroll artifact name" || bad "scroll artifact name"
+grep -q 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "Apr 30 pointer artifact name" || bad "Apr 30 pointer artifact name"
+grep -q 'MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "May 20 pointer-dead artifact name" || bad "May 20 pointer-dead artifact name"
+grep -q 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "PATH-A ship-blocker name" || bad "PATH-A ship-blocker name"
+grep -q 'FILEVERSION    2,0,4,0' "$ROOT/MagicMouseDriver.rc" && ok "FileVersion 2.0.4.0 in VERSIONINFO" || bad "FileVersion 2.0.4.0 in VERSIONINFO"
+grep -q 'OriginalFilename", "MagicMouseDriver-kmdf-2.0.4-scroll.sys' "$ROOT/MagicMouseDriver.rc" && ok "OriginalFilename is scroll artifact" || bad "OriginalFilename is scroll artifact"
+if grep -q '<TargetName>MagicMouseDriver</TargetName>' "$ROOT/MagicMouseDriver.vcxproj"; then
+  ok "vcxproj TargetName still MagicMouseDriver"
+else
+  bad "vcxproj TargetName still MagicMouseDriver"
+fi
+REPO="$(cd "$ROOT/.." && pwd)"
+if grep -q 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys' "$REPO/README.md" && \
+   grep -q 'MagicMouseDriver-kmdf-2.0.4-scroll.sys' "$REPO/README.md" && \
+   grep -q 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys' "$REPO/README.md"; then
+  ok "root README names pointer-only vs scroll vs SHIP-BLOCKER"
+else
+  bad "root README names pointer-only vs scroll vs SHIP-BLOCKER"
+fi
+if grep -q 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys' "$REPO/v1-binary-patch/installer/Install-MagicMousePatch.ps1" && \
+   grep -q 'System32\\drivers\\applewirelessmouse.sys' "$REPO/v1-binary-patch/installer/Install-MagicMousePatch.ps1"; then
+  ok "PATH-A package name vs Windows install name"
+else
+  bad "PATH-A package name vs Windows install name"
+fi
 
 exit "$fail"

--- a/v2-kmdf-driver/tests/validate-package.sh
+++ b/v2-kmdf-driver/tests/validate-package.sh
@@ -45,8 +45,22 @@ else
 fi
 test -f "$ROOT/Driver.c" && ok "Driver.c present" || bad "Driver.c present"
 test -f "$ROOT/AclTranslate.c" && ok "AclTranslate.c present" || bad "AclTranslate.c present"
-grep -q 'out\[0\] = 0x02' "$ROOT/GestureEngine.c" && ok "GestureEngine emits RID 0x02" || bad "GestureEngine emits RID 0x02"
-grep -q 'ReadI16Le' "$ROOT/GestureEngine.c" && ok "optical X/Y copied" || bad "optical X/Y copied"
+grep -q '0x85, 0x12' "$ROOT/HidDescriptor.c" && ok "descriptor COL01 RID 0x12" || bad "descriptor COL01 RID 0x12"
+grep -q '0x85, 0x90' "$ROOT/HidDescriptor.c" && ok "descriptor COL02 RID 0x90" || bad "descriptor COL02 RID 0x90"
+grep -q '0x09, 0x38' "$ROOT/HidDescriptor.c" && ok "descriptor Wheel usage 0x38" || bad "descriptor Wheel usage 0x38"
+if grep -q '0x85, 0x47' "$ROOT/HidDescriptor.c"; then
+  bad "descriptor must not inject Feature 0x47"
+else
+  ok "descriptor has no Feature 0x47"
+fi
+if grep -q 'out\[0\] = 0x02' "$ROOT/GestureEngine.c"; then
+  bad "GestureEngine must not convert to RID 0x02"
+else
+  ok "GestureEngine does not emit RID 0x02"
+fi
+grep -q 'out\[0\] = MM_REPORT_ID_MOUSE' "$ROOT/GestureEngine.c" && ok "GestureEngine stays on RID 0x12" || bad "GestureEngine stays on RID 0x12"
+grep -q '#define MM_MOUSE_REPORT_LEN 8' "$ROOT/Driver.h" && ok "0x12 report is 8 bytes" || bad "0x12 report is 8 bytes"
+grep -q 'ReadI16Le' "$ROOT/GestureEngine.c" && ok "optical X/Y copied as INT16" || bad "optical X/Y copied as INT16"
 grep -q "UserId 'SYSTEM'" "$ROOT/Install-KMDF.ps1" && ok "SYSTEM principal" || bad "SYSTEM principal"
 grep -q 'MM-Kmdf-Install' "$ROOT/scripts/Kmdf-Common.ps1" && ok "task name MM-Kmdf-Install" || bad "task name MM-Kmdf-Install"
 grep -qi 'magic-tray' "$ROOT/MAGIC-TRAY.md" && ok "magic-tray pull note" || bad "magic-tray pull note"

--- a/v2-kmdf-driver/tests/validate-package.sh
+++ b/v2-kmdf-driver/tests/validate-package.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Linux-side package checks. Does not build a .sys.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+ok()  { echo "OK  $1"; }
+bad() { echo "FAIL $1"; fail=1; }
+
+echo "Validating $ROOT"
+
+if grep -q 'PID&0323' "$ROOT/MagicMouseDriver.inf"; then ok "0323 hardware ID in INF"; else bad "0323 hardware ID in INF"; fi
+if grep -qE 'PID&030[Dd]|PID&0269|PID&0310' "$ROOT/MagicMouseDriver.inf"; then
+  bad "INF hardware IDs must not include 030D/0269/0310"
+else
+  ok "INF hardware IDs are 0323-only"
+fi
+if grep -q 'LowerFilters",0x00010000,"MagicMouseDriver"' "$ROOT/MagicMouseDriver.inf"; then
+  ok "sole LowerFilters=MagicMouseDriver"
+else
+  bad "sole LowerFilters=MagicMouseDriver"
+fi
+if grep -q 'LowerFilters.*,"applewirelessmouse"' "$ROOT/MagicMouseDriver.inf"; then
+  bad "INF must not set applewirelessmouse as a filter"
+else
+  ok "INF does not set applewirelessmouse LowerFilters"
+fi
+test -f "$ROOT/Install-KMDF.cmd" && ok "one-click cmd exists" || bad "one-click cmd exists"
+test -f "$ROOT/scripts/Invoke-KmdfInstall.ps1" && ok "SYSTEM install runner exists" || bad "SYSTEM install runner exists"
+test -f "$ROOT/scripts/Invoke-KmdfPostBoot.ps1" && ok "post-boot runner exists" || bad "post-boot runner exists"
+if test -f "$ROOT/mm-dev.ps1" || test -f "$ROOT/scripts/mm-dev.ps1"; then
+  bad "mm-dev.ps1 must not ship"
+else
+  ok "no mm-dev.ps1"
+fi
+if grep -R -n --include='*.ps1' --include='*.cmd' 'Phase=Full' "$ROOT" >/dev/null; then
+  bad "Phase=Full leftover"
+else
+  ok "no Phase=Full leftover"
+fi
+if grep -R -n --include='*.ps1' "MagicMouseDriver', 'applewirelessmouse" "$ROOT" >/dev/null; then
+  bad "dual-filter array in scripts"
+else
+  ok "no dual-filter array in scripts"
+fi
+test -f "$ROOT/Driver.c" && ok "Driver.c present" || bad "Driver.c present"
+test -f "$ROOT/AclTranslate.c" && ok "AclTranslate.c present" || bad "AclTranslate.c present"
+grep -q 'out\[0\] = 0x02' "$ROOT/GestureEngine.c" && ok "GestureEngine emits RID 0x02" || bad "GestureEngine emits RID 0x02"
+grep -q 'ReadI16Le' "$ROOT/GestureEngine.c" && ok "optical X/Y copied" || bad "optical X/Y copied"
+grep -q "UserId 'SYSTEM'" "$ROOT/Install-KMDF.ps1" && ok "SYSTEM principal" || bad "SYSTEM principal"
+grep -q 'MM-Kmdf-Install' "$ROOT/scripts/Kmdf-Common.ps1" && ok "task name MM-Kmdf-Install" || bad "task name MM-Kmdf-Install"
+grep -qi 'magic-tray' "$ROOT/MAGIC-TRAY.md" && ok "magic-tray pull note" || bad "magic-tray pull note"
+grep -q '559B136A' "$ROOT/scripts/Kmdf-Common.ps1" && ok "May 20 pointer-dead SHA banned" || bad "May 20 pointer-dead SHA banned"
+grep -q 'CN=MagicMouseFix' "$ROOT/scripts/Kmdf-Common.ps1" && ok "signs as MagicMouseFix" || bad "signs as MagicMouseFix"
+
+exit "$fail"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Do not merge. Do not install on the live Apr 30 PC yet.

Linux cannot produce a `.sys`. Keep the live Apr 30 pointer-only KMDF on that machine. No May 20, no PATH-A, no dual-filter. Do not merge until hardware proves scroll.

## Artifact names (do not mix these up)

Windows install names are **unchanged**: KMDF still loads as `MagicMouseDriver.sys`; PATH-A still loads as `applewirelessmouse.sys`.

| Package / backup filename | FileVersion | Role |
|---------------------------|-------------|------|
| **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** | **not** 2.0.4.0 (live MagicMouseFix `AD5D244B`) | **Pointer-only.** Scroll dead. Leave on the Apr 30 PC. |
| **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`** | 2.0.2.0 | **Pointer-dead.** Installer already refuses this SHA. |
| **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** | **2.0.4.0** (`DriverVer` 2.0.4.0) | **Scroll candidate.** Hash after a Windows WDK build. INF still copies it as `MagicMouseDriver.sys`. |
| **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`** | PATH-A v1 | **SHIP-BLOCKER** (BSOD 0xD1). Stays in `v1-binary-patch/`. Never `MagicMouseDriver.sys`. Never the 0323 product. |

## Live HID 2026-08-30 21:23 MDT (authoritative)

Taken on Apr 30 MagicMouseFix KMDF (`AD5D244B`). Stack is already correct (`HidBth / MagicMouseDriver / BthEnum`). Filter flip is not the bug.

| Probe | Result |
|-------|--------|
| `HidD_GetInputReport(0x90)` on **COL02** | Works. `bytes=[90 04 2F …]` → **47%** (`buf[2]=0x2F`) |
| Feature **0x47** on COL01 / COL02 | **Fails** |
| COL01 Input **0x12** | **X/Y only**. No Wheel usage `0x0038` |
| All other InRpt / Feat | **Fail** |

Product battery is RID **0x90 Input**, not 0x47. Product scroll is Wheel / AC Pan on the **0x12** path HidBth delivers.

## What 2.0.4 changes vs 2.0.3

2.0.3 injected Descriptor C (RID **0x02** + Feat **0x47**) and converted `0x12 → 6-byte 0x02`. hidclass never bound that.

2.0.4 (`DriverVer 08/31/2026,2.0.4.0`, FileVersion **2.0.4.0** on the scroll artifact):

- SDP inject stays on **RID 0x12** and **adds** Wheel (GD `0x38`) + AC Pan (Consumer `0x0238`)
- COL02 is RID **0x90 Input** (percent at byte[2]). No Feature 0x47
- ACL / read rewrite stays on 8-byte `0x12`: `[12][buttons][X i16][Y i16][AC Pan][Wheel]`
- `0x90` is passed through
- Installer prefers the labeled 2.0.4-scroll artifact, refuses May 20 by name and SHA, refuses `applewirelessmouse*`, backs up the live KMDF under the Apr 30 / May 20 / scroll label

## One click (when a Windows WDK `.sys` exists — not now)

Double-click `v2-kmdf-driver/Install-KMDF.cmd`.

1. First run: one UAC to register SYSTEM tasks `MM-Kmdf-Install` and `MM-Kmdf-PostBoot`.
2. Later runs: `schtasks /run` only — no UAC.
3. SYSTEM task: reuse `CN=MagicMouseFix` if present, sign, `pnputil`, bind **0323 only**, BT bounce **only if HID did not start**.
4. Result: `C:\ProgramData\MagicMouseDriver\RESULT.txt`

No `mm-dev.ps1 -Phase Full`. No dual-filter. No 030D.

## Linux

This environment cannot produce a `.sys`. `tests/validate-package.sh` passes (0323-only, sole filter, live 0x12/0x90 HID, INF still `MagicMouseDriver.sys`, labeled artifacts, FileVersion 2.0.4.0). **Do not ask Floor to hand-replace the live Apr 30 `.sys`.**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3220343e-d57a-46db-96a9-178cef05cd9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3220343e-d57a-46db-96a9-178cef05cd9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

