### PR TITLE
Magic Tray 0323 entrypoint; PATH-A unsupported; Test Mode + HVCI off

### DIFF
--- a/.github/workflows/ps-lint.yml
+++ b/.github/workflows/ps-lint.yml
@@ -2,12 +2,12 @@ name: PowerShell Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ai/magic-mouse-initial-release ]
     paths:
       - '**.ps1'
       - '.github/workflows/ps-lint.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, ai/magic-mouse-initial-release ]
     paths:
       - '**.ps1'
       - '.github/workflows/ps-lint.yml'

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,12 @@ TestResults/
 Thumbs.db
 .DS_Store
 
-# Git-ignore driver binaries EXCEPT in release/
+# Git-ignore driver binaries EXCEPT the labeled PATH-A ship-blocker (if present).
+# KMDF still *installs* as MagicMouseDriver.sys; PATH-A still *installs* as
+# applewirelessmouse.sys. Package / backup names must stay distinct.
 *.sys
-!v1-binary-patch/applewirelessmouse.sys
-!v1-binary-patch/installer/applewirelessmouse.sys
+!v1-binary-patch/applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
+!v1-binary-patch/installer/applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
 
 # Certificates EXCEPT release/
 *.cer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-08-31
+
+### Changed
+
+- Artifact / backup / FileVersion labels so KMDF and PATH-A cannot be mixed up. Windows still installs KMDF as `MagicMouseDriver.sys` and PATH-A as `applewirelessmouse.sys`.
+  - Pointer-only: `MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys` (FileVersion not 2.0.4.0)
+  - Pointer-dead: `MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys` (FileVersion 2.0.2.0; installer refuses)
+  - Scroll candidate: `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion / DriverVer **2.0.4.0**)
+  - PATH-A ship-blocker: `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` (v1-binary-patch only)
+- Live HID 2026-08-30 21:23 MDT on Apr 30 MagicMouseFix (`AD5D244B`): **stay on the path HidBth delivers**
+  - COL01 Input **0x12** is X/Y only (no Wheel usage 0x0038) — that is why pointer moves and scroll does not
+  - COL02 `HidD_GetInputReport(0x90)` works: `bytes=[90 04 2F ...]` → 47% at `buf[2]`
+  - Feature **0x47 fails** on COL01 and COL02. Product battery is RID **0x90 Input**, not 0x47
+- SDP inject now adds Wheel (GD 0x38) and AC Pan (Consumer 0x0238) on **RID 0x12**, plus RID **0x90** battery Input
+- Gesture/ACL rewrite stays on 8-byte RID **0x12** (`[12][buttons][X i16][Y i16][AC Pan][Wheel]`). Does **not** convert to RID 0x02
+- Do not install this build on the live Apr 30 PC until a Windows WDK `.sys` exists. Do not merge until hardware proves scroll
+
+## [2.0.3] - 2026-08-31
+
+### Added
+
+- KMDF `MagicMouseDriver` source package in `v2-kmdf-driver/` (PID **0x0323 only**)
+- One-click `Install-KMDF.cmd`: first run registers SYSTEM tasks `MM-Kmdf-Install` and `MM-Kmdf-PostBoot`; later runs start the task with no UAC
+- Unattended SYSTEM path: test-signing, self-sign cert + catalog, `pnputil` install, sole `LowerFilters=MagicMouseDriver`, Bluetooth disable/enable bounce, reboot if required, post-boot verify
+- RID 0x12 / 0x27 → 6-byte RID 0x02 translation (optical X/Y + buttons + **vertical and horizontal surface scroll**) on ACL completions and IRP_MJ_READ — **superseded in 2.0.4** (live hidclass bound 0x12, not 0x02)
+- Installer refuses May 20 WDKTestCert SHA256 `559B136A…`; reuses `CN=MagicMouseFix` when present; Bluetooth bounce only if HID did not start
+- `MAGIC-TRAY.md`: tray PR #74 should pull this KMDF for 0323 and must not vendor it
+
+### Fixed
+
+- Live 2.0.2.0: HID started, pointer did not move — descriptor injection without matching X/Y reports
+
+### Removed / rejected
+
+- No `mm-dev.ps1 -Phase Full`
+- No dual-filter `MagicMouseDriver,applewirelessmouse`
+- No 030D / 0310 INF hardware IDs
+- v1 patched `applewirelessmouse.sys` marked ship-blocker (BSOD 0xD1)
+
 ## [1.0.0] - 2026-05-18
 
 ### Added

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -6,6 +6,30 @@
 
         # Internal helper functions (Stop-, Remove-, Set-) are not exported cmdlets
         # and do not need -WhatIf/-Confirm ShouldProcess support.
-        'PSUseShouldProcessForStateChangingFunctions'
+        'PSUseShouldProcessForStateChangingFunctions',
+
+        # This rule's naive English pluralisation misfires on the Windows nouns this
+        # repo is built around, and it offers no allow-list to spell the exceptions:
+        #   * 'Sys' is the .sys driver-file extension (Find-KmdfSys, Backup-KmdfLiveSys)
+        #   * 'Program Files' is a literal Windows directory name
+        #   * 'LowerFilters' is a literal registry value name
+        #   * 'Caps' is the HIDP_CAPS structure (Get-HidCaps)
+        # Renaming to satisfy it would make these helpers describe Windows less
+        # accurately, so the rule is off rather than the names being wrong.
+        'PSUseSingularNouns'
     )
+
+    Rules = @{
+        # Pin the built-in cmdlet inventory to Windows PowerShell 5.1, which is what
+        # actually runs these installers (they are launched by powershell.exe from
+        # .cmd wrappers and scheduled tasks). The analyser otherwise defaults to its
+        # 'core-6.1.0-windows' profile, whose PSDesiredStateConfiguration entry
+        # carries a stray private helper -- Write-Log, listed as CommandType Function
+        # at version 0.0 -- that is not a real PowerShell cmdlet and never shipped as
+        # one. Comparing against the 5.1 inventory drops that phantom while keeping
+        # the rule live for genuine shadowing of real cmdlets.
+        PSAvoidOverwritingBuiltInCmdlets = @{
+            PowerShellVersion = @('desktop-5.1.14393.206-windows')
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,259 +1,178 @@
 # Magic Mouse v3 Windows Scroll Fix
 
-**STATUS: Production Ready v1.0.0**
+**0323 product: KMDF `MagicMouseDriver`.** This is the driver [Magic Tray](https://github.com/LesleyMurfin/magic-mouse-tray) installs for the 2024 / USB-C Magic Mouse (Bluetooth PID `0x0323`). Free, MIT, no subscription.
 
-A Windows kernel driver patch that restores scroll functionality on Apple Magic Mouse v3 (2024) after Bluetooth reconnection.
+The **only** 0323 install entrypoint is:
 
-## What This Fixes
+```
+v2-kmdf-driver/Install-KMDF.cmd
+```
 
-Apple Magic Mouse v3 on Windows 10/11 loses scroll capability after Bluetooth idle disconnect followed by DeviceSetupManager property synchronization. This patch significantly reduces occurrence of that loss (and may prevent it) by protecting the HID collection structure during DSM initialization. v1.0 empirical results show a 3.1× improvement over the unpatched baseline; long-term (multi-day) prevention is not yet characterized. The v2 KMDF rewrite targets full prevention.
+Magic Tray clones this repository’s `main` branch and runs that path. You can run the same file by hand.
 
-**Affected hardware:**
-- Apple Magic Mouse v3 (2024), Bluetooth PID 0x0323
-- Windows 10 build 14393 or later / Windows 11 any build
+Do **not** install `v1-binary-patch` / `Install-MagicMousePatch.ps1` / a patched `applewirelessmouse.sys`. That PATH-A binary is unsupported for shipping (BSOD `0xD1`).
 
-> **Have a Magic Mouse v1 or v2?** This repo is v3-only. For v1/v2 scroll fix on Windows, see [`sbagirici/apple-magic-mouse-scroll-fix-windows`](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows) — the project this work builds on.
+## What this fixes
 
-**Symptoms before patch:**
-- Scroll wheel works immediately after pairing
-- After ~15–30 min idle + Bluetooth disconnect, scroll stops responding
-- Cursor movement continues normally
-- Issue does not self-recover; requires driver reinstall or device repair
+Apple Magic Mouse v3 on Windows 10/11 loses surface scroll after a Bluetooth idle disconnect and DeviceSetupManager property sync. Cursor still moves; scroll does not come back until you unpair/repair (or install this driver).
 
-## Supported Hardware
+This repo ships a from-scratch KMDF lower filter (`MagicMouseDriver`) that binds **PID 0x0323 only**, keeps `LowerFilters=MagicMouseDriver` as the **sole** filter, and presents a standard mouse (RID `0x12` with Wheel / AC Pan) plus battery Input RID `0x90` on COL02.
+
+## Supported hardware
 
 | Model | Year | Bluetooth PID | Supported? |
 |-------|------|---------------|------------|
-| Magic Mouse v1 | 2009 | `0x030D` | ❌ Not supported — see [sbagirici's repo](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows) |
-| Magic Mouse v2 | 2015 | `0x0269` | ❌ Not supported — see [sbagirici's repo](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows) |
-| Magic Mouse v3 | 2024 | `0x0323` | ✅ This repo |
+| Magic Mouse v1 | 2009 | `0x030D` | No — use [tealtadpole Boot Camp INF](https://github.com/tealtadpole/MagicMouse2DriversWin11x64) / Magic Tray v1 path |
+| Magic Mouse v2 | 2015 | `0x0269` / `0x0310` | No — same v1/v2 INF path |
+| Magic Mouse v3 (USB-C) | 2024 | `0x0323` | **Yes — this repo** |
 
-**Verify your PID:** Device Manager → Human Interface Devices → Apple Magic Mouse → Properties → Details → Hardware Ids. Look for `PID&030D`, `PID&0269`, or `PID&0323`.
+**Verify your PID:** Device Manager → Human Interface Devices → Apple Magic Mouse → Properties → Details → Hardware Ids. You want `PID&0323`.
 
-## System Requirements
+## System requirements
 
-- Windows 10 build 14393 or later, or Windows 11 any version
-- Apple Magic Mouse v3 (PID `0x0323`) paired over Bluetooth
-- Administrator account for installation
+- Windows 10 build 14393 or later, or Windows 11
+- Magic Mouse v3 (PID `0x0323`) paired over Bluetooth
+- Administrator (first run only — one UAC prompt)
 - Reboot access
+- **Test Mode** (`bcdedit /set testsigning on`) — there is no Microsoft-signed `.sys` in this repo yet. A “Test Mode” watermark is expected.
+- **Memory integrity / HVCI off** — Windows 11 Core isolation blocks self-signed kernel drivers. Settings → Privacy & security → Windows Security → Device security → Core isolation → Memory integrity **Off**, then reboot.
 
-## Quick Install (3 Steps)
+This installer does **not** turn Driver Signature Enforcement fully off.
 
-### Step 1: Download & Verify
+## Install (Magic Tray or one click)
 
-```powershell
-# Download v1.0.0 release
-# Extract to C:\Program Files\MagicMousePatch\
+### From Magic Tray
 
-# Verify binary integrity (mandatory)
-$sys = "C:\Program Files\MagicMousePatch\v1-binary-patch\applewirelessmouse.sys"
-(Get-FileHash $sys -Algorithm SHA256).Hash
-# Expected: 370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
-```
+1. Pair the USB-C Magic Mouse.
+2. In Magic Tray choose **Best for this mouse** / **MagicMouseDriver (KMDF)**.
+3. Accept the Administrator prompt.
+4. Read `C:\ProgramData\MagicMouseDriver\RESULT.txt` after the task finishes (`PASS` or `FAIL`). The PC may reboot if Test Mode was just enabled.
 
-### Step 2: Run Installer
+### Manual (same entrypoint)
 
-```powershell
-# Open PowerShell as Administrator
-cd "C:\Program Files\MagicMousePatch\v1-binary-patch\installer"
-.\Install-MagicMousePatch.ps1
+1. Clone this repository **on Windows**.
+2. Double-click `v2-kmdf-driver\Install-KMDF.cmd`.
+3. Accept Administrator **once**. That registers two SYSTEM tasks (`MM-Kmdf-Install`, `MM-Kmdf-PostBoot`). Later clicks start the task with no UAC.
+4. The SYSTEM task then, unattended:
+   - Builds `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion **2.0.4.0**) if a WDK/EWDK is present, and stages it as `MagicMouseDriver.sys` for the INF
+   - Turns on test signing if needed
+   - Self-signs `.sys` + `.cat` (`CN=MagicMouseFix`) and trusts the publisher
+   - `pnputil` installs the package
+   - Binds **PID 0323 only**, `LowerFilters=MagicMouseDriver` **sole** (never `applewirelessmouse`, never 030D)
+   - Bounces Bluetooth if HID did not start
+   - Reboots if test signing just changed
+   - After boot, verifies service Running and stack `HidBth` → `MagicMouseDriver`
+5. Result file: `C:\ProgramData\MagicMouseDriver\RESULT.txt`  
+   Log: `C:\ProgramData\MagicMouseDriver\install.log`
 
-# Accept certificate trust prompt when prompted
-```
+Details: [`v2-kmdf-driver/README.md`](v2-kmdf-driver/README.md). Uninstall: double-click `v2-kmdf-driver\Uninstall-KMDF.cmd`.
 
-### Step 3: Reboot
-
-```powershell
-# Follow on-screen instructions, or manually:
-shutdown /r /t 60 /c "MagicMousePatch installer - rebooting"
-```
-
-## What Changes on Your System
+## What changes on your system
 
 | Item | Change |
 |------|--------|
-| Certificate | MagicMouseFix cert imported to LocalMachine\TrustedPublisher and Root store |
-| Driver file | C:\Windows\System32\drivers\applewirelessmouse.sys (66 KB) |
-| Service | applewirelessmouse service created, demand-start (Type 1, Start 3) |
-| Registry | HKLM\SYSTEM\CurrentControlSet\Enum\BTHENUM\...\Device Parameters\LowerFilters |
-| Backup | Original driver backed up to C:\ProgramData\MagicMousePatch\backup\ |
+| Certificate | `CN=MagicMouseFix` in LocalMachine TrustedPublisher and Root |
+| Driver file | `C:\Windows\System32\drivers\MagicMouseDriver.sys` |
+| Service | `MagicMouseDriver` (kernel, demand-start) |
+| Filter | `LowerFilters=MagicMouseDriver` on the 0323 BTHENUM node only |
+| Tasks | `MM-Kmdf-Install`, `MM-Kmdf-PostBoot` (SYSTEM) |
+| Test Mode | `bcdedit /set testsigning on` if it was off |
 
-The patch acts as a WDM lower filter on the Bluetooth HID stack, intercepting device initialization before HID collection structures can collapse.
-
-## Verify It Worked
+## Verify
 
 After reboot:
 
 ```powershell
-# Check driver is loaded
-Get-PnpDevice -Class Mouse | Where-Object {$_.Name -match "Apple"}
+sc query MagicMouseDriver
+# STATE should be 4 RUNNING
 
-# Check service is running
-sc query applewirelessmouse
-# Should show STATE        : 4 RUNNING
+Get-PnpDevice -Class Mouse | Where-Object { $_.InstanceId -match 'PID_0323|PID&0323' }
 
-# Event log confirmation (optional)
-Get-WinEvent -LogName "Microsoft-Windows-Kernel-PnP/Configuration" -MaxEvents 20 `
-  | Where-Object {$_.Message -match "applewirelessmouse"}
+Get-Content C:\ProgramData\MagicMouseDriver\RESULT.txt
 ```
 
-Test scroll functionality:
-1. Open any application with scrollable content
-2. Move mouse over content and scroll
-3. Disconnect Magic Mouse (turn off), wait 2 minutes, turn back on
-4. Verify scroll still works
+Then:
 
-## Uninstall
+1. Scroll in any window.
+2. Turn the mouse off, wait two minutes, turn it back on.
+3. Confirm scroll still works.
 
-```powershell
-# Open PowerShell as Administrator
-cd "C:\Program Files\MagicMousePatch\v1-binary-patch\installer"
-.\Uninstall-MagicMousePatch.ps1
+Battery for this mouse is HID Input report **0x90 on COL02** (`percent = buf[2]`). Feature 0x47 is not used.
 
-# Follow prompts; reboot when complete
-```
+## Package names (do not mix these up)
 
-Uninstall restores the original driver and removes all Windows registry entries and certificates.
+Windows still loads KMDF as **`MagicMouseDriver.sys`**. Backup / artifact labels are different so they cannot be confused with PATH-A:
 
-## How It Works
+| Package / backup filename | FileVersion | Role |
+|---------------------------|-------------|------|
+| **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** | **2.0.4.0** | **This product.** INF dest `MagicMouseDriver.sys`. |
+| **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** | not 2.0.4.0 | Pointer-only baseline. Scroll dead. Not the shipping candidate. |
+| **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`** | 2.0.2.0 | Pointer-dead. Installer refuses this SHA. |
+| **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`** | PATH-A v1 | **Unsupported.** Lives in `v1-binary-patch/`. Never `MagicMouseDriver.sys`. Never install for 0323. |
 
-### The Problem: Mode A → Mode B Collapse
+There is **no prebuilt `.sys` on GitHub**. Linux cannot compile a kernel driver. On Windows with the WDK, `Install-KMDF.cmd` builds FileVersion 2.0.4.0.
 
-After ~15–30 min idle, Windows DeviceSetupManager writes 35 property descriptors to the
-Magic Mouse device container. BTHPORT rewrites its internal service cache, collapsing the
-dual HID collection structure:
+## PATH-A / v1 binary patch — unsupported
+
+`v1-binary-patch/` is historical. It is **not** the 0323 product.
+
+- Do not run `Install-MagicMousePatch.ps1`.
+- Do not copy a patched `applewirelessmouse.sys` over the KMDF service.
+- Do not dual-filter `MagicMouseDriver` + `applewirelessmouse` (BSOD `0xD1`).
+
+If you previously installed PATH-A, uninstall it (or use `Uninstall-KMDF.cmd` after switching) before installing KMDF.
+
+## How it works
+
+After ~15–30 min idle, DeviceSetupManager can collapse the v3 HID collection:
 
 ```
 MODE A (working)                      MODE B (broken — after DSM trigger)
 ────────────────────────────────      ────────────────────────────────────
   Magic Mouse v3 (BT paired)            Magic Mouse v3 (BT paired)
-    |                                     |
-    +-- COL01  <-- scroll + cursor        +-- TLC (unified)  <-- scroll LOST
-    |   (HID\VID_004C&PID_0323&COL01)         cursor still works
     |
-    +-- COL02  <-- battery / diag
-        (HID\VID_004C&PID_0323&COL02)
-
-  DynamicCachedServices:                DynamicCachedServices:
-    Entry 0: COL01  0x00110000            Entry 0: TLC    0x00110000
-    Entry 1: COL02  0x00020000            Entry 1: empty  0x00000000
-                                          (COL02 gone)
+    +-- COL01  <-- pointer + scroll     +-- TLC (unified)  <-- scroll LOST
+    |
+    +-- COL02  <-- battery / diag           cursor still works
 ```
 
-Mode B is **permanent** — device reconnect, sleep/wake, and restart do not recover it.
-Only fix without this patch: unpair and repair the device.
-
-### The Fix: WDM Lower Filter Driver
-
-`applewirelessmouse.sys` is inserted as a lower filter in the Bluetooth HID stack,
-intercepting initialization before the collapse can take hold:
+Mode B does not self-heal. The KMDF filter sits under HidBth on the 0323 node only:
 
 ```
-  Application (scroll events)
+  hidclass.sys
        |
-  Windows Input Manager
+  HidBth.sys
        |
-  hidclass.sys          (HID Class Driver)
+  MagicMouseDriver.sys   <-- KMDF lower filter (this product)
        |
-  HidBth.sys            (Bluetooth HID miniport)
-       |
-  applewirelessmouse.sys  <-- LOWER FILTER (this patch)
-       |                     intercepts DSM descriptor rewrite
-  BTHENUM PDO           (Magic Mouse device node)
-       |
-  BTHPORT.SYS           (Bluetooth port driver)
-       |
-  Magic Mouse v3 hardware
+  BTHENUM PDO (PID 0323)
 ```
 
-Registered via:
-```
-HKLM\SYSTEM\CurrentControlSet\Enum\BTHENUM\
-  {00001124-...}_VID&0001004C_PID&0323\...\
-    LowerFilters  REG_MULTI_SZ  "applewirelessmouse"
-```
+Live HID contract: COL01 Input **0x12** (X/Y + Wheel/AC Pan on the shipping build), COL02 Input **0x90** battery. Not Feature 0x47. Not RID 0x02.
 
-**Test evidence:**
-- Test 1 (power off/on): scroll persists — PASS
-- Test 2 (idle + DSM replay): held Mode A for 69 min vs historical 22 min before flip — PASS
-- Test 3 (pnputil rescan): scroll stable — PASS
-- Test 4 (sleep/wake): cache byte-identical, scroll works — PASS
-- Test 6 (UsoClient force-DSM): scroll preserved — PASS
-- Phase 5 (cold reboot): DSM ran twice post-boot, scroll still working — PASS
+## Magic Mouse v1 / v2
 
-## Roadmap
-
-**v1.0.0 (current):** Binary patch of Apple firmware via WDM lower filter.
-- Patched applewirelessmouse.sys (66 KB)
-- PowerShell installer + uninstaller
-- Registry-based LowerFilters registration
-- Requires certificate trust
-
-**v2.0.0 (in progress):** KMDF filter driver rewrite.
-- From-scratch WDF source code
-- No Apple binary dependency
-- Cleaner driver signing process
-- Better Windows Defender SmartScreen integration
-- Windows 11 22H2+ target
-
-See `/v2-kmdf-driver/README.md` for v2 status.
+This repository is **v3 / 0323 only**. For 2009/2015 mice, Magic Tray installs the tealtadpole Boot Camp INF. See also [`sbagirici/apple-magic-mouse-scroll-fix-windows`](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows).
 
 ## Contributing
 
-### Reporting Issues
+Issues: [GitHub Issues](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix/issues).
 
-File issues at [GitHub Issues](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix/issues).
-
-**Required information:**
-- Windows version and build (run `winver`)
-- Magic Mouse hardware version and PID (Device Manager → Human Interface Devices → Apple Magic Mouse → Details → Hardware Ids)
-- Steps to reproduce
-- Output from Event Viewer:
-  - Microsoft-Windows-Kernel-PnP/Configuration (last 50 events)
-  - Microsoft-Windows-DeviceSetupManager/Admin (last 50 events)
-
-Export logs:
+Include `winver`, Hardware Ids (PID), `C:\ProgramData\MagicMouseDriver\install.log`, and:
 
 ```powershell
 wevtutil epl "Microsoft-Windows-Kernel-PnP/Configuration" C:\pnp-config.evtx
 wevtutil epl "Microsoft-Windows-DeviceSetupManager/Admin" C:\dsm-admin.evtx
-# Attach .evtx files to issue
 ```
 
-### Testing Patches
-
-1. Clone this repository
-2. Install the patched version per Quick Install
-3. Run idle + reconnect test (69+ min)
-4. Document results in a test comment with exact Windows version and hardware revision
-
-### Pull Requests
-
-- All commits to feature branches
-- PR must include test evidence from your hardware
-- Link to related issue
-- All .ps1 scripts must pass PSScriptAnalyzer (via GitHub Actions)
-
-## Attribution
-
-Big thanks to [`sbagirici`](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows) for the original patched `applewirelessmouse.sys` binary and the LowerFilter installation approach that this project builds on. Without that starting point, the v3 investigation would have taken significantly longer.
-
-**v1 / v2 users:** sbagirici's repo is the right place for you — go give it a star.
-
-Our additions on top of that baseline (v3-specific):
-- Full root cause analysis of the H-011 / DSM trigger bug (COL01/COL02 Mode A/B collapse mechanism)
-- Test battery (Tests 1–6 + Phase 5) quantifying a 3.1× improvement factor
-- Rewritten PowerShell installer/uninstaller with correct LowerFilters path, REG_MULTI_SZ type, and two-level BTHENUM enumeration
-- SHA256 verification, DMCA notice, HID descriptor research, and release packaging
+PowerShell scripts must pass PSScriptAnalyzer (GitHub Actions).
 
 ## License
 
-MIT License — Copyright 2026 Revive Business Solutions.
-
-See `LICENSE` file for full text.
+MIT License — Copyright 2026 Revive Business Solutions. See `LICENSE`.
 
 ## Support
 
-Questions? Contact: riley@revivebusiness.ca
+Questions: riley@revivebusiness.ca
 
-For security issues, see `SECURITY.md`.
+Security: `SECURITY.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ If you discover a security vulnerability in this driver patch, please report it 
 This security policy covers only this driver patch repository and its distributed binaries/scripts.
 
 **In scope:**
-- applewirelessmouse.sys kernel driver
+- PATH-A `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` (installs as `applewirelessmouse.sys`) and KMDF `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (installs as `MagicMouseDriver.sys`)
 - PowerShell installer and uninstaller scripts
 - Registry modifications made by installer/uninstaller
 - Certificate installation process
@@ -52,7 +52,7 @@ This security policy covers only this driver patch repository and its distribute
 
 1. **Verify binary integrity:** Always run the SHA256 hash check before installation
    ```powershell
-   (Get-FileHash "applewirelessmouse.sys" -Algorithm SHA256).Hash
+   (Get-FileHash "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys" -Algorithm SHA256).Hash
    # Expected: 370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
    ```
 

--- a/v1-binary-patch/README.md
+++ b/v1-binary-patch/README.md
@@ -1,270 +1,32 @@
-# v1.0.0 — Binary Patch Installer
+# v1.0.0 — Binary patch (unsupported)
 
-**STATUS: Production Ready**
+**SHIP-BLOCKER for PID 0323.** Do not install this tree.
 
-This directory contains the PATH-A binary patch approach: a pre-built, patched applewirelessmouse.sys kernel driver and PowerShell installer/uninstaller.
+The package file is **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`**. It has caused BSOD `0xD1` (`DRIVER_IRQL_NOT_LESS_OR_EQUAL`). It is **not** the 0323 product. Never name it `MagicMouseDriver.sys`. Windows would still copy it to `applewirelessmouse.sys` if someone ran the historical installer.
 
-## Quick Start
+**0323 install entrypoint:** [`../v2-kmdf-driver/Install-KMDF.cmd`](../v2-kmdf-driver/Install-KMDF.cmd)
 
-### 1. Verify Your Hardware
+That KMDF package is `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion 2.0.4.0; INF dest `MagicMouseDriver.sys`; sole `LowerFilters=MagicMouseDriver`; PID 0323 only). Do not dual-filter PATH-A with MagicMouseDriver.
 
-Open Device Manager and locate your Magic Mouse:
+This folder is kept as history (bug analysis, architecture notes, SHA256 of the old payload). There is no supported install path here. Do not run `installer/Install-MagicMousePatch.ps1`.
 
-1. **Windows Key + X** → Device Manager
-2. Expand **Human Interface Devices**
-3. Find **Apple Magic Mouse**
-4. Right-click → **Properties**
-5. Go to **Details** tab
-6. In the dropdown, select **Hardware Ids**
-7. You should see something like:
-   ```
-   BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004C_PID&0323\6&11223344_0
-   ```
-   **Look for `PID&0323`** — if you don't see this, you don't have Magic Mouse v3 (2024), and this patch won't help.
+## Historical payload (do not load)
 
-### 2. Download & Verify
-
-1. Extract this repository to your preferred location (e.g., `C:\Program Files\MagicMousePatch\`)
-
-2. **Verify the driver binary integrity:**
-   ```powershell
-   # Open PowerShell (Windows Key + X → PowerShell)
-   # Navigate to this directory
-   cd "C:\Program Files\MagicMousePatch\v1-binary-patch"
-   
-   # Check the SHA256 hash
-   (Get-FileHash "applewirelessmouse.sys" -Algorithm SHA256).Hash
-   ```
-   
-   **Expected output:**
-   ```
-   370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
-   ```
-   
-   **If the hash does not match, stop. Do not install.** Your download may be corrupted.
-
-3. **Verify certificate thumbprint** (optional but recommended):
-   ```powershell
-   $cert = Get-AuthenticodeSignature "applewirelessmouse.sys"
-   $cert.SignerCertificate.Thumbprint
-   ```
-   
-   **Expected output:**
-   ```
-   16940C0F937D569363560D5FEC5CD8FA6D6D9BCE
-   ```
-
-### 3. Run Installer
-
-1. **Open PowerShell as Administrator:**
-   - Windows Key + X
-   - Select **Windows PowerShell (Admin)** or **Windows Terminal (Admin)**
-   - If prompted by User Account Control, click **Yes**
-
-2. **Navigate to installer directory:**
-   ```powershell
-   cd "C:\Program Files\MagicMousePatch\v1-binary-patch\installer"
-   ```
-
-3. **Run the installer:**
-   ```powershell
-   .\Install-MagicMousePatch.ps1
-   ```
-
-4. **Wait for prompts:**
-   - **Certificate Trust Prompt:** Click **Yes** when Windows Security asks "Do you want to install this device software?"
-   - **Administrator Confirmation:** Click **Yes** if prompted
-   - **Reboot Instruction:** The script will tell you when to reboot
-
-### 4. Reboot
-
-When the installer finishes, reboot your computer:
-
-```powershell
-shutdown /r /t 60 /c "Magic Mouse Patch installing - system will reboot in 60 seconds"
-```
-
-Or manually:
-- Windows Key + Power button
-- Click **Restart**
-
-**Important:** Do NOT skip the reboot. The driver will not load until after a reboot.
-
-## Verify Installation
-
-After rebooting, verify the patch installed correctly:
-
-### Check 1: Service Status
-
-```powershell
-# Open PowerShell (no admin required for this check)
-sc query applewirelessmouse
-```
-
-Expected output:
-```
-SERVICE_NAME: applewirelessmouse
-        TYPE               : 1  KERNEL_DRIVER
-        STATE              : 4  RUNNING
-        WIN32_EXIT_CODE    : 0  (0x0)
-        SERVICE_EXIT_CODE  : 0  (0x0)
-        CHECKPOINT         : 0x0
-        WAIT_HINT          : 0x0
-```
-
-If STATE shows `4 RUNNING`, the driver is loaded — good!
-
-### Check 2: Device Manager
-
-1. Windows Key + X → Device Manager
-2. Expand **Human Interface Devices**
-3. Find **Apple Magic Mouse**
-4. Should show no warning icons (yellow triangle = problem)
-
-### Check 3: Scroll Test
-
-1. Open any application with scrollable content (web browser, text editor, etc.)
-2. Position your cursor over the scrollable area
-3. Scroll using the Magic Mouse wheel — should respond smoothly
-4. Try scrolling in both directions
-
-### Check 4: Event Log (Optional)
-
-To see if the driver loaded correctly:
-
-```powershell
-# View recent kernel PnP events
-Get-WinEvent -LogName "Microsoft-Windows-Kernel-PnP/Configuration" -MaxEvents 20 | Format-List TimeCreated, Message | head -20
-```
-
-Look for entries mentioning "applewirelessmouse" or the device ID.
-
-## Uninstall
-
-If you need to remove the patch:
-
-1. **Open PowerShell as Administrator**
-
-2. **Navigate to installer directory:**
-   ```powershell
-   cd "C:\Program Files\MagicMousePatch\v1-binary-patch\installer"
-   ```
-
-3. **Run uninstaller:**
-   ```powershell
-   .\Uninstall-MagicMousePatch.ps1
-   ```
-
-4. **Reboot when prompted**
-
-The uninstaller will:
-- Remove the applewirelessmouse service
-- Delete the patched driver from System32\drivers\
-- Restore the original driver from backup (if it exists)
-- Remove the MagicMouseFix certificate from certificate stores
-- Remove registry entries
-- Clean up C:\ProgramData\MagicMousePatch\
-
-After reboot, your system will be back to its original state before the patch was installed.
-
-## Troubleshooting
-
-### Issue: Certificate Trust Prompt Never Appears
-
-**Cause:** Your system may have a policy preventing certificate installation.
-
-**Fix:**
-```powershell
-# Try installing certificate manually
-$cert = Get-AuthenticodeSignature "applewirelessmouse.sys"
-# If this shows no signer, the binary is corrupted
-
-# Try importing certificate directly
-$cer = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2("MagicMouseFix.cer")
-$store = New-Object System.Security.Cryptography.X509Certificates.X509Store("TrustedPublisher", "LocalMachine")
-$store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
-$store.Add($cer)
-$store.Close()
-```
-
-Then run the installer again.
-
-### Issue: "Access Denied" When Running Installer
-
-**Cause:** PowerShell execution policy blocks scripts.
-
-**Fix:**
-```powershell
-# Check current policy
-Get-ExecutionPolicy
-
-# Temporarily allow script execution for this session
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
-
-# Then run installer
-.\Install-MagicMousePatch.ps1
-```
-
-### Issue: Scroll Still Doesn't Work After Installation
-
-**Symptoms:**
-- Installer completed successfully
-- Service is running (`sc query applewirelessmouse` shows STATE: 4)
-- Device Manager shows no warnings
-- But scroll still doesn't work
-
-**Diagnostic steps:**
-1. Turn off Magic Mouse, wait 30 seconds, turn back on
-2. Wait 10 seconds for reconnection
-3. Try scroll again
-4. If still broken, collect event logs:
-   ```powershell
-   wevtutil epl "Microsoft-Windows-Kernel-PnP/Configuration" C:\pnp-config.evtx
-   wevtutil epl "Microsoft-Windows-DeviceSetupManager/Admin" C:\dsm-admin.evtx
-   ```
-   And open a GitHub issue with these logs attached.
-
-### Issue: System Crashes or Instability After Installation
-
-**This should not happen.** If it does:
-
-1. Boot into Safe Mode (Shift + Restart during boot)
-2. Open PowerShell as Administrator
-3. Run uninstaller:
-   ```powershell
-   cd "C:\Program Files\MagicMousePatch\v1-binary-patch\installer"
-   .\Uninstall-MagicMousePatch.ps1
-   ```
-4. Reboot normally
-5. Open a GitHub issue with:
-   - Exact error or crash message
-   - Windows version and build (winver)
-   - System event log (wevtutil epl "System" C:\system.evtx)
-
-## File Manifest
+If you need to identify a leftover PATH-A binary on disk:
 
 ```
-v1-binary-patch/
-├── README.md (this file)
-├── applewirelessmouse.sys (patched driver binary, 66 KB)
-├── MagicMouseFix.cer (code-signing certificate)
-├── installer/
-│   ├── Install-MagicMousePatch.ps1 (main installer)
-│   ├── Uninstall-MagicMousePatch.ps1 (uninstaller)
-│   └── applewirelessmouse.sys (copy for installer reference)
-├── docs/
-│   ├── bug-analysis.md (detailed problem explanation)
-│   └── architecture.md (how the filter driver works)
+SHA256  370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
+Windows dest   C:\Windows\System32\drivers\applewirelessmouse.sys
+Package name   applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
 ```
 
-## For v2 Users (Future)
+Uninstall leftovers with `installer/Uninstall-MagicMousePatch.ps1` (Administrator), then install KMDF.
 
-v2.0.0 will be a from-scratch KMDF driver rewrite. Until then, v1.0.0 (this binary patch) is the current production release.
+## Docs (research only)
 
-See `/v2-kmdf-driver/README.md` for v2 status and roadmap.
+- `docs/bug-analysis.md` — Mode A / Mode B DSM collapse
+- `docs/architecture.md` — WDM lower-filter notes
 
 ## Support
 
-- **Questions:** riley@revivebusiness.ca
-- **Bug reports:** GitHub Issues (include event logs)
-- **Security issues:** See SECURITY.md
+Use [`../v2-kmdf-driver/README.md`](../v2-kmdf-driver/README.md) and the root README. Security: `../SECURITY.md`.

--- a/v1-binary-patch/installer/Install-MagicMousePatch.ps1
+++ b/v1-binary-patch/installer/Install-MagicMousePatch.ps1
@@ -5,8 +5,10 @@
 Installs the Magic Mouse v3 scroll fix (PATH-A binary patch) on Windows.
 
 .DESCRIPTION
-Installs a lower-filter kernel driver (applewirelessmouse.sys) that restores scroll
-functionality on Apple Magic Mouse v3 (PID 0x0323) when paired over Bluetooth.
+Installs a lower-filter kernel driver. Package file is
+applewirelessmouse-patched-pathA-SHIPBLOCKER.sys. Windows still loads
+applewirelessmouse.sys. This is a SHIP-BLOCKER (BSOD 0xD1), not the 0323
+KMDF product, and must never be named MagicMouseDriver.sys.
 
 Logic is extracted from the production-tested install route
 (PATHA-V5-DIRECTCOPY-INSTALL) and adapted for a pre-signed public binary.
@@ -16,7 +18,7 @@ Workflow:
   2. HiberbootEnabled (Fast Startup) must be 0
   3. Test Signing mode must be ON (self-signed kernel driver)
   4. HVCI / Memory Integrity warning (Win11 22H2+ blocks self-signed drivers)
-  5. SHA256 + size verify of shipped applewirelessmouse.sys
+  5. SHA256 + size verify of applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
   6. Import MagicMouseFix.cer to LocalMachine\TrustedPublisher (NOT Root)
   7. Backup existing driver to C:\ProgramData\MagicMousePatch\backup\
   8. Detect v3 device via BTHENUM PID&0323
@@ -48,9 +50,17 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 }
 
 $ScriptRoot   = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$DriverSrc    = Join-Path $ScriptRoot "applewirelessmouse.sys"
+$PackageName  = "applewirelessmouse-patched-pathA-SHIPBLOCKER.sys"
+$DriverSrc    = @(
+    (Join-Path (Split-Path -Parent $ScriptRoot) $PackageName),
+    (Join-Path $ScriptRoot $PackageName)
+) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+if (-not $DriverSrc) {
+    $DriverSrc = Join-Path (Split-Path -Parent $ScriptRoot) $PackageName
+}
 $CertPath     = Join-Path $ScriptRoot "MagicMouseFix.cer"
 $BackupDir    = "C:\ProgramData\MagicMousePatch\backup"
+# Windows service / ImagePath name — do not change.
 $TargetDriver = "C:\Windows\System32\drivers\applewirelessmouse.sys"
 $ServiceName  = "applewirelessmouse"
 
@@ -161,7 +171,7 @@ function Test-HvciState {
 function Test-DriverBinary {
     Write-Section "Verifying shipped driver binary..."
     if (-not (Test-Path $DriverSrc)) {
-        Write-Status "Driver binary not found: $DriverSrc" "ERROR"
+        Write-Status "PATH-A package not found: $DriverSrc (expected $PackageName; Windows still installs as applewirelessmouse.sys). Never use MagicMouseDriver.sys." "ERROR"
         return $false
     }
     $size = (Get-Item $DriverSrc).Length
@@ -236,7 +246,7 @@ function Backup-ExistingDriver {
         New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null
     }
     $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
-    $dst   = Join-Path $BackupDir "applewirelessmouse_$stamp.sys"
+    $dst   = Join-Path $BackupDir "applewirelessmouse-pre-pathA_$stamp.sys"
     Copy-Item -Path $TargetDriver -Destination $dst -Force
     Write-Status "Backed up to $dst" "OK"
     return $true

--- a/v1-binary-patch/installer/Install-MagicMousePatch.ps1
+++ b/v1-binary-patch/installer/Install-MagicMousePatch.ps1
@@ -60,7 +60,7 @@ if (-not $DriverSrc) {
 }
 $CertPath     = Join-Path $ScriptRoot "MagicMouseFix.cer"
 $BackupDir    = "C:\ProgramData\MagicMousePatch\backup"
-# Windows service / ImagePath name — do not change.
+# Windows service / ImagePath name - do not change.
 $TargetDriver = "C:\Windows\System32\drivers\applewirelessmouse.sys"
 $ServiceName  = "applewirelessmouse"
 

--- a/v1-binary-patch/installer/SHA256SUMS.txt
+++ b/v1-binary-patch/installer/SHA256SUMS.txt
@@ -1,7 +1,10 @@
-# SHA256 checksums for Magic Mouse v3 Windows Fix v1.0.0
+# SHA256 checksums for Magic Mouse v3 PATH-A ship-blocker (historical only).
+# Package filename: applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
+# Windows still installs that payload as applewirelessmouse.sys.
+# Never name this MagicMouseDriver.sys. Never treat it as the 0323 KMDF product.
 # Verify with: certutil -hashfile <file> SHA256  (Windows)
 #              sha256sum <file>                   (Linux/macOS)
 
-370a5555aebf673c3156ea5b5fbabd8030f2ee7a3a6bd0fcb1b4b6c93fa56a03  applewirelessmouse.sys
+370a5555aebf673c3156ea5b5fbabd8030f2ee7a3a6bd0fcb1b4b6c93fa56a03  applewirelessmouse-patched-pathA-SHIPBLOCKER.sys
 # MagicMouseFix.cer checksum — fill in after cert export
 # <sha256>  MagicMouseFix.cer

--- a/v1-binary-patch/installer/Uninstall-MagicMousePatch.ps1
+++ b/v1-binary-patch/installer/Uninstall-MagicMousePatch.ps1
@@ -128,7 +128,8 @@ function Restore-DriverBackup {
         }
         return
     }
-    $backups = Get-ChildItem -Path $BackupDir -Filter "applewirelessmouse_*.sys" -ErrorAction SilentlyContinue |
+    $backups = @(Get-ChildItem -Path $BackupDir -Filter "applewirelessmouse-pre-pathA_*.sys" -ErrorAction SilentlyContinue) +
+               @(Get-ChildItem -Path $BackupDir -Filter "applewirelessmouse_*.sys" -ErrorAction SilentlyContinue) |
                Sort-Object LastWriteTime -Descending
     if (-not $backups) {
         Write-Status "No backup files found; removing patched driver instead" "WARN"

--- a/v2-kmdf-driver/AclTranslate.c
+++ b/v2-kmdf-driver/AclTranslate.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+//
+// Rewrite Magic Mouse 0x12 reports on the L2CAP ACL path HidBth uses.
+//
+// HidBth sits above this filter. hidclass IRP_MJ_READ stops at HidBth, so
+// EvtIoRead is not the live pointer path. HidBth posts BRB_L2CA_ACL_TRANSFER
+// (IOCTL_INTERNAL_BTH_SUBMIT_BRB) down through us to BthEnum. On IN
+// completion the buffer is a Bluetooth HID interrupt payload:
+//   raw:        12 <MOUSE2...>
+//   HID DATA:   A1 12 <MOUSE2...>
+//
+// Live HID 2026-08-30 21:23 MDT: COL01 Input 0x12 is X/Y only (no 0x0038).
+// Stay on 0x12 and fill Wheel / AC Pan. Do not convert to RID 0x02.
+// RID 0x90 (COL02 battery Input) is passed through.
+
+#include "AclTranslate.h"
+#include "GestureEngine.h"
+
+#ifndef HID_MSG_DATA_INPUT
+#define HID_MSG_DATA_INPUT 0xA1
+#endif
+
+BOOLEAN
+TranslateAclHidReport(
+    _Inout_updates_bytes_(len) PUCHAR buf,
+    _In_ ULONG len,
+    _Out_ PULONG newLen,
+    _Inout_ PDEVICE_CONTEXT ctx)
+{
+    *newLen = len;
+
+    if (buf == NULL || ctx == NULL || len < 1)
+    {
+        return FALSE;
+    }
+
+    // Battery: live HidD_GetInputReport(0x90) on COL02. Do not rewrite.
+    if (buf[0] == MM_REPORT_ID_BATTERY ||
+        (buf[0] == HID_MSG_DATA_INPUT && len >= 2 && buf[1] == MM_REPORT_ID_BATTERY))
+    {
+        return FALSE;
+    }
+
+    if (len < 6)
+    {
+        return FALSE;
+    }
+
+    PUCHAR report = buf;
+    ULONG  reportLen = len;
+    BOOLEAN hidHdr = FALSE;
+
+    if (buf[0] == HID_MSG_DATA_INPUT && len >= 7 &&
+        (buf[1] == MM_REPORT_ID_MOUSE || buf[1] == 0x27))
+    {
+        hidHdr = TRUE;
+        report = buf + 1;
+        reportLen = len - 1;
+    }
+    else if (buf[0] != MM_REPORT_ID_MOUSE && buf[0] != 0x27)
+    {
+        return FALSE;
+    }
+
+    UCHAR translated[MM_MOUSE_REPORT_LEN];
+    ULONG translatedLen = sizeof(translated);
+    NTSTATUS ts = TranslateMouse2ToHid(report, reportLen, translated, &translatedLen, ctx);
+    if (!NT_SUCCESS(ts) || translatedLen != MM_MOUSE_REPORT_LEN)
+    {
+        return FALSE;
+    }
+
+    // May grow a 6-byte native X/Y-only 0x12 to 8 bytes (Wheel/AC Pan).
+    // ACL buffers are far larger than 8; BufferSize is the received length.
+    if (hidHdr)
+    {
+        buf[0] = HID_MSG_DATA_INPUT;
+        RtlCopyMemory(buf + 1, translated, MM_MOUSE_REPORT_LEN);
+        *newLen = 1 + MM_MOUSE_REPORT_LEN;
+    }
+    else
+    {
+        RtlCopyMemory(buf, translated, MM_MOUSE_REPORT_LEN);
+        *newLen = MM_MOUSE_REPORT_LEN;
+    }
+    return TRUE;
+}

--- a/v2-kmdf-driver/AclTranslate.c
+++ b/v2-kmdf-driver/AclTranslate.c
@@ -15,6 +15,7 @@
 
 #include "AclTranslate.h"
 #include "GestureEngine.h"
+#include "TrackpadPtp.h"
 
 #ifndef HID_MSG_DATA_INPUT
 #define HID_MSG_DATA_INPUT 0xA1
@@ -32,6 +33,52 @@ TranslateAclHidReport(
     if (buf == NULL || ctx == NULL || len < 1)
     {
         return FALSE;
+    }
+
+    if (MmIsTrackpadPid(ctx->ProductId))
+    {
+        PUCHAR report = buf;
+        ULONG  reportLen = len;
+        BOOLEAN hidHdr = FALSE;
+        UCHAR translated[TP_PTP_REPORT_LEN];
+        ULONG translatedLen;
+        NTSTATUS ts;
+
+        if (buf[0] == TP_RID_BATTERY ||
+            (buf[0] == HID_MSG_DATA_INPUT && len >= 2 && buf[1] == TP_RID_BATTERY))
+        {
+            return FALSE;
+        }
+
+        if (buf[0] == HID_MSG_DATA_INPUT && len >= 2)
+        {
+            hidHdr = TRUE;
+            report = buf + 1;
+            reportLen = len - 1;
+        }
+
+        translatedLen = sizeof(translated);
+        WdfSpinLockAcquire(ctx->Lock);
+        ts = TranslateTrackpadToPtp(report, reportLen, translated, &translatedLen,
+                                    ctx->ProductId, &ctx->PtpScanTime);
+        WdfSpinLockRelease(ctx->Lock);
+        if (!NT_SUCCESS(ts) || translatedLen != TP_PTP_REPORT_LEN)
+        {
+            return FALSE;
+        }
+
+        if (hidHdr)
+        {
+            buf[0] = HID_MSG_DATA_INPUT;
+            RtlCopyMemory(buf + 1, translated, TP_PTP_REPORT_LEN);
+            *newLen = 1 + TP_PTP_REPORT_LEN;
+        }
+        else
+        {
+            RtlCopyMemory(buf, translated, TP_PTP_REPORT_LEN);
+            *newLen = TP_PTP_REPORT_LEN;
+        }
+        return TRUE;
     }
 
     // Battery: live HidD_GetInputReport(0x90) on COL02. Do not rewrite.

--- a/v2-kmdf-driver/AclTranslate.h
+++ b/v2-kmdf-driver/AclTranslate.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "Driver.h"
+
+// TRUE if buf looks like a Bluetooth HID input carrying MOUSE2 RID 0x12
+// (raw 0x12 or HID DATA+INPUT 0xA1 0x12). On TRUE, *newLen is the rewritten
+// length (8, or 9 with 0xA1). Buffer is mutated in place. 0x90 is not rewritten.
+BOOLEAN
+TranslateAclHidReport(
+    _Inout_updates_bytes_(len) PUCHAR buf,
+    _In_ ULONG len,
+    _Out_ PULONG newLen,
+    _Inout_ PDEVICE_CONTEXT ctx);

--- a/v2-kmdf-driver/BUILDING.md
+++ b/v2-kmdf-driver/BUILDING.md
@@ -1,0 +1,29 @@
+# Building MagicMouseDriver-kmdf-2.0.4-scroll.sys
+
+Linux cannot produce a `.sys`. Build on Windows 10/11 x64 with Visual Studio + WDK, or a mounted Enterprise WDK.
+
+`msbuild` / INF still emit **`MagicMouseDriver.sys`** (Windows service name). Copy or let the installer label the artifact **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`**. FileVersion / DriverVer is **2.0.4.0**.
+
+Do **not** install a build on the live Apr 30 PC (`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`, pointer OK / scroll dead) until you are ready to prove 2.0.4 scroll. Do not merge until hardware proves pointer **and** scroll. Never name a KMDF build `applewirelessmouse*.sys`.
+
+## WDK / Visual Studio
+
+```bat
+msbuild MagicMouseDriver.vcxproj /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off
+```
+
+Output is typically `x64\Release\MagicMouseDriver.sys` (INF name). The installer copies it to `MagicMouseDriver-kmdf-2.0.4-scroll.sys` next to the INF. You can also drop that labeled file next to the INF to skip compile.
+
+`SignMode=Off` is required: WDK's inline sign task often deletes the `.sys` when `signtool` wants `/fd sha256`. The SYSTEM installer signs afterwards.
+
+## Enterprise WDK ISO
+
+1. Mount the EWDK ISO.
+2. Run `LaunchBuildEnv.cmd` (or `BuildEnv\SetupBuildEnv.cmd`).
+3. `msbuild` the vcxproj as above.
+
+The SYSTEM task (`MM-Kmdf-Install`) can see WDK on `C:\Program Files*`. It **cannot** see an ISO you mounted only in your interactive session (Session 0). Prefer an installed WDK, or place a prebuilt `.sys` in the package folder.
+
+## After the `.sys` exists
+
+Double-click `Install-KMDF.cmd`. Do not run a pile of helper scripts by hand.

--- a/v2-kmdf-driver/DESIGN-mouse-multitouch-click.md
+++ b/v2-kmdf-driver/DESIGN-mouse-multitouch-click.md
@@ -1,0 +1,85 @@
+# DESIGN — 0323 2/3-finger click (MU-parity, no tap)
+
+Status: Implement in `GestureEngine.c` / `.h`. Surface scroll stays the existing 0323 touch-delta path.
+
+Magic Mouse 2024 (`PID 0x0323`) has one mechanical switch under the whole glass. Firmware reports that switch in MOUSE2 `data[1]` bit 0. The 14+8×N touch block (already parsed for Wheel / AC Pan) says how many fingers are down. Magic Utilities maps that count to extra buttons. This vertical does the same two rows only: **2-finger click = right**, **3-finger click = middle**. It does not copy Linux `emulate_3button` (that is X-position of one firm touch, GPL). It does not synthesize a click from finger down/up. 1-finger tap is a non-goal — the mouse already has a button.
+
+## Linux numeric facts (no GPL)
+
+`drivers/hid/hid-magicmouse.c` layout only:
+
+| Item | Value |
+| --- | --- |
+| MOUSE2 report ID | `0x12` |
+| Compact report | 8 bytes (no touch) |
+| Full header | 14 bytes, then `8 * N` touch records |
+| Hardware buttons | `data[1]` (bit 0 mechanical / left) |
+| Touch id | `(tdata[6] << 2 \| tdata[5] >> 6) & 0xF` |
+| Touch x | signed 12-bit: `(tdata[1] << 28 \| tdata[0] << 20) >> 20` |
+| Touch y | `-((tdata[2] << 24 \| tdata[1] << 16) >> 20)` |
+| Touch state | `tdata[7] & 0xF0` |
+| NONE / START / DRAG | `0x00` / `0x30` / `0x40` |
+| Touch size (unused here) | `tdata[5] & 0x3F` |
+
+Linux middle-click is `x` vs ±350 on a single firm contact (`size >= 8`). **Do not port that.** Contact count is the MU-parity map.
+
+## Contact-count → button
+
+Active contact = a touch record whose state is START or DRAG. NONE is up. Same slots `AccumulateSurfaceScroll` already walks (`id < 16`).
+
+| Active contacts at mechanical **press edge** | Output `out[1]` |
+| --- | --- |
+| no touch block (compact / short header) | hardware `data[1] & 0x03` |
+| 0 (all NONE) with mechanical down | hardware `data[1] & 0x03` |
+| 1 | Left (`0x01`) |
+| 2 | Right (`0x02`) |
+| 3 or more | Middle (`0x04`) |
+
+Output is **exactly one** button, not OR'd with firmware left. A 2-finger click is right only.
+
+## Finger-down / up so scroll drag is not a click
+
+1. **Touch never synthesizes a button.** START, DRAG, and NONE do not set `out[1]`. Only the mechanical bit (`data[1] & 0x01`) does. A 1- or 2-finger surface drag with the switch up stays buttons = 0 and still produces Wheel / AC Pan from touch delta.
+2. **Latch on 0→1, hold until 1→0.** Contact count is sampled on the mechanical press edge and stored in `DEVICE_CONTEXT` (`ClickHeld`, `ClickLatched`). A finger lifting mid-click does not switch right → left. Release clears the latch.
+3. **Press edge during a detent is not a click.** If the same report already produced Wheel or AC Pan, latch 0 for that press. Scroll-then-bottom-out must not emit right/middle. Tiny motion below `MM_SCROLL_STEP` still clicks.
+4. **Compact reports mid-press keep the latch** if mechanical is still down (no new count). Mechanical up on compact clears.
+
+Scroll path is unchanged: `AccumulateSurfaceScroll` still fills Wheel / AC Pan from START anchors and DRAG steps. Click remap runs **after** that, under its own lock acquire (WDF spinlocks are not recursive).
+
+## HID report / descriptor
+
+Output stays 8-byte RID `0x12`: `[12][buttons][X i16][Y i16][AC Pan][Wheel]`.
+
+COL01 currently advertises Button 1–2 and pads 6 constant bits. Bit 2 would be ignored. Same-length patch: Usage Maximum 3, Report Count 3, pad 5 bits. Descriptor **byte count is unchanged**, so SDP overlay size does not grow.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `v2-kmdf-driver/DESIGN-mouse-multitouch-click.md` | This design. |
+| `v2-kmdf-driver/GestureEngine.c` | Count START/DRAG, latch, remap. Scroll loop untouched. |
+| `v2-kmdf-driver/GestureEngine.h` | Button bits including middle. |
+| `v2-kmdf-driver/Driver.h` | `ClickHeld` / `ClickLatched` on `DEVICE_CONTEXT`. |
+| `v2-kmdf-driver/HidDescriptor.c` | Same-length Button 1–3. |
+| `v2-kmdf-driver/tests/test_mouse_multitouch_click.py` | Host-side map + scroll-not-click. No live mouse. |
+
+## Tests
+
+No WDK on Linux. Host Python, no hardware:
+
+- Source: `TranslateMouse2ToHid` still calls `AccumulateSurfaceScroll`; `MM_SCROLL_STEP` present; no `magicmouse_emit_buttons` / `firm_touch` / `middle_button_start`.
+- 1-finger mechanical, no drag → left; Wheel 0.
+- 2-finger START + mechanical, no detent → right; Wheel 0.
+- 3-finger START + mechanical → middle.
+- 2-finger DRAG of `MM_SCROLL_STEP` with mechanical **up** → Wheel ±1, buttons 0.
+- 2-finger DRAG detent on the **press** report → buttons 0 (suppressed).
+- Latch: 2-finger press then one finger NONE, mechanical still down → still right.
+- Compact 8-byte `data[1]=1` with no prior latch → left (hardware).
+
+## Non-goals
+
+- 1-finger tap-to-click.
+- Linux X-position 3-button emulation.
+- Trackpad files, tray C#, MU binaries, PathA, `pnputil`.
+- Changing `MM_SCROLL_STEP` or adding a 2-finger-only scroll gate.
+- Push. Killing the live tray. Installing on the live PC.

--- a/v2-kmdf-driver/Driver.c
+++ b/v2-kmdf-driver/Driver.c
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: MIT
+#include "Driver.h"
+#include "InputHandler.h"
+#include "GestureEngine.h"
+#include "AclTranslate.h"
+
+// BRB_L2CA_ACL_TRANSFER field offsets on x64 (bthddi.h / Win10+).
+// BRB_HEADER.Type is at +0x16. ACL Buffer/Size follow the 0x70-byte header
+// + BTH_ADDR + ChannelHandle. Validated against WDK 10.0.14393 bthddi.h.
+#define MM_BRB_LENGTH_OFFSET  0x10
+#define MM_BRB_TYPE_OFFSET    0x16
+#define MM_ACL_FLAGS_OFFSET   0x80
+#define MM_ACL_BUFSIZE_OFFSET 0x84
+#define MM_ACL_BUFFER_OFFSET  0x88
+#define MM_ACL_MDL_OFFSET     0x90
+#define MM_ACL_MIN_BRB_LEN    0x98
+
+static VOID
+ForwardPassthrough(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target)
+{
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WDF_REQUEST_SEND_OPTIONS opts;
+    WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+    if (!WdfRequestSend(Request, Target, &opts))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+static VOID
+ForwardSdpWithCompletion(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target, _In_ PDEVICE_CONTEXT ctx)
+{
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->IoctlInterceptCount++;
+    WdfSpinLockRelease(ctx->Lock);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, OnSdpQueryComplete, ctx);
+    if (!WdfRequestSend(Request, Target, WDF_NO_SEND_OPTIONS))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+NTSTATUS
+DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
+{
+    WDF_DRIVER_CONFIG config;
+    WDF_DRIVER_CONFIG_INIT(&config, EvtDeviceAdd);
+    DbgPrint("MM: DriverEntry %s artifact %s (INF installs as MagicMouseDriver.sys)\n",
+             MM_FILE_VERSION_STR, MM_ARTIFACT_SYS_NAME);
+    return WdfDriverCreate(DriverObject, RegistryPath, WDF_NO_OBJECT_ATTRIBUTES,
+                           &config, WDF_NO_HANDLE);
+}
+
+NTSTATUS
+EvtDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT DeviceInit)
+{
+    UNREFERENCED_PARAMETER(Driver);
+
+    WdfFdoInitSetFilter(DeviceInit);
+
+    WDF_OBJECT_ATTRIBUTES reqAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&reqAttr, MM_REQUEST_CONTEXT);
+    WdfDeviceInitSetRequestAttributes(DeviceInit, &reqAttr);
+
+    WDF_OBJECT_ATTRIBUTES devAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&devAttr, DEVICE_CONTEXT);
+
+    WDFDEVICE device;
+    NTSTATUS status = WdfDeviceCreate(&DeviceInit, &devAttr, &device);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+
+    WDF_OBJECT_ATTRIBUTES lockAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&lockAttr);
+    lockAttr.ParentObject = device;
+    status = WdfSpinLockCreate(&lockAttr, &ctx->Lock);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    ctx->EnableInjection = TRUE;
+    {
+        WDFKEY paramsKey = NULL;
+        NTSTATUS ks = WdfDriverOpenParametersRegistryKey(
+            Driver, KEY_READ, WDF_NO_OBJECT_ATTRIBUTES, &paramsKey);
+        if (NT_SUCCESS(ks) && paramsKey != NULL)
+        {
+            ULONG val = 1;
+            UNICODE_STRING valName;
+            RtlInitUnicodeString(&valName, L"EnableInjection");
+            if (NT_SUCCESS(WdfRegistryQueryULong(paramsKey, &valName, &val)))
+            {
+                ctx->EnableInjection = (val != 0);
+            }
+            WdfRegistryClose(paramsKey);
+        }
+    }
+
+    ctx->ProductId = 0;
+    {
+        PDEVICE_OBJECT pdo = WdfDeviceWdmGetPhysicalDevice(device);
+        if (pdo != NULL)
+        {
+            WCHAR hwIdBuf[256] = { 0 };
+            ULONG retLen = 0;
+            NTSTATUS pidStatus = IoGetDeviceProperty(
+                pdo,
+                DevicePropertyHardwareID,
+                sizeof(hwIdBuf) - sizeof(WCHAR),
+                hwIdBuf,
+                &retLen);
+
+            if (NT_SUCCESS(pidStatus) && retLen >= sizeof(WCHAR))
+            {
+                ULONG wcharCount = retLen / sizeof(WCHAR);
+                for (ULONG i = 0; i + 8 <= wcharCount; i++)
+                {
+                    if (hwIdBuf[i]     == L'P' &&
+                        hwIdBuf[i + 1] == L'I' &&
+                        hwIdBuf[i + 2] == L'D' &&
+                        hwIdBuf[i + 3] == L'&')
+                    {
+                        USHORT pid = 0;
+                        for (ULONG j = i + 4; j < wcharCount && j < i + 8; j++)
+                        {
+                            WCHAR  c      = hwIdBuf[j];
+                            USHORT nibble = 0;
+                            if      (c >= L'0' && c <= L'9') { nibble = (USHORT)(c - L'0'); }
+                            else if (c >= L'A' && c <= L'F') { nibble = (USHORT)(c - L'A' + 10); }
+                            else if (c >= L'a' && c <= L'f') { nibble = (USHORT)(c - L'a' + 10); }
+                            else { break; }
+                            pid = (USHORT)((pid << 4) | nibble);
+                        }
+                        ctx->ProductId = pid;
+                        break;
+                    }
+                }
+            }
+        }
+        DbgPrint("MM: AddDevice ProductId=0x%04X EnableInjection=%d\n",
+                 ctx->ProductId, ctx->EnableInjection);
+    }
+
+    WDF_TIMER_CONFIG timerCfg;
+    WDF_TIMER_CONFIG_INIT_PERIODIC(&timerCfg, MmDiagTimerFunc, 1000);
+    WDF_OBJECT_ATTRIBUTES timerAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&timerAttr);
+    timerAttr.ParentObject = device;
+    status = WdfTimerCreate(&timerCfg, &timerAttr, &ctx->DiagTimer);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    WDF_WORKITEM_CONFIG wiCfg;
+    WDF_WORKITEM_CONFIG_INIT(&wiCfg, MmDiagWorkItemFunc);
+    WDF_OBJECT_ATTRIBUTES wiAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&wiAttr);
+    wiAttr.ParentObject = device;
+    status = WdfWorkItemCreate(&wiCfg, &wiAttr, &ctx->DiagWorkItem);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    WdfTimerStart(ctx->DiagTimer, WDF_REL_TIMEOUT_IN_MS(1000));
+
+    WDF_IO_QUEUE_CONFIG qCfg;
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&qCfg, WdfIoQueueDispatchParallel);
+    qCfg.EvtIoDeviceControl         = EvtIoDeviceControl;
+    qCfg.EvtIoInternalDeviceControl = EvtIoInternalDeviceControl;
+    qCfg.EvtIoRead                  = EvtIoRead;
+    qCfg.EvtIoDefault               = EvtIoDefault;
+
+    WDFQUEUE queue;
+    return WdfIoQueueCreate(device, &qCfg, WDF_NO_OBJECT_ATTRIBUTES, &queue);
+}
+
+VOID
+EvtIoInternalDeviceControl(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request,
+                            _In_ size_t OutputBufferLength, _In_ size_t InputBufferLength,
+                            _In_ ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE       device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx    = GetDeviceContext(device);
+    WDFIOTARGET     target = WdfDeviceGetIoTarget(device);
+
+    if (IoControlCode == IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        ForwardSdpWithCompletion(Request, target, ctx);
+        return;
+    }
+
+    if (IoControlCode == IOCTL_INTERNAL_BTH_SUBMIT_BRB &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        PIRP irp = WdfRequestWdmGetIrp(Request);
+        PIO_STACK_LOCATION sl = IoGetCurrentIrpStackLocation(irp);
+        PUCHAR brb = (PUCHAR)sl->Parameters.Others.Argument1;
+
+        if (brb != NULL)
+        {
+            USHORT type = 0;
+            ULONG  brbLen = 0;
+            RtlCopyMemory(&brbLen, brb + MM_BRB_LENGTH_OFFSET, sizeof(ULONG));
+            RtlCopyMemory(&type, brb + MM_BRB_TYPE_OFFSET, sizeof(USHORT));
+
+            if (type == (USHORT)BRB_L2CA_ACL_TRANSFER && brbLen >= MM_ACL_MIN_BRB_LEN)
+            {
+                ULONG flags = 0;
+                RtlCopyMemory(&flags, brb + MM_ACL_FLAGS_OFFSET, sizeof(ULONG));
+                if ((flags & ACL_TRANSFER_DIRECTION_IN) != 0)
+                {
+                    PMM_REQUEST_CONTEXT reqCtx = GetRequestContext(Request);
+                    reqCtx->Brb = brb;
+
+                    WdfSpinLockAcquire(ctx->Lock);
+                    ctx->AclInterceptCount++;
+                    WdfSpinLockRelease(ctx->Lock);
+
+                    WdfRequestFormatRequestUsingCurrentType(Request);
+                    WdfRequestSetCompletionRoutine(Request, OnAclTransferComplete, ctx);
+                    if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+                    {
+                        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    ForwardPassthrough(Request, target);
+}
+
+VOID
+EvtIoDeviceControl(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request,
+                   _In_ size_t OutputBufferLength, _In_ size_t InputBufferLength,
+                   _In_ ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE       device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx    = GetDeviceContext(device);
+    WDFIOTARGET     target = WdfDeviceGetIoTarget(device);
+
+    if (IoControlCode == IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        ForwardSdpWithCompletion(Request, target, ctx);
+        return;
+    }
+
+    ForwardPassthrough(Request, target);
+}
+
+VOID
+EvtIoDefault(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request)
+{
+    ForwardPassthrough(Request, WdfDeviceGetIoTarget(WdfIoQueueGetDevice(Queue)));
+}
+
+VOID
+EvtIoRead(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request, _In_ size_t Length)
+{
+    UNREFERENCED_PARAMETER(Length);
+
+    WDFDEVICE       device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx    = GetDeviceContext(device);
+    WDFIOTARGET     target = WdfDeviceGetIoTarget(device);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, OnReadComplete, ctx);
+    if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+VOID
+OnAclTransferComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+                      _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+    PMM_REQUEST_CONTEXT reqCtx = GetRequestContext(Request);
+    PUCHAR brb = (reqCtx != NULL) ? (PUCHAR)reqCtx->Brb : NULL;
+
+    if (NT_SUCCESS(status) && ctx != NULL && brb != NULL)
+    {
+        ULONG brbLen = 0;
+        RtlCopyMemory(&brbLen, brb + MM_BRB_LENGTH_OFFSET, sizeof(ULONG));
+        if (brbLen >= MM_ACL_MIN_BRB_LEN)
+        {
+            ULONG  bufSize = 0;
+            PVOID  buffer  = NULL;
+            PMDL   mdl     = NULL;
+            RtlCopyMemory(&bufSize, brb + MM_ACL_BUFSIZE_OFFSET, sizeof(ULONG));
+            RtlCopyMemory(&buffer,  brb + MM_ACL_BUFFER_OFFSET,  sizeof(PVOID));
+            RtlCopyMemory(&mdl,     brb + MM_ACL_MDL_OFFSET,     sizeof(PMDL));
+
+            PUCHAR payload = (PUCHAR)buffer;
+            if (payload == NULL && mdl != NULL)
+            {
+                payload = (PUCHAR)MmGetSystemAddressForMdlSafe(mdl, NormalPagePriority);
+            }
+
+            if (payload != NULL && bufSize >= 1)
+            {
+                ULONG newLen = bufSize;
+                __try
+                {
+                    // May grow 6-byte X/Y-only 0x12 to 8 (Wheel/AC Pan).
+                    // ACL allocations are larger than the received length.
+                    if (TranslateAclHidReport(payload, bufSize, &newLen, ctx) &&
+                        newLen > 0 && newLen <= 256)
+                    {
+                        RtlCopyMemory(brb + MM_ACL_BUFSIZE_OFFSET, &newLen, sizeof(ULONG));
+                        WdfSpinLockAcquire(ctx->Lock);
+                        ctx->AclTranslateCount++;
+                        ctx->Rid12Count++;
+                        WdfSpinLockRelease(ctx->Lock);
+                    }
+                }
+                __except (EXCEPTION_EXECUTE_HANDLER)
+                {
+                    DbgPrint("MM: OnAclTransferComplete — buffer exception, passthrough\n");
+                }
+            }
+        }
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+VOID
+OnReadComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+               _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    PUCHAR buf    = NULL;
+    SIZE_T bufLen = 0;
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufLen)) || buf == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    SIZE_T bytesRead = Params->IoStatus.Information;
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->HidReadCount++;
+    if (bytesRead > 0 && bytesRead <= bufLen && (buf[0] == 0x12 || buf[0] == 0x27))
+    {
+        ctx->Rid12Count++;
+    }
+    WdfSpinLockRelease(ctx->Lock);
+
+    __try
+    {
+        // 0x90 battery Input is passed through. 0x12 stays 0x12 (8 bytes).
+        if (bytesRead >= 6 && (buf[0] == 0x12 || buf[0] == 0x27) &&
+            (ctx->ProductId == 0 || ctx->ProductId == MM_PID_V3))
+        {
+            UCHAR  translated[MM_MOUSE_REPORT_LEN];
+            ULONG  translatedLen = sizeof(translated);
+            NTSTATUS ts = TranslateMouse2ToHid(buf, bytesRead, translated, &translatedLen, ctx);
+            if (NT_SUCCESS(ts) && translatedLen == MM_MOUSE_REPORT_LEN &&
+                bufLen >= MM_MOUSE_REPORT_LEN)
+            {
+                RtlCopyMemory(buf, translated, translatedLen);
+                WdfRequestSetInformation(Request, translatedLen);
+            }
+        }
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        DbgPrint("MM: OnReadComplete — buffer exception, passthrough\n");
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+VOID
+OnSdpQueryComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+                   _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    PVOID  buf         = NULL;
+    size_t bufAllocLen = 0;
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufAllocLen)) ||
+        buf == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    size_t sdpLen = Params->IoStatus.Information;
+    if (sdpLen == 0 || sdpLen > bufAllocLen)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->LastSdpBufSize = (ULONG)sdpLen;
+    ULONG snapLen = (sdpLen < 64) ? (ULONG)sdpLen : 64;
+    RtlCopyMemory(ctx->LastSdpBytes, buf, snapLen);
+    if (snapLen < 64) { RtlZeroMemory(ctx->LastSdpBytes + snapLen, 64 - snapLen); }
+    WdfSpinLockRelease(ctx->Lock);
+
+    // This INF binds 0323 only. Still refuse to rewrite if PID is a known
+    // other Magic Mouse (defense in depth — do not retarget 030D).
+    if (ctx->ProductId != 0 && ctx->ProductId != MM_PID_V3)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    ULONG    newLen      = (ULONG)sdpLen;
+    NTSTATUS patchStatus = SdpRewrite_Process((PUCHAR)buf, (ULONG)sdpLen, &newLen);
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->LastPatchStatus = (ULONG)patchStatus;
+    if (patchStatus == STATUS_SUCCESS)
+    {
+        ctx->SdpScanHits++;
+        ctx->SdpPatchSuccess++;
+    }
+    else if (patchStatus == STATUS_MORE_PROCESSING_REQUIRED)
+    {
+        ctx->SdpScanHits++;
+    }
+    WdfSpinLockRelease(ctx->Lock);
+
+    if (patchStatus == STATUS_SUCCESS && newLen != (ULONG)sdpLen)
+    {
+        WdfRequestSetInformation(Request, (ULONG_PTR)newLen);
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+VOID
+MmDiagTimerFunc(_In_ WDFTIMER Timer)
+{
+    WDFDEVICE device = (WDFDEVICE)WdfTimerGetParentObject(Timer);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    if (ctx != NULL && ctx->DiagWorkItem != NULL)
+    {
+        WdfWorkItemEnqueue(ctx->DiagWorkItem);
+    }
+}
+
+VOID
+MmDiagWorkItemFunc(_In_ WDFWORKITEM WorkItem)
+{
+    WDFDEVICE device = (WDFDEVICE)WdfWorkItemGetParentObject(WorkItem);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    if (ctx == NULL) { return; }
+
+    ULONG ictlCount, scanHits, patchOk, lastSize, lastStatus;
+    ULONG hidReads, rid12, aclN, aclX;
+    UCHAR lastBytes[64];
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ictlCount  = ctx->IoctlInterceptCount;
+    scanHits   = ctx->SdpScanHits;
+    patchOk    = ctx->SdpPatchSuccess;
+    lastSize   = ctx->LastSdpBufSize;
+    lastStatus = ctx->LastPatchStatus;
+    hidReads   = ctx->HidReadCount;
+    rid12      = ctx->Rid12Count;
+    aclN       = ctx->AclInterceptCount;
+    aclX       = ctx->AclTranslateCount;
+    RtlCopyMemory(lastBytes, ctx->LastSdpBytes, 64);
+    WdfSpinLockRelease(ctx->Lock);
+
+    UNICODE_STRING keyPath;
+    RtlInitUnicodeString(&keyPath,
+        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Services\\MagicMouseDriver\\Diag");
+    OBJECT_ATTRIBUTES attr;
+    InitializeObjectAttributes(&attr, &keyPath,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+    HANDLE key  = NULL;
+    ULONG  disp = 0;
+    if (!NT_SUCCESS(ZwCreateKey(&key, KEY_WRITE, &attr, 0, NULL,
+                                REG_OPTION_NON_VOLATILE, &disp)))
+    {
+        return;
+    }
+
+    UNICODE_STRING n;
+
+#define SET_DWORD(Name, Val) \
+    RtlInitUnicodeString(&n, Name); \
+    ZwSetValueKey(key, &n, 0, REG_DWORD, &(Val), sizeof(ULONG))
+
+    SET_DWORD(L"IoctlInterceptCount", ictlCount);
+    SET_DWORD(L"SdpScanHits",         scanHits);
+    SET_DWORD(L"SdpPatchSuccess",     patchOk);
+    SET_DWORD(L"LastSdpBufSize",      lastSize);
+    SET_DWORD(L"LastPatchStatusHex",  lastStatus);
+    SET_DWORD(L"HidReadCount",        hidReads);
+    SET_DWORD(L"Rid12Count",          rid12);
+    SET_DWORD(L"AclInterceptCount",   aclN);
+    SET_DWORD(L"AclTranslateCount",   aclX);
+
+#undef SET_DWORD
+
+    RtlInitUnicodeString(&n, L"LastSdpBytes");
+    ZwSetValueKey(key, &n, 0, REG_BINARY, lastBytes, 64);
+    ZwClose(key);
+}

--- a/v2-kmdf-driver/Driver.c
+++ b/v2-kmdf-driver/Driver.c
@@ -3,6 +3,7 @@
 #include "InputHandler.h"
 #include "GestureEngine.h"
 #include "AclTranslate.h"
+#include "TrackpadPtp.h"
 
 // BRB_L2CA_ACL_TRANSFER field offsets on x64 (bthddi.h / Win10+).
 // BRB_HEADER.Type is at +0x16. ACL Buffer/Size follow the 0x70-byte header
@@ -369,8 +370,22 @@ OnReadComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
 
     __try
     {
-        // 0x90 battery Input is passed through. 0x12 stays 0x12 (8 bytes).
-        if (bytesRead >= 6 && (buf[0] == 0x12 || buf[0] == 0x27) &&
+        // Trackpad PIDs: Apple 0x28/0x31 → PTP RID 0x01. 0323 stays on 0x12.
+        if (MmIsTrackpadPid(ctx->ProductId) && bytesRead >= 1 &&
+            bufLen >= TP_PTP_REPORT_LEN)
+        {
+            UCHAR  translated[TP_PTP_REPORT_LEN];
+            ULONG  translatedLen = sizeof(translated);
+            NTSTATUS ts = TranslateTrackpadToPtp(buf, bytesRead, translated,
+                                                 &translatedLen, ctx->ProductId,
+                                                 &ctx->PtpScanTime);
+            if (NT_SUCCESS(ts) && translatedLen == TP_PTP_REPORT_LEN)
+            {
+                RtlCopyMemory(buf, translated, translatedLen);
+                WdfRequestSetInformation(Request, translatedLen);
+            }
+        }
+        else if (bytesRead >= 6 && (buf[0] == 0x12 || buf[0] == 0x27) &&
             (ctx->ProductId == 0 || ctx->ProductId == MM_PID_V3))
         {
             UCHAR  translated[MM_MOUSE_REPORT_LEN];
@@ -430,16 +445,23 @@ OnSdpQueryComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
     if (snapLen < 64) { RtlZeroMemory(ctx->LastSdpBytes + snapLen, 64 - snapLen); }
     WdfSpinLockRelease(ctx->Lock);
 
-    // This INF binds 0323 only. Still refuse to rewrite if PID is a known
-    // other Magic Mouse (defense in depth — do not retarget 030D).
-    if (ctx->ProductId != 0 && ctx->ProductId != MM_PID_V3)
+    // 0323 mouse blob, or trackpad PTP blob. Never rewrite 030D/0269/0310.
+    ULONG    newLen      = (ULONG)sdpLen;
+    NTSTATUS patchStatus;
+    if (MmIsTrackpadPid(ctx->ProductId))
+    {
+        patchStatus = SdpRewrite_ProcessEx((PUCHAR)buf, (ULONG)sdpLen, &newLen,
+                                           g_PtpHidDescriptor, g_PtpHidDescriptorSize);
+    }
+    else if (ctx->ProductId != 0 && ctx->ProductId != MM_PID_V3)
     {
         WdfRequestComplete(Request, status);
         return;
     }
-
-    ULONG    newLen      = (ULONG)sdpLen;
-    NTSTATUS patchStatus = SdpRewrite_Process((PUCHAR)buf, (ULONG)sdpLen, &newLen);
+    else
+    {
+        patchStatus = SdpRewrite_Process((PUCHAR)buf, (ULONG)sdpLen, &newLen);
+    }
 
     WdfSpinLockAcquire(ctx->Lock);
     ctx->LastPatchStatus = (ULONG)patchStatus;

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+//
+// MagicMouseDriver — KMDF lower filter for Apple Magic Mouse PID 0x0323 only.
+//
+// Stack:
+//   hidclass.sys → HidBth.sys → [this filter] → BthEnum PDO
+//
+// Two jobs:
+//   1. SDP: rewrite HIDDescriptorList (0x0206) so COL01 RID 0x12 exposes
+//      Wheel (GD 0x38) and AC Pan (Consumer 0x0238). Live HID 2026-08-30
+//      21:23 MDT (Apr 30 MagicMouseFix AD5D244B): COL01 Input 0x12 is X/Y
+//      only — that is why the pointer moves and scroll does not. HidBth
+//      delivers 0x12. Descriptor C (RID 0x02 + Feat 0x47) is not what
+//      hidclass bound. Same IOCTL Apple uses
+//      (IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE = 0x410210).
+//   2. Reports: stay on RID 0x12. Fill Wheel/AC Pan from the 14+8*N touch
+//      block (Linux hid-magicmouse MOUSE2). Do not convert to 0x02.
+//      Battery is RID 0x90 Input on COL02 (HidD_GetInputReport; percent
+//      at byte[2]). Feat 0x47 fails on COL01 and COL02.
+//      Paths:
+//        - BRB_L2CA_ACL_TRANSFER completions (the path HidBth actually uses)
+//        - IRP_MJ_READ completions (backup; hidclass reads usually stop at HidBth)
+//
+// Sole filter. Do not stack with applewirelessmouse (v1 binary is a 0xD1
+// ship-blocker). This package does not bind PID 0x030D / 0x0269.
+
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+#define MM_POOL_TAG 'DMgm'
+
+// FileVersion / package label for this source. INF still copies MagicMouseDriver.sys.
+#define MM_FILE_VERSION_STR     "2.0.4.0"
+#define MM_ARTIFACT_SYS_NAME    "MagicMouseDriver-kmdf-2.0.4-scroll.sys"
+
+// Magic Mouse 2024 / Magic Mouse 2 USB-C — the only PID this package binds.
+#define MM_PID_V3  0x0323u
+
+// IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
+// CTL_CODE(FILE_DEVICE_BLUETOOTH=0x41, Function=0x84, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE 0x00410210UL
+
+// IOCTL_INTERNAL_BTH_SUBMIT_BRB (bthioctl.h) — METHOD_NEITHER.
+#ifndef IOCTL_INTERNAL_BTH_SUBMIT_BRB
+#define IOCTL_INTERNAL_BTH_SUBMIT_BRB 0x00410003UL
+#endif
+
+// BRB_L2CA_ACL_TRANSFER (bthddi.h). Defined here so the source builds against
+// a WDK that has bthddi.h and so reviewers can see the constant without
+// opening the SDK.
+#ifndef BRB_L2CA_ACL_TRANSFER
+#define BRB_L2CA_ACL_TRANSFER 0x0105
+#endif
+
+#ifndef ACL_TRANSFER_DIRECTION_IN
+#define ACL_TRANSFER_DIRECTION_IN 0x00000001UL
+#endif
+
+// Injected RID 0x12 report:
+//   [RID 0x12][buttons][X i16][Y i16][AC Pan][Wheel] = 8 bytes.
+#define MM_MOUSE_REPORT_LEN 8
+
+#define MM_TOUCH_SLOTS 16
+
+typedef struct _DEVICE_CONTEXT
+{
+    WDFSPINLOCK Lock;
+
+    BOOLEAN EnableInjection;
+    USHORT  ProductId;          // 0x0323, or 0 if HardwareId could not be read
+
+    ULONG   IoctlInterceptCount;
+    ULONG   SdpScanHits;
+    ULONG   SdpPatchSuccess;
+    ULONG   LastSdpBufSize;
+    ULONG   LastPatchStatus;
+    UCHAR   LastSdpBytes[64];
+
+    ULONG   HidReadCount;
+    ULONG   Rid12Count;
+    ULONG   AclInterceptCount;
+    ULONG   AclTranslateCount;
+
+    // Surface-scroll anchors (Linux hid-magicmouse emit_touch style).
+    INT16   TouchAnchorY[MM_TOUCH_SLOTS];
+    INT16   TouchAnchorX[MM_TOUCH_SLOTS];
+    BOOLEAN TouchAnchorValid[MM_TOUCH_SLOTS];
+
+    WDFTIMER    DiagTimer;
+    WDFWORKITEM DiagWorkItem;
+
+} DEVICE_CONTEXT, *PDEVICE_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext)
+
+// Per-request stash so BRB completion uses the same PBRB HidBth submitted
+// (do not re-read the IRP stack in the completion routine).
+typedef struct _MM_REQUEST_CONTEXT
+{
+    PVOID Brb;   // PBRB, typed as PVOID so Driver.h does not include bthddi.h
+} MM_REQUEST_CONTEXT, *PMM_REQUEST_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(MM_REQUEST_CONTEXT, GetRequestContext)
+
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_DEVICE_ADD               EvtDeviceAdd;
+EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL EvtIoInternalDeviceControl;
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL      EvtIoDeviceControl;
+EVT_WDF_IO_QUEUE_IO_DEFAULT             EvtIoDefault;
+EVT_WDF_IO_QUEUE_IO_READ                EvtIoRead;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnSdpQueryComplete;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnReadComplete;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnAclTransferComplete;
+EVT_WDF_TIMER                           MmDiagTimerFunc;
+EVT_WDF_WORKITEM                        MmDiagWorkItemFunc;

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -88,6 +88,10 @@ typedef struct _DEVICE_CONTEXT
     INT16   TouchAnchorX[MM_TOUCH_SLOTS];
     BOOLEAN TouchAnchorValid[MM_TOUCH_SLOTS];
 
+    // Mechanical click latch (2-finger right / 3-finger middle). Not a tap.
+    BOOLEAN ClickHeld;
+    UCHAR   ClickLatched;
+
     WDFTIMER    DiagTimer;
     WDFWORKITEM DiagWorkItem;
 

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
-// MagicMouseDriver — KMDF lower filter for Apple Magic Mouse PID 0x0323 only.
+// MagicMouseDriver — KMDF lower filter for Apple Magic Mouse PID 0x0323
+// and Magic Trackpad PIDs 0x030E / 0x0265 / 0x0324 (PTP tap). 0323 path unchanged.
 //
 // Stack:
 //   hidclass.sys → HidBth.sys → [this filter] → BthEnum PDO
@@ -22,7 +23,7 @@
 //        - IRP_MJ_READ completions (backup; hidclass reads usually stop at HidBth)
 //
 // Sole filter. Do not stack with applewirelessmouse (v1 binary is a 0xD1
-// ship-blocker). This package does not bind PID 0x030D / 0x0269.
+// ship-blocker). This package does not bind PID 0x030D / 0x0269 / 0x0310.
 
 #pragma once
 
@@ -35,8 +36,11 @@
 #define MM_FILE_VERSION_STR     "2.0.4.0"
 #define MM_ARTIFACT_SYS_NAME    "MagicMouseDriver-kmdf-2.0.4-scroll.sys"
 
-// Magic Mouse 2024 / Magic Mouse 2 USB-C — the only PID this package binds.
-#define MM_PID_V3  0x0323u
+// Magic Mouse 2024 / Magic Mouse 2 USB-C, plus Magic Trackpad BT PIDs.
+#define MM_PID_V3           0x0323u
+#define MM_PID_TRACKPAD_V1  0x030Eu
+#define MM_PID_TRACKPAD_V2  0x0265u
+#define MM_PID_TRACKPAD_V3  0x0324u
 
 // IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
 // CTL_CODE(FILE_DEVICE_BLUETOOTH=0x41, Function=0x84, METHOD_BUFFERED, FILE_ANY_ACCESS)
@@ -91,6 +95,8 @@ typedef struct _DEVICE_CONTEXT
     // Mechanical click latch (2-finger right / 3-finger middle). Not a tap.
     BOOLEAN ClickHeld;
     UCHAR   ClickLatched;
+
+    ULONG   PtpScanTime;
 
     WDFTIMER    DiagTimer;
     WDFWORKITEM DiagWorkItem;

--- a/v2-kmdf-driver/GestureEngine.c
+++ b/v2-kmdf-driver/GestureEngine.c
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 // GestureEngine.c — stay on MOUSE2_REPORT_ID 0x12; add Wheel / AC Pan.
 //
-// Optical X/Y and buttons come from the 0x12 header (Linux hid-magicmouse.c
+// Optical X/Y come from the 0x12 header (Linux hid-magicmouse.c
 // magicmouse_raw_event, MOUSE2 case). Surface scroll is a simplified port of
 // magicmouse_emit_touch() TOUCH_STATE_DRAG handling for 0323 / Mouse 2.
+// Mechanical bit0 is remapped by START/DRAG count: 2 → right, 3+ → middle.
 #include "GestureEngine.h"
 
 #define MM2_BTN_MASK      0x03
@@ -112,6 +113,99 @@ AccumulateSurfaceScroll(
     WdfSpinLockRelease(ctx->Lock);
 }
 
+static ULONG
+CountActiveTouches(
+    _In_reads_bytes_(inLen) PUCHAR in,
+    _In_ SIZE_T inLen)
+{
+    ULONG n = 0;
+
+    if (inLen < MM2_HEADER_LEN) { return 0; }
+
+    ULONG nTouches = (ULONG)((inLen - MM2_HEADER_LEN) / MM2_TOUCH_BYTES);
+    for (ULONG i = 0; i < nTouches; i++)
+    {
+        ULONG off = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES;
+        if (off + MM2_TOUCH_BYTES > inLen) { break; }
+
+        UCHAR state = (UCHAR)((in + off)[7] & TOUCH_STATE_MASK);
+        if (state == TOUCH_STATE_START || state == TOUCH_STATE_DRAG)
+        {
+            n++;
+        }
+    }
+    return n;
+}
+
+static UCHAR
+MapContactCountToButtons(_In_ ULONG contacts)
+{
+    if (contacts >= 3) { return MM_BTN_MIDDLE; }
+    if (contacts == 2) { return MM_BTN_RIGHT; }
+    if (contacts == 1) { return MM_BTN_LEFT; }
+    return 0;
+}
+
+static UCHAR
+RemapMechanicalClick(
+    _In_ UCHAR hwButtons,
+    _In_ ULONG contacts,
+    _In_ BOOLEAN haveTouchBlock,
+    _In_ BOOLEAN scrolled,
+    _Inout_ PDEVICE_CONTEXT ctx)
+{
+    UCHAR out;
+    BOOLEAN mechDown = (BOOLEAN)((hwButtons & MM_BTN_LEFT) != 0);
+
+    WdfSpinLockAcquire(ctx->Lock);
+
+    if (!haveTouchBlock)
+    {
+        if (ctx->ClickHeld && mechDown)
+        {
+            out = ctx->ClickLatched;
+        }
+        else
+        {
+            ctx->ClickHeld = FALSE;
+            ctx->ClickLatched = 0;
+            out = (UCHAR)(hwButtons & MM2_BTN_MASK);
+        }
+        WdfSpinLockRelease(ctx->Lock);
+        return out;
+    }
+
+    if (!mechDown)
+    {
+        ctx->ClickHeld = FALSE;
+        ctx->ClickLatched = 0;
+        WdfSpinLockRelease(ctx->Lock);
+        return 0;
+    }
+
+    if (!ctx->ClickHeld)
+    {
+        ctx->ClickHeld = TRUE;
+        if (scrolled)
+        {
+            ctx->ClickLatched = 0;
+        }
+        else if (contacts == 0)
+        {
+            ctx->ClickLatched = (UCHAR)(hwButtons & MM2_BTN_MASK);
+        }
+        else
+        {
+            ctx->ClickLatched = MapContactCountToButtons(contacts);
+        }
+    }
+
+    out = ctx->ClickLatched;
+    WdfSpinLockRelease(ctx->Lock);
+    return out;
+}
+
+
 NTSTATUS
 TranslateMouse2ToHid(
     _In_reads_bytes_(inLen)     PUCHAR in,
@@ -142,7 +236,6 @@ TranslateMouse2ToHid(
         return STATUS_NO_MORE_ENTRIES;
     }
 
-    UCHAR buttons = (UCHAR)(in[1] & MM2_BTN_MASK);
     INT16 x16 = (inLen >= 4) ? ReadI16Le(in + 2) : 0;
     INT16 y16 = (inLen >= 6) ? ReadI16Le(in + 4) : 0;
 
@@ -158,6 +251,16 @@ TranslateMouse2ToHid(
         hwheel = (CHAR)in[6];
         wheel  = (CHAR)in[7];
     }
+
+    BOOLEAN haveTouch = (BOOLEAN)(inLen >= MM2_HEADER_LEN);
+    ULONG contacts = haveTouch ? CountActiveTouches(in, inLen) : 0;
+    BOOLEAN scrolled = (BOOLEAN)(wheel != 0 || hwheel != 0);
+    UCHAR buttons = RemapMechanicalClick(
+        (UCHAR)(in[1] & MM2_BTN_MASK),
+        contacts,
+        haveTouch,
+        scrolled,
+        ctx);
 
     out[0] = MM_REPORT_ID_MOUSE;
     out[1] = buttons;

--- a/v2-kmdf-driver/GestureEngine.c
+++ b/v2-kmdf-driver/GestureEngine.c
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+// GestureEngine.c — stay on MOUSE2_REPORT_ID 0x12; add Wheel / AC Pan.
+//
+// Optical X/Y and buttons come from the 0x12 header (Linux hid-magicmouse.c
+// magicmouse_raw_event, MOUSE2 case). Surface scroll is a simplified port of
+// magicmouse_emit_touch() TOUCH_STATE_DRAG handling for 0323 / Mouse 2.
+#include "GestureEngine.h"
+
+#define MM2_BTN_MASK      0x03
+#define TOUCH_STATE_MASK  0xF0
+#define TOUCH_STATE_START 0x30
+#define TOUCH_STATE_DRAG  0x40
+
+static __forceinline CHAR
+ClampI8(_In_ INT value)
+{
+    if (value > 127)  { return (CHAR)127; }
+    if (value < -127) { return (CHAR)-127; }
+    return (CHAR)value;
+}
+
+// Linux: x = (int)((data[3] << 24) | (data[2] << 16)) >> 16
+static __forceinline INT16
+ReadI16Le(_In_reads_(2) const UCHAR* p)
+{
+    USHORT raw = (USHORT)p[0] | (USHORT)((USHORT)p[1] << 8);
+    return (INT16)raw;
+}
+
+static VOID
+WriteI16Le(
+    _Out_writes_bytes_(2) PUCHAR p,
+    _In_ INT16 value
+    )
+{
+    p[0] = (UCHAR)((USHORT)value & 0xFF);
+    p[1] = (UCHAR)(((USHORT)value >> 8) & 0xFF);
+}
+
+// Linux: x = (tdata[1] << 28 | tdata[0] << 20) >> 20  (signed 12-bit)
+static __forceinline INT
+ReadI12Le(_In_reads_(2) const UCHAR* p)
+{
+    INT v = (INT)(((ULONG)p[1] << 28) | ((ULONG)p[0] << 20));
+    return v >> 20;
+}
+
+static VOID
+AccumulateSurfaceScroll(
+    _In_reads_bytes_(inLen) PUCHAR in,
+    _In_ SIZE_T inLen,
+    _Inout_ PDEVICE_CONTEXT ctx,
+    _Out_ PINT outWheel,
+    _Out_ PINT outHWheel)
+{
+    *outWheel  = 0;
+    *outHWheel = 0;
+
+    if (inLen < MM2_HEADER_LEN) { return; }
+
+    ULONG nTouches = (ULONG)((inLen - MM2_HEADER_LEN) / MM2_TOUCH_BYTES);
+    if (nTouches == 0) { return; }
+
+    WdfSpinLockAcquire(ctx->Lock);
+
+    for (ULONG i = 0; i < nTouches; i++)
+    {
+        ULONG off = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES;
+        if (off + MM2_TOUCH_BYTES > inLen) { break; }
+
+        PUCHAR t = in + off;
+        ULONG id = ((ULONG)t[6] << 2 | ((ULONG)t[5] >> 6)) & 0xFu;
+        if (id >= MM_TOUCH_SLOTS) { continue; }
+
+        // Linux magicmouse_emit_touch (Magic Mouse / Mouse 2 / 0323):
+        //   x = (tdata[1] << 28 | tdata[0] << 20) >> 20
+        //   y = -((tdata[2] << 24 | tdata[1] << 16) >> 20)
+        INT x = ReadI12Le(t + 0);
+        INT yPacked = (INT)(((ULONG)t[2] << 24) | ((ULONG)t[1] << 16));
+        INT y = -(yPacked >> 20);
+        UCHAR state = (UCHAR)(t[7] & TOUCH_STATE_MASK);
+
+        if (state == TOUCH_STATE_START)
+        {
+            ctx->TouchAnchorX[id] = (INT16)x;
+            ctx->TouchAnchorY[id] = (INT16)y;
+            ctx->TouchAnchorValid[id] = TRUE;
+            continue;
+        }
+
+        if (state != TOUCH_STATE_DRAG || !ctx->TouchAnchorValid[id])
+        {
+            if (state == 0x00) { ctx->TouchAnchorValid[id] = FALSE; }
+            continue;
+        }
+
+        INT stepY = (INT)ctx->TouchAnchorY[id] - y;
+        INT stepX = (INT)ctx->TouchAnchorX[id] - x;
+
+        if (stepY >= MM_SCROLL_STEP || stepY <= -MM_SCROLL_STEP)
+        {
+            *outWheel += (stepY > 0) ? 1 : -1;
+            ctx->TouchAnchorY[id] = (INT16)y;
+        }
+        if (stepX >= MM_SCROLL_STEP || stepX <= -MM_SCROLL_STEP)
+        {
+            *outHWheel += (stepX > 0) ? -1 : 1;
+            ctx->TouchAnchorX[id] = (INT16)x;
+        }
+    }
+
+    WdfSpinLockRelease(ctx->Lock);
+}
+
+NTSTATUS
+TranslateMouse2ToHid(
+    _In_reads_bytes_(inLen)     PUCHAR in,
+    _In_                        SIZE_T inLen,
+    _Out_writes_bytes_all_(MM_MOUSE_REPORT_LEN) PUCHAR out,
+    _Inout_                     PULONG outLen,
+    _Inout_                     PDEVICE_CONTEXT ctx)
+{
+    *outLen = 0;
+
+    if (in == NULL || out == NULL || ctx == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (inLen < 6 || (in[0] != MM_REPORT_ID_MOUSE && in[0] != 0x27))
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    // Compact (8) or full (14 + 8*N). Still accept >=6 so a short header
+    // yields buttons + X/Y rather than a dropped report.
+    BOOLEAN sizedOk =
+        (inLen == MM2_COMPACT_LEN) ||
+        (inLen >= MM2_HEADER_LEN && ((inLen - MM2_HEADER_LEN) % MM2_TOUCH_BYTES) == 0) ||
+        (inLen >= 6 && inLen < MM2_HEADER_LEN);
+    if (!sizedOk)
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    UCHAR buttons = (UCHAR)(in[1] & MM2_BTN_MASK);
+    INT16 x16 = (inLen >= 4) ? ReadI16Le(in + 2) : 0;
+    INT16 y16 = (inLen >= 6) ? ReadI16Le(in + 4) : 0;
+
+    INT wheel  = 0;
+    INT hwheel = 0;
+    if (inLen >= MM2_HEADER_LEN)
+    {
+        AccumulateSurfaceScroll(in, inLen, ctx, &wheel, &hwheel);
+    }
+    else if (inLen >= 8)
+    {
+        // Compact 0x12: preserve any wheel bytes already present.
+        hwheel = (CHAR)in[6];
+        wheel  = (CHAR)in[7];
+    }
+
+    out[0] = MM_REPORT_ID_MOUSE;
+    out[1] = buttons;
+    WriteI16Le(out + 2, x16);
+    WriteI16Le(out + 4, y16);
+    out[6] = (UCHAR)ClampI8(hwheel);
+    out[7] = (UCHAR)ClampI8(wheel);
+
+    *outLen = MM_MOUSE_REPORT_LEN;
+    return STATUS_SUCCESS;
+}

--- a/v2-kmdf-driver/GestureEngine.h
+++ b/v2-kmdf-driver/GestureEngine.h
@@ -14,11 +14,14 @@
 //
 // Output (8 bytes) matches the injected COL01 0x12 descriptor:
 //   [0] RID 0x12
-//   [1] buttons (bit0 left, bit1 right)
+//   [1] buttons (bit0 left, bit1 right, bit2 middle)
 //   [2..3] X INT16 LE  — native / Linux MOUSE2 optical (keep pointer)
 //   [4..5] Y INT16 LE
 //   [6] AC Pan INT8    — horizontal surface scroll
 //   [7] Wheel INT8     — vertical surface scroll (usage 0x0038)
+//
+// Mechanical click (data[1] bit 0) is remapped from 0323 START/DRAG count:
+//   1 → left, 2 → right, 3+ → middle. Touch DRAG never synthesizes a click.
 #pragma once
 #include "Driver.h"
 
@@ -35,11 +38,16 @@
 // Linux uses (64 - scroll_speed) * scroll_accel with defaults ~224.
 #define MM_SCROLL_STEP 64
 
+#define MM_BTN_LEFT    0x01
+#define MM_BTN_RIGHT   0x02
+#define MM_BTN_MIDDLE  0x04
+
 // TranslateMouse2ToHid
 //
 // Accepts RID 0x12 (MOUSE2) or RID 0x27. Always produces an 8-byte RID 0x12
 // with Wheel / AC Pan filled from the 14+8*N touch block when present.
 // Optical X/Y stay INT16 so the Apr 30 pointer path is not clamped to INT8.
+// Buttons: hardware bit0 remapped by contact count when a touch block exists.
 NTSTATUS TranslateMouse2ToHid(
     _In_reads_bytes_(inLen)     PUCHAR in,
     _In_                        SIZE_T inLen,

--- a/v2-kmdf-driver/GestureEngine.h
+++ b/v2-kmdf-driver/GestureEngine.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+//
+// Stay on RID 0x12 (MOUSE2_REPORT_ID). Do not convert to RID 0x02.
+//
+// Live HID 2026-08-30 21:23 MDT (Apr 30 MagicMouseFix AD5D244B):
+//   COL01 Input 0x12 is X/Y only. No Wheel usage 0x0038.
+//   That is why the pointer moves and scroll does not.
+//   HidBth delivers 0x12. Product battery is RID 0x90 Input on COL02,
+//   not Feature 0x47 (fails on COL01 and COL02).
+//
+// Layout from Linux drivers/hid/hid-magicmouse.c (GPL-2.0-or-later):
+//   magicmouse_raw_event() MOUSE2_REPORT_ID — size 8 or (14 + 8*N)
+//   magicmouse_emit_touch() surface-scroll (0323 uses the Mouse 2 path)
+//
+// Output (8 bytes) matches the injected COL01 0x12 descriptor:
+//   [0] RID 0x12
+//   [1] buttons (bit0 left, bit1 right)
+//   [2..3] X INT16 LE  — native / Linux MOUSE2 optical (keep pointer)
+//   [4..5] Y INT16 LE
+//   [6] AC Pan INT8    — horizontal surface scroll
+//   [7] Wheel INT8     — vertical surface scroll (usage 0x0038)
+#pragma once
+#include "Driver.h"
+
+// 1-byte RID + 13-byte header = 14 bytes with zero touch points.
+// Linux also accepts a compact 8-byte MOUSE2 report (no touch block).
+#define MM2_HEADER_LEN 14
+#define MM2_COMPACT_LEN 8
+#define MM2_TOUCH_BYTES 8
+
+#define MM_REPORT_ID_MOUSE    0x12
+#define MM_REPORT_ID_BATTERY  0x90
+
+// Surface drag distance (touch units) per Wheel detent. Conservative start;
+// Linux uses (64 - scroll_speed) * scroll_accel with defaults ~224.
+#define MM_SCROLL_STEP 64
+
+// TranslateMouse2ToHid
+//
+// Accepts RID 0x12 (MOUSE2) or RID 0x27. Always produces an 8-byte RID 0x12
+// with Wheel / AC Pan filled from the 14+8*N touch block when present.
+// Optical X/Y stay INT16 so the Apr 30 pointer path is not clamped to INT8.
+NTSTATUS TranslateMouse2ToHid(
+    _In_reads_bytes_(inLen)     PUCHAR in,
+    _In_                        SIZE_T inLen,
+    _Out_writes_bytes_all_(MM_MOUSE_REPORT_LEN) PUCHAR out,
+    _Inout_                     PULONG outLen,
+    _Inout_                     PDEVICE_CONTEXT ctx
+);

--- a/v2-kmdf-driver/HidDescriptor.c
+++ b/v2-kmdf-driver/HidDescriptor.c
@@ -15,7 +15,7 @@
 //
 // 0x12 report after injection (8 bytes):
 //   [0] RID 0x12
-//   [1] buttons
+//   [1] buttons (bit0 left, bit1 right, bit2 middle)
 //   [2..3] X INT16 LE   — same offsets as native / Linux MOUSE2
 //   [4..5] Y INT16 LE
 //   [6] AC Pan INT8     — synthesized from surface
@@ -34,14 +34,14 @@ const UCHAR g_HidDescriptor[] = {
 
     0x05, 0x09,             //   Usage Page (Button)
     0x19, 0x01,             //   Usage Minimum (Button 1)
-    0x29, 0x02,             //   Usage Maximum (Button 2)
+    0x29, 0x03,             //   Usage Maximum (Button 3)
     0x15, 0x00,             //   Logical Minimum (0)
     0x25, 0x01,             //   Logical Maximum (1)
-    0x95, 0x02,             //   Report Count (2)
+    0x95, 0x03,             //   Report Count (3)
     0x75, 0x01,             //   Report Size (1)
-    0x81, 0x02,             //   Input (Data, Var, Abs)          — 2 bits
+    0x81, 0x02,             //   Input (Data, Var, Abs)          — 3 bits
     0x95, 0x01,             //   Report Count (1)
-    0x75, 0x06,             //   Report Size (6)
+    0x75, 0x05,             //   Report Size (5)
     0x81, 0x03,             //   Input (Constant)                — pad to 8 bits
 
     0x05, 0x01,             //   Usage Page (Generic Desktop)

--- a/v2-kmdf-driver/HidDescriptor.c
+++ b/v2-kmdf-driver/HidDescriptor.c
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+//
+// HID report descriptor injected into SDP attribute 0x0206.
+//
+// Live HID 2026-08-30 21:23 MDT on Apr 30 MagicMouseFix (AD5D244B):
+//   COL01 Input 0x12 = X/Y only. Usage Wheel 0x0038 is ABSENT.
+//   That is why the pointer moves and scroll does not.
+//   COL02 HidD_GetInputReport(0x90) = [90 04 2F ...] → 47% at byte[2].
+//   Feature 0x47 fails on COL01 and COL02. Product battery is RID 0x90.
+//
+// HidBth delivers RID 0x12 to hidclass. Descriptor C (RID 0x02 + Feat 0x47)
+// is not what the live stack bound. This blob stays on 0x12 / 0x90 and ADDS
+// Wheel (GD 0x38) and AC Pan (Consumer 0x0238) to the 0x12 collection so
+// mouhid can see scroll on the same reports HidBth already forwards.
+//
+// 0x12 report after injection (8 bytes):
+//   [0] RID 0x12
+//   [1] buttons
+//   [2..3] X INT16 LE   — same offsets as native / Linux MOUSE2
+//   [4..5] Y INT16 LE
+//   [6] AC Pan INT8     — synthesized from surface
+//   [7] Wheel INT8      — synthesized from surface
+//
+// Do NOT pad with 0x00 (hidparse STATUS_ILLEGAL_INSTRUCTION).
+
+#include "HidDescriptor.h"
+
+const UCHAR g_HidDescriptor[] = {
+    // ---- COL01: Mouse, Report ID 0x12 (what HidBth actually delivers) ----
+    0x05, 0x01,             // Usage Page (Generic Desktop)
+    0x09, 0x02,             // Usage (Mouse)
+    0xA1, 0x01,             // Collection (Application)
+    0x85, 0x12,             //   Report ID (0x12)
+
+    0x05, 0x09,             //   Usage Page (Button)
+    0x19, 0x01,             //   Usage Minimum (Button 1)
+    0x29, 0x02,             //   Usage Maximum (Button 2)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0x01,             //   Logical Maximum (1)
+    0x95, 0x02,             //   Report Count (2)
+    0x75, 0x01,             //   Report Size (1)
+    0x81, 0x02,             //   Input (Data, Var, Abs)          — 2 bits
+    0x95, 0x01,             //   Report Count (1)
+    0x75, 0x06,             //   Report Size (6)
+    0x81, 0x03,             //   Input (Constant)                — pad to 8 bits
+
+    0x05, 0x01,             //   Usage Page (Generic Desktop)
+    0x09, 0x01,             //   Usage (Pointer)
+    0xA1, 0x00,             //   Collection (Physical)
+    0x16, 0x00, 0x80,       //     Logical Minimum (-32768)
+    0x26, 0xFF, 0x7F,       //     Logical Maximum (32767)
+    0x09, 0x30,             //     Usage (X)
+    0x09, 0x31,             //     Usage (Y)
+    0x75, 0x10,             //     Report Size (16)
+    0x95, 0x02,             //     Report Count (2)
+    0x81, 0x06,             //     Input (Data, Var, Rel)        — 4 bytes
+
+    0x15, 0x81,             //     Logical Minimum (-127)
+    0x25, 0x7F,             //     Logical Maximum (127)
+    0x05, 0x0C,             //     Usage Page (Consumer)
+    0x0A, 0x38, 0x02,       //     Usage (AC Pan 0x0238)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x01,             //     Report Count (1)
+    0x81, 0x06,             //     Input (Data, Var, Rel)        — byte[6]
+
+    0x05, 0x01,             //     Usage Page (Generic Desktop)
+    0x09, 0x38,             //     Usage (Wheel 0x0038)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x01,             //     Report Count (1)
+    0x81, 0x06,             //     Input (Data, Var, Rel)        — byte[7]
+    0xC0,                   //   End Collection (Physical)
+    0xC0,                   // End Collection (Application)
+
+    // ---- COL02: Battery, Report ID 0x90 Input (live: [90 04 2F ...] = 47%) ----
+    0x05, 0x01,             // Usage Page (Generic Desktop)
+    0x09, 0x06,             // Usage (Keyboard) — unused; TLC tag only
+    0x05, 0x06,             // Usage Page (Generic Device Controls)
+    0x09, 0x20,             // Usage (Battery Strength)
+    0xA1, 0x01,             // Collection (Application)
+    0x85, 0x90,             //   Report ID (0x90)
+    0x75, 0x08,             //   Report Size (8)
+    0x95, 0x01,             //   Report Count (1)
+    0x81, 0x03,             //   Input (Constant)                — byte[1] = 0x04 live
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0x64,             //   Logical Maximum (100)
+    0x09, 0x20,             //   Usage (Battery Strength)
+    0x95, 0x01,             //   Report Count (1)
+    0x81, 0x02,             //   Input (Data, Var, Abs)          — byte[2] percent
+    0xC0,                   // End Collection
+};
+
+const ULONG g_HidDescriptorSize = sizeof(g_HidDescriptor);

--- a/v2-kmdf-driver/HidDescriptor.h
+++ b/v2-kmdf-driver/HidDescriptor.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Driver.h"
+
+// Live-aligned descriptor (2026-08-30 HID on Apr 30 MagicMouseFix):
+//   COL01 Input RID 0x12 — buttons, X, Y, AC Pan, Wheel
+//   COL02 Input RID 0x90 — battery (HidD_GetInputReport; percent at byte[2])
+// Do not inject RID 0x02 / Feature 0x47 — hidclass never bound those.
+extern const UCHAR g_HidDescriptor[];
+extern const ULONG g_HidDescriptorSize;

--- a/v2-kmdf-driver/InputHandler.c
+++ b/v2-kmdf-driver/InputHandler.c
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+//
+// SdpRewrite — SDP attribute 0x0206 (HIDDescriptorList) descriptor injection.
+//
+// Called from OnSdpQueryComplete after IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
+// (0x410210) completes. Replaces the HID report descriptor with the
+// live-aligned blob (COL01 RID 0x12 + Wheel/AC Pan, COL02 RID 0x90 Input).
+//
+// SDP DataElement (Bluetooth Core Spec Vol 3 Part B §3.3):
+//   09 02 06    UINT16 attribute ID = 0x0206
+//   35 LL       outer SEQUENCE
+//     35 LL     inner SEQUENCE
+//       08 22   UINT8 HID Report Descriptor type
+//       25 NN   TEXT_STRING length
+//         <NN bytes>
+//
+// Plus the top-level AttributeLists sequence after the 8-byte
+// BTH_SDP_STREAM_RESPONSE header.
+
+#include "InputHandler.h"
+#include "HidDescriptor.h"
+
+#define SDP_TYPE_UINT8   0x08
+#define SDP_TYPE_UINT16  0x09
+#define SDP_SEQ_1B       0x35
+#define SDP_SEQ_2B       0x36
+#define SDP_STR_1B       0x25
+
+#define HID_DESC_ATTR_HI  0x02
+#define HID_DESC_ATTR_LO  0x06
+#define HID_RPT_DESC_TYPE 0x22
+
+#define SDP_SCAN_MATCH_LEN 11
+#define SDP_DESC_MAX_LEN  512
+
+static BOOLEAN
+ScanForSdpHidDescriptor(
+    _In_reads_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG    bufSize,
+    _Out_ PULONG   descOffset,
+    _Out_ PULONG   descLen)
+{
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN) { return FALSE; }
+    ULONG limit = bufSize - SDP_SCAN_MATCH_LEN;
+
+    for (ULONG i = 0; i <= limit; i++)
+    {
+        if (buf[i]     != SDP_TYPE_UINT16)  { continue; }
+        if (buf[i + 1] != HID_DESC_ATTR_HI) { continue; }
+        if (buf[i + 2] != HID_DESC_ATTR_LO) { continue; }
+
+        if (buf[i + 3] != SDP_SEQ_1B) { continue; }
+        UCHAR outerLen = buf[i + 4];
+        if (outerLen < 4) { continue; }
+        if ((ULONG)(i + 5) + outerLen > bufSize) { continue; }
+
+        if (buf[i + 5] != SDP_SEQ_1B) { continue; }
+        UCHAR innerLen = buf[i + 6];
+        if (innerLen < 4) { continue; }
+        if ((ULONG)(i + 7) + innerLen > bufSize) { continue; }
+
+        if (buf[i + 7] != SDP_TYPE_UINT8)    { continue; }
+        if (buf[i + 8] != HID_RPT_DESC_TYPE) { continue; }
+
+        if (buf[i + 9] != SDP_STR_1B) { continue; }
+        UCHAR nd = buf[i + 10];
+        if (nd == 0 || nd > SDP_DESC_MAX_LEN) { continue; }
+        if ((ULONG)(i + 11) + nd > bufSize) { continue; }
+
+        *descOffset = i + 11;
+        *descLen    = (ULONG)nd;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static NTSTATUS
+PatchSdpHidDescriptor(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG    bufSize,
+    _In_  ULONG    descOffset,
+    _In_  ULONG    descLen,
+    _Out_ PULONG   newBufUsed)
+{
+    ASSERT(descOffset >= 11);
+    if (g_HidDescriptorSize == 0) { return STATUS_INVALID_PARAMETER; }
+
+    ULONG newDescLen   = g_HidDescriptorSize;
+    ULONG innerPayload = 2 + 2 + newDescLen;
+    ULONG outerPayload = 2 + innerPayload;
+
+    if (newDescLen   > 0xFF) { return STATUS_INVALID_PARAMETER; }
+    if (innerPayload > 0xFF) { return STATUS_INVALID_PARAMETER; }
+    if (outerPayload > 0xFF) { return STATUS_INVALID_PARAMETER; }
+
+    ULONG tailOffset = descOffset + descLen;
+    if (tailOffset > bufSize) { return STATUS_INVALID_PARAMETER; }
+    ULONG tailBytes  = bufSize - tailOffset;
+    ULONG needed     = descOffset + newDescLen + tailBytes;
+    if (needed > bufSize) { return STATUS_BUFFER_TOO_SMALL; }
+
+    if (newDescLen != descLen && tailBytes > 0)
+    {
+        ULONG newTailOffset = descOffset + newDescLen;
+        RtlMoveMemory(buf + newTailOffset, buf + tailOffset, tailBytes);
+    }
+
+    if (newDescLen < descLen)
+    {
+        ULONG gapStart = descOffset + newDescLen + tailBytes;
+        ULONG gapLen   = descLen - newDescLen;
+        RtlZeroMemory(buf + gapStart, gapLen);
+    }
+
+    RtlCopyMemory(buf + descOffset, g_HidDescriptor, newDescLen);
+
+    buf[descOffset - 1] = (UCHAR)newDescLen;
+    buf[descOffset - 5] = (UCHAR)innerPayload;
+    buf[descOffset - 7] = (UCHAR)outerPayload;
+
+    // buf[0..7] = BTH_SDP_STREAM_RESPONSE; buf[8] is AttributeLists tag.
+    LONG delta = (LONG)newDescLen - (LONG)descLen;
+    if (delta != 0 && bufSize >= 11 && buf[8] == SDP_SEQ_1B)
+    {
+        LONG newTop = (LONG)(UCHAR)buf[9] + delta;
+        if (newTop >= 0 && newTop <= 0xFF)
+        {
+            buf[9] = (UCHAR)newTop;
+        }
+
+        ULONG respSize;
+        RtlCopyMemory(&respSize, buf + 4, sizeof(ULONG));
+        LONG newResp = (LONG)respSize + delta;
+        if (newResp > 0)
+        {
+            respSize = (ULONG)newResp;
+            RtlCopyMemory(buf + 4, &respSize, sizeof(ULONG));
+        }
+    }
+    else if (delta != 0 && bufSize >= 12 && buf[8] == SDP_SEQ_2B)
+    {
+        USHORT top    = (USHORT)(((USHORT)buf[9] << 8) | (USHORT)buf[10]);
+        LONG   newTop = (LONG)top + delta;
+        if (newTop >= 0 && newTop <= 0xFFFF)
+        {
+            buf[9]  = (UCHAR)((USHORT)newTop >> 8);
+            buf[10] = (UCHAR)((USHORT)newTop & 0xFF);
+        }
+
+        ULONG respSize;
+        RtlCopyMemory(&respSize, buf + 4, sizeof(ULONG));
+        LONG newResp = (LONG)respSize + delta;
+        if (newResp > 0)
+        {
+            respSize = (ULONG)newResp;
+            RtlCopyMemory(buf + 4, &respSize, sizeof(ULONG));
+        }
+    }
+
+    *newBufUsed = needed;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen)
+{
+    *newLen = bufSize;
+
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    ULONG descOffset = 0, descLen = 0;
+    if (!ScanForSdpHidDescriptor(buf, bufSize, &descOffset, &descLen))
+    {
+        return STATUS_NOT_FOUND;
+    }
+
+    DbgPrint("MM: SDP 0x0206 at buf[%lu], existing=%lu B, injecting %lu B\n",
+             descOffset, descLen, g_HidDescriptorSize);
+
+    ULONG    used = 0;
+    NTSTATUS s    = PatchSdpHidDescriptor(buf, bufSize, descOffset, descLen, &used);
+    if (!NT_SUCCESS(s))
+    {
+        DbgPrint("MM: PatchSdpHidDescriptor 0x%08X — passthrough\n", s);
+        return STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
+    DbgPrint("MM: Patch OK — SDP buffer %lu -> %lu bytes\n", bufSize, used);
+    *newLen = used;
+    return STATUS_SUCCESS;
+}

--- a/v2-kmdf-driver/InputHandler.c
+++ b/v2-kmdf-driver/InputHandler.c
@@ -80,12 +80,13 @@ PatchSdpHidDescriptor(
     _In_  ULONG    bufSize,
     _In_  ULONG    descOffset,
     _In_  ULONG    descLen,
+    _In_reads_bytes_(newDescLen) const UCHAR *desc,
+    _In_  ULONG    newDescLen,
     _Out_ PULONG   newBufUsed)
 {
     ASSERT(descOffset >= 11);
-    if (g_HidDescriptorSize == 0) { return STATUS_INVALID_PARAMETER; }
+    if (desc == NULL || newDescLen == 0) { return STATUS_INVALID_PARAMETER; }
 
-    ULONG newDescLen   = g_HidDescriptorSize;
     ULONG innerPayload = 2 + 2 + newDescLen;
     ULONG outerPayload = 2 + innerPayload;
 
@@ -112,7 +113,7 @@ PatchSdpHidDescriptor(
         RtlZeroMemory(buf + gapStart, gapLen);
     }
 
-    RtlCopyMemory(buf + descOffset, g_HidDescriptor, newDescLen);
+    RtlCopyMemory(buf + descOffset, desc, newDescLen);
 
     buf[descOffset - 1] = (UCHAR)newDescLen;
     buf[descOffset - 5] = (UCHAR)innerPayload;
@@ -162,14 +163,16 @@ PatchSdpHidDescriptor(
 }
 
 NTSTATUS
-SdpRewrite_Process(
+SdpRewrite_ProcessEx(
     _Inout_updates_bytes_(bufSize) PUCHAR  buf,
     _In_  ULONG  bufSize,
-    _Out_ PULONG newLen)
+    _Out_ PULONG newLen,
+    _In_reads_bytes_(descSize) const UCHAR *desc,
+    _In_  ULONG  descSize)
 {
     *newLen = bufSize;
 
-    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN)
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN || desc == NULL || descSize == 0)
     {
         return STATUS_INVALID_PARAMETER;
     }
@@ -181,10 +184,11 @@ SdpRewrite_Process(
     }
 
     DbgPrint("MM: SDP 0x0206 at buf[%lu], existing=%lu B, injecting %lu B\n",
-             descOffset, descLen, g_HidDescriptorSize);
+             descOffset, descLen, descSize);
 
     ULONG    used = 0;
-    NTSTATUS s    = PatchSdpHidDescriptor(buf, bufSize, descOffset, descLen, &used);
+    NTSTATUS s    = PatchSdpHidDescriptor(buf, bufSize, descOffset, descLen,
+                                          desc, descSize, &used);
     if (!NT_SUCCESS(s))
     {
         DbgPrint("MM: PatchSdpHidDescriptor 0x%08X — passthrough\n", s);
@@ -194,4 +198,14 @@ SdpRewrite_Process(
     DbgPrint("MM: Patch OK — SDP buffer %lu -> %lu bytes\n", bufSize, used);
     *newLen = used;
     return STATUS_SUCCESS;
+}
+
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen)
+{
+    return SdpRewrite_ProcessEx(buf, bufSize, newLen,
+                                g_HidDescriptor, g_HidDescriptorSize);
 }

--- a/v2-kmdf-driver/InputHandler.h
+++ b/v2-kmdf-driver/InputHandler.h
@@ -5,7 +5,7 @@
 #include <wdf.h>
 
 // Scan an SDP attribute response for HIDDescriptorList (0x0206) and replace
-// the embedded report descriptor with g_HidDescriptor[].
+// the embedded report descriptor.
 //
 // Returns:
 //   STATUS_SUCCESS                   — patched; *newLen = new byte count
@@ -17,3 +17,11 @@ SdpRewrite_Process(
     _Inout_updates_bytes_(bufSize) PUCHAR  buf,
     _In_  ULONG  bufSize,
     _Out_ PULONG newLen);
+
+NTSTATUS
+SdpRewrite_ProcessEx(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen,
+    _In_reads_bytes_(descSize) const UCHAR *desc,
+    _In_  ULONG  descSize);

--- a/v2-kmdf-driver/InputHandler.h
+++ b/v2-kmdf-driver/InputHandler.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+// Scan an SDP attribute response for HIDDescriptorList (0x0206) and replace
+// the embedded report descriptor with g_HidDescriptor[].
+//
+// Returns:
+//   STATUS_SUCCESS                   — patched; *newLen = new byte count
+//   STATUS_NOT_FOUND                 — 0x0206 not present (normal)
+//   STATUS_MORE_PROCESSING_REQUIRED  — pattern found, patch rejected
+//   STATUS_INVALID_PARAMETER         — buf NULL or too small
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen);

--- a/v2-kmdf-driver/Install-KMDF.cmd
+++ b/v2-kmdf-driver/Install-KMDF.cmd
@@ -1,0 +1,10 @@
+@echo off
+REM One click. First time: accept the Administrator prompt (registers a SYSTEM task).
+REM Later clicks: no prompt — the task just runs.
+cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Install-KMDF.ps1"
+echo.
+echo Result file: C:\ProgramData\MagicMouseDriver\RESULT.txt
+echo Log:         C:\ProgramData\MagicMouseDriver\install.log
+echo.
+pause

--- a/v2-kmdf-driver/Install-KMDF.ps1
+++ b/v2-kmdf-driver/Install-KMDF.ps1
@@ -5,7 +5,7 @@ One click for a non-technical user: register a SYSTEM task and install MagicMous
 .DESCRIPTION
 Double-click Install-KMDF.cmd. The first run asks for Administrator once so it can
 register MM-Kmdf-Install and MM-Kmdf-PostBoot as SYSTEM. After that, this script
-only starts the task — no UAC.
+only starts the task - no UAC.
 
 The SYSTEM task builds if needed, self-signs, installs, binds 0323 only
 (LowerFilters=MagicMouseDriver, no applewirelessmouse, no 030D), bounces
@@ -92,7 +92,7 @@ function Register-KmdfSystemTasks {
         -Action $installAction `
         -Principal $principal `
         -Settings $installSettings `
-        -Description 'MagicMouseDriver KMDF one-click install (PID 0323 only). Trigger with schtasks /run — no UAC after first register.' `
+        -Description 'MagicMouseDriver KMDF one-click install (PID 0323 only). Trigger with schtasks /run - no UAC after first register.' `
         -Force | Out-Null
 
     Register-ScheduledTask -TaskName $script:KmdfTaskPostBoot `
@@ -145,7 +145,7 @@ function Uninstall-KmdfPackage {
     Write-Host "Uninstall finished. Reboot if the mouse stack looks stuck." -ForegroundColor Green
 }
 
-# --- later clicks: task already there → no UAC ---
+# --- later clicks: task already there -> no UAC ---
 if (-not $Uninstall) {
     $existing = Get-ScheduledTask -TaskName $script:KmdfTaskInstall -ErrorAction SilentlyContinue
     if ($existing) {

--- a/v2-kmdf-driver/Install-KMDF.ps1
+++ b/v2-kmdf-driver/Install-KMDF.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+One click for a non-technical user: register a SYSTEM task and install MagicMouseDriver for PID 0323.
+
+.DESCRIPTION
+Double-click Install-KMDF.cmd. The first run asks for Administrator once so it can
+register MM-Kmdf-Install and MM-Kmdf-PostBoot as SYSTEM. After that, this script
+only starts the task — no UAC.
+
+The SYSTEM task builds if needed, self-signs, installs, binds 0323 only
+(LowerFilters=MagicMouseDriver, no applewirelessmouse, no 030D), bounces
+Bluetooth, reboots if test signing just changed, then post-boot verifies.
+
+Results: C:\ProgramData\MagicMouseDriver\RESULT.txt
+Logs:    C:\ProgramData\MagicMouseDriver\install.log
+
+.PARAMETER Uninstall
+Remove the SYSTEM tasks, unbind 0323, delete the KMDF package.
+
+.PARAMETER NoElevate
+Internal. Set when relaunched via UAC so we do not loop.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Uninstall,
+    [switch]$NoElevate
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $Here 'scripts\Kmdf-Common.ps1')
+
+function Start-KmdfInstallTask {
+    Write-Host ""
+    Write-Host "Starting SYSTEM task '$script:KmdfTaskInstall' (no approval prompt)..." -ForegroundColor Cyan
+    & schtasks.exe /run /tn $script:KmdfTaskInstall
+    if ($LASTEXITCODE -ne 0) { return $false }
+    Write-Host "The installer is running in the background as SYSTEM." -ForegroundColor Green
+    Write-Host "Watch:  $script:KmdfResult" -ForegroundColor Yellow
+    Write-Host "Log:    $script:KmdfLog" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "The PC may reboot by itself if test signing was just turned on." -ForegroundColor Yellow
+    Write-Host "After reboot, RESULT.txt is the pass/fail." -ForegroundColor Yellow
+    return $true
+}
+
+function Copy-KmdfPackageToProgramFiles {
+    Initialize-KmdfDataDir
+    if (-not (Test-Path -LiteralPath $script:KmdfInstallDir)) {
+        New-Item -ItemType Directory -Path $script:KmdfInstallDir -Force | Out-Null
+    }
+    Write-Host "Copying KMDF package to $script:KmdfInstallDir" -ForegroundColor Gray
+    Copy-Item -Path (Join-Path $Here '*') -Destination $script:KmdfInstallDir -Recurse -Force
+    icacls.exe "$script:KmdfInstallDir" /inheritance:r /grant 'SYSTEM:(OI)(CI)F' /grant 'Administrators:(OI)(CI)F' /grant 'Users:(OI)(CI)RX' | Out-Null
+}
+
+function Register-KmdfSystemTasks {
+    $installPs1  = Join-Path $script:KmdfInstallDir 'scripts\Invoke-KmdfInstall.ps1'
+    $postBootPs1 = Join-Path $script:KmdfInstallDir 'scripts\Invoke-KmdfPostBoot.ps1'
+    if (-not (Test-Path -LiteralPath $installPs1))  { throw "Missing $installPs1" }
+    if (-not (Test-Path -LiteralPath $postBootPs1)) { throw "Missing $postBootPs1" }
+
+    $installAction = New-ScheduledTaskAction -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$installPs1`" -PackageRoot `"$script:KmdfInstallDir`""
+    $postAction = New-ScheduledTaskAction -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$postBootPs1`""
+
+    $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+
+    $installSettings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 30) `
+        -MultipleInstances IgnoreNew `
+        -Hidden
+
+    $postSettings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 15) `
+        -MultipleInstances IgnoreNew `
+        -Hidden
+
+    $startup = New-ScheduledTaskTrigger -AtStartup
+    $startup.Delay = 'PT45S'
+
+    Register-ScheduledTask -TaskName $script:KmdfTaskInstall `
+        -Action $installAction `
+        -Principal $principal `
+        -Settings $installSettings `
+        -Description 'MagicMouseDriver KMDF one-click install (PID 0323 only). Trigger with schtasks /run — no UAC after first register.' `
+        -Force | Out-Null
+
+    Register-ScheduledTask -TaskName $script:KmdfTaskPostBoot `
+        -Action $postAction `
+        -Principal $principal `
+        -Settings $postSettings `
+        -Trigger $startup `
+        -Description 'MagicMouseDriver KMDF post-boot verify (PID 0323 stack + service).' `
+        -Force | Out-Null
+
+    Write-Host "Registered SYSTEM tasks: $script:KmdfTaskInstall , $script:KmdfTaskPostBoot" -ForegroundColor Green
+}
+
+function Unregister-KmdfSystemTasks {
+    foreach ($n in @($script:KmdfTaskInstall, $script:KmdfTaskPostBoot)) {
+        Unregister-ScheduledTask -TaskName $n -Confirm:$false -ErrorAction SilentlyContinue
+        Write-Host "Removed task $n" -ForegroundColor Gray
+    }
+}
+
+function Uninstall-KmdfPackage {
+    Write-Host "Unbinding PID 0323 and removing MagicMouseDriver..." -ForegroundColor Yellow
+    $mice = @(Get-Kmdf0323Device)
+    foreach ($m in $mice) {
+        $rp = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($m.InstanceId)"
+        try {
+            $lf = @((Get-ItemProperty -LiteralPath $rp -ErrorAction Stop).LowerFilters)
+            $new = @($lf | Where-Object { $_ -ne 'MagicMouseDriver' })
+            if ($new.Count -gt 0) {
+                Set-ItemProperty -LiteralPath $rp -Name LowerFilters -Value $new -Type MultiString
+            } else {
+                Remove-ItemProperty -LiteralPath $rp -Name LowerFilters -ErrorAction SilentlyContinue
+            }
+            & pnputil.exe /restart-device $m.InstanceId 2>&1 | Out-Null
+        } catch {
+            Write-Host "  $($m.InstanceId): $_" -ForegroundColor Yellow
+        }
+    }
+
+    $pnpRaw = & pnputil.exe /enum-drivers 2>$null | Out-String
+    $oems = ($pnpRaw -split '(?=Published Name:)') |
+        Where-Object { $_ -match 'MagicMouseDriver\.inf' } |
+        ForEach-Object { if ($_ -match 'Published Name:\s+(oem\d+\.inf)') { $Matches[1] } }
+    foreach ($oem in $oems) {
+        & pnputil.exe /delete-driver $oem /uninstall /force 2>&1 | Out-Null
+    }
+
+    & sc.exe stop MagicMouseDriver 2>&1 | Out-Null
+    & sc.exe delete MagicMouseDriver 2>&1 | Out-Null
+    Write-Host "Uninstall finished. Reboot if the mouse stack looks stuck." -ForegroundColor Green
+}
+
+# --- later clicks: task already there → no UAC ---
+if (-not $Uninstall) {
+    $existing = Get-ScheduledTask -TaskName $script:KmdfTaskInstall -ErrorAction SilentlyContinue
+    if ($existing) {
+        if (Start-KmdfInstallTask) { exit 0 }
+        Write-Host "Could not start the existing task (exit $LASTEXITCODE). Will elevate and repair registration." -ForegroundColor Yellow
+    }
+}
+
+if (-not (Test-KmdfIsAdmin) -and -not $NoElevate) {
+    Write-Host "First run needs Administrator once to register the SYSTEM task." -ForegroundColor Yellow
+    $relaunch = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath, '-NoElevate')
+    if ($Uninstall) { $relaunch += '-Uninstall' }
+    $proc = Start-Process -FilePath 'powershell.exe' -ArgumentList $relaunch -Verb RunAs -Wait -PassThru
+    exit $proc.ExitCode
+}
+
+if (-not (Test-KmdfIsAdmin)) {
+    Write-Host "Administrator approval was cancelled. Nothing was installed." -ForegroundColor Red
+    exit 2
+}
+
+if ($Uninstall) {
+    Unregister-KmdfSystemTasks
+    Uninstall-KmdfPackage
+    Write-KmdfResult -Status 'FAIL' -Detail 'Uninstalled by user.'
+    exit 0
+}
+
+Copy-KmdfPackageToProgramFiles
+Register-KmdfSystemTasks
+if (-not (Start-KmdfInstallTask)) {
+    Write-Host "schtasks /run failed after registration." -ForegroundColor Red
+    exit 1
+}
+exit 0

--- a/v2-kmdf-driver/MAGIC-TRAY.md
+++ b/v2-kmdf-driver/MAGIC-TRAY.md
@@ -1,0 +1,25 @@
+# magic-tray: install this KMDF for 0323
+
+Magic Tray treats **this repo / `v2-kmdf-driver/`** as the 0323 driver. Clone `main` and run `v2-kmdf-driver/Install-KMDF.cmd`.
+
+## Do
+
+- Offer **Install KMDF** that clones or downloads `magic-mouse-v3-windows-fix` and starts `v2-kmdf-driver/Install-KMDF.cmd` (or `schtasks /run /tn MM-Kmdf-Install` after first register).
+- Bind **PID 0323 only**.
+- Keep `LowerFilters=MagicMouseDriver` **sole**.
+
+## Do not
+
+- Vendor this tree into `magic-tray/driver/`.
+- Default 0323 to `sbagirici/apple-magic-mouse-scroll-fix-windows` or Boot Camp `applewirelessmouse.sys`.
+- Dual-filter with `applewirelessmouse` (v1 binary is a BSOD 0xD1 ship-blocker).
+- Retarget 030D / 0269 with this INF.
+- Call leftover `mm-dev.ps1 -Phase Full`.
+- Install a May 20 / PATH-A / dual-filter binary.
+- Treat PATH-A / May 20 as installable 0323 products.
+- Ship or install `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys` as `MagicMouseDriver.sys`.
+- Ship May 20 as `MagicMouseDriver-kmdf-2.0.4-scroll.sys`.
+
+Tray SELECT for 0323 should pull **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** (FileVersion 2.0.4.0; INF dest `MagicMouseDriver.sys`). Leave **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** as the pointer-only baseline. Refuse **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`**. PATH-A stays in `v1-binary-patch/` as **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`**.
+
+Live HID 2026-08-30 21:23 MDT (Apr 30 `AD5D244B`, do not replace that `.sys` yet): battery is RID **0x90** Input on COL02; Feat **0x47** fails; COL01 Input **0x12** is X/Y only (no `0x0038`). Tray should ship the 2.0.4 source that stays on that 0x12 path.

--- a/v2-kmdf-driver/MagicMouseDriver.inf
+++ b/v2-kmdf-driver/MagicMouseDriver.inf
@@ -1,0 +1,89 @@
+; MagicMouseDriver.inf
+; SPDX-License-Identifier: MIT
+;
+; KMDF lower filter for Apple Magic Mouse PID 0x0323 only
+; (2024 / Magic Mouse 2 USB-C over Bluetooth).
+;
+; Stack: HidBth → MagicMouseDriver → BthEnum
+;
+; Live HID 2026-08-30 21:23 MDT (Apr 30 MagicMouseFix AD5D244B):
+;   COL01 Input 0x12 = X/Y only (no Wheel 0x0038) — pointer OK, scroll dead.
+;   COL02 Input 0x90 = battery (HidD_GetInputReport; percent at byte[2]).
+;   Feature 0x47 fails on COL01/COL02. Product is 0x12+wheel / 0x90, not 0x02/0x47.
+;
+; Sole filter. Do NOT install alongside applewirelessmouse
+; (that binary is a BSOD 0xD1 ship-blocker on this PID).
+; This INF does not bind 0x030D / 0x0269 / 0x0310.
+;
+; Install: double-click Install-KMDF.cmd (registers a SYSTEM task).
+; Manual:  pnputil /add-driver MagicMouseDriver.inf /install
+;
+; Windows / INF / service file name is MagicMouseDriver.sys (do not change).
+; Package artifact for this DriverVer is MagicMouseDriver-kmdf-2.0.4-scroll.sys
+; (FileVersion 2.0.4.0). Do not confuse with:
+;   MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys     pointer-only
+;   MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys pointer-dead
+;   applewirelessmouse-patched-pathA-SHIPBLOCKER.sys     PATH-A, not this product
+
+[Version]
+Signature   = "$WINDOWS NT$"
+Class       = HIDClass
+ClassGUID   = {745A17A0-74D3-11D0-B6FE-00A0C90F57DA}
+Provider    = %ManufacturerName%
+DriverPackageDisplayName = %DeviceDesc%
+DriverPackageType = PlugAndPlay
+DriverVer   = 08/31/2026,2.0.4.0
+CatalogFile = MagicMouseDriver.cat
+PnpLockdown = 1
+
+[DestinationDirs]
+DefaultDestDir = 12
+
+[Manufacturer]
+%ManufacturerName% = MagicMouseDriver, NTamd64
+
+[MagicMouseDriver.NTamd64]
+; PID 0x0323 only — VID 0x004C (Apple Bluetooth)
+%DeviceDesc% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+
+[MagicMouseDriver_Install.NT]
+Include   = hidbth.inf
+Needs     = HIDBTH_Inst.NT
+CopyFiles = MagicMouseDriver_Copy
+
+[MagicMouseDriver_Copy]
+MagicMouseDriver.sys
+
+[MagicMouseDriver_Install.NT.HW]
+AddReg  = MagicMouseDriver_AddReg
+Include = input.inf
+Needs   = HID_Inst.NT.HW
+
+[MagicMouseDriver_AddReg]
+; 0x00010000 = FLG_ADDREG_TYPE_MULTI_SZ — replaces any previous LowerFilters.
+HKR,,"LowerFilters",0x00010000,"MagicMouseDriver"
+HKLM,"SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Parameters","EnableInjection",0x00010001,1
+
+[MagicMouseDriver_Install.NT.Services]
+Include    = hidbth.inf
+Needs      = HIDBTH_Inst.NT.Services
+AddService = MagicMouseDriver, , MagicMouseDriver_Service_Inst
+
+[MagicMouseDriver_Service_Inst]
+DisplayName   = %ServiceDesc%
+ServiceType   = 1
+StartType     = 3
+ErrorControl  = 1
+ServiceBinary = %12%\MagicMouseDriver.sys
+
+[SourceDisksNames]
+1 = %DiskName%,,,""
+
+[SourceDisksFiles]
+MagicMouseDriver.sys = 1,,
+
+[Strings]
+ManufacturerName = "Magic Mouse Driver"
+DeviceDesc       = "Apple Magic Mouse (PID 0323) KMDF filter"
+ServiceDesc      = "MagicMouseDriver (0323 KMDF lower filter)"
+DiskName         = "Magic Mouse Driver Installation Disk"

--- a/v2-kmdf-driver/MagicMouseDriver.inf
+++ b/v2-kmdf-driver/MagicMouseDriver.inf
@@ -1,9 +1,8 @@
 ; MagicMouseDriver.inf
 ; SPDX-License-Identifier: MIT
 ;
-; KMDF lower filter for Apple Magic Mouse PID 0x0323 only
-; (2024 / Magic Mouse 2 USB-C over Bluetooth).
-;
+; KMDF lower filter for Apple Magic Mouse PID 0x0323 and Magic Trackpad
+; PIDs 0x030E / 0x0265 / 0x0324 (PTP tap). Does not bind 0x030D / 0x0269 / 0x0310.
 ; Stack: HidBth → MagicMouseDriver → BthEnum
 ;
 ; Live HID 2026-08-30 21:23 MDT (Apr 30 MagicMouseFix AD5D244B):
@@ -43,8 +42,11 @@ DefaultDestDir = 12
 %ManufacturerName% = MagicMouseDriver, NTamd64
 
 [MagicMouseDriver.NTamd64]
-; PID 0x0323 only — VID 0x004C (Apple Bluetooth)
+; PID 0x0323 — VID 0x004C (Apple Bluetooth)
 %DeviceDesc% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+%TrackpadV1Desc% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&030E
+%TrackpadV2Desc% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0265
+%TrackpadV3Desc% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0324
 
 [MagicMouseDriver_Install.NT]
 Include   = hidbth.inf
@@ -85,5 +87,8 @@ MagicMouseDriver.sys = 1,,
 [Strings]
 ManufacturerName = "Magic Mouse Driver"
 DeviceDesc       = "Apple Magic Mouse (PID 0323) KMDF filter"
-ServiceDesc      = "MagicMouseDriver (0323 KMDF lower filter)"
+TrackpadV1Desc   = "Apple Magic Trackpad (PID 030E) KMDF PTP filter"
+TrackpadV2Desc   = "Apple Magic Trackpad 2 (PID 0265) KMDF PTP filter"
+TrackpadV3Desc   = "Apple Magic Trackpad 2024 (PID 0324) KMDF PTP filter"
+ServiceDesc      = "MagicMouseDriver (0323 / trackpad KMDF lower filter)"
 DiskName         = "Magic Mouse Driver Installation Disk"

--- a/v2-kmdf-driver/MagicMouseDriver.rc
+++ b/v2-kmdf-driver/MagicMouseDriver.rc
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+//
+// FileVersion 2.0.4.0 — KMDF scroll candidate only.
+// Package / artifact name: MagicMouseDriver-kmdf-2.0.4-scroll.sys
+// Windows / INF install name stays MagicMouseDriver.sys (do not change).
+//
+// Distinct from:
+//   MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys   pointer-only (not 2.0.4.0)
+//   MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys  FileVersion 2.0.2.0, refuse
+//   applewirelessmouse-patched-pathA-SHIPBLOCKER.sys   PATH-A, never this product
+
+#include <windows.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    2,0,4,0
+ PRODUCTVERSION 2,0,4,0
+ FILEFLAGSMASK  0x3fL
+#ifdef _DEBUG
+ FILEFLAGS      0x1L
+#else
+ FILEFLAGS      0x0L
+#endif
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_DRV
+ FILESUBTYPE    VFT2_DRV_SYSTEM
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName",      "Magic Mouse Driver"
+            VALUE "FileDescription",  "KMDF 2.0.4 scroll candidate (PID 0323). Installs as MagicMouseDriver.sys."
+            VALUE "FileVersion",      "2.0.4.0"
+            VALUE "InternalName",     "MagicMouseDriver-kmdf-2.0.4-scroll"
+            VALUE "LegalCopyright",   "MIT"
+            VALUE "OriginalFilename", "MagicMouseDriver-kmdf-2.0.4-scroll.sys"
+            VALUE "ProductName",      "MagicMouseDriver KMDF 2.0.4 scroll"
+            VALUE "ProductVersion",   "2.0.4.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/v2-kmdf-driver/MagicMouseDriver.sln
+++ b/v2-kmdf-driver/MagicMouseDriver.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MagicMouseDriver", "MagicMouseDriver.vcxproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/v2-kmdf-driver/MagicMouseDriver.vcxproj
+++ b/v2-kmdf-driver/MagicMouseDriver.vcxproj
@@ -75,6 +75,7 @@
     <ClCompile Include="HidDescriptor.c" />
     <ClCompile Include="InputHandler.c" />
     <ClCompile Include="AclTranslate.c" />
+    <ClCompile Include="TrackpadPtp.c" />
   </ItemGroup>
 
   <ItemGroup>
@@ -83,6 +84,7 @@
     <ClInclude Include="HidDescriptor.h" />
     <ClInclude Include="InputHandler.h" />
     <ClInclude Include="AclTranslate.h" />
+    <ClInclude Include="TrackpadPtp.h" />
   </ItemGroup>
 
   <ItemGroup>

--- a/v2-kmdf-driver/MagicMouseDriver.vcxproj
+++ b/v2-kmdf-driver/MagicMouseDriver.vcxproj
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  KMDF MagicMouseDriver — PID 0x0323 only.
+
+  Build (Windows + WDK or mounted EWDK):
+    msbuild MagicMouseDriver.vcxproj /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off
+
+  Or double-click Install-KMDF.cmd — it builds if a .sys is missing and EWDK/WDK exists.
+
+  Linux cannot produce a .sys. WDK output is MagicMouseDriver.sys (INF/service name).
+  Copy the artifact to MagicMouseDriver-kmdf-2.0.4-scroll.sys (FileVersion 2.0.4.0).
+  Never name a KMDF build applewirelessmouse*.sys.
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <TargetName>MagicMouseDriver</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <DriverType>KMDF</DriverType>
+    <KmdfVersionMajor>1</KmdfVersionMajor>
+    <KmdfVersionMinor>33</KmdfVersionMinor>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+      <Driver>WDM</Driver>
+      <AdditionalDependencies>wdmguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="Driver.c" />
+    <ClCompile Include="GestureEngine.c" />
+    <ClCompile Include="HidDescriptor.c" />
+    <ClCompile Include="InputHandler.c" />
+    <ClCompile Include="AclTranslate.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Driver.h" />
+    <ClInclude Include="GestureEngine.h" />
+    <ClInclude Include="HidDescriptor.h" />
+    <ClInclude Include="InputHandler.h" />
+    <ClInclude Include="AclTranslate.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Inf Include="MagicMouseDriver.inf" />
+    <ResourceCompile Include="MagicMouseDriver.rc" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(WDKContentRoot)\build\WindowsDriver.targets"
+          Condition="Exists('$(WDKContentRoot)\build\WindowsDriver.targets')" />
+
+</Project>

--- a/v2-kmdf-driver/README.md
+++ b/v2-kmdf-driver/README.md
@@ -1,287 +1,79 @@
-# v2.0.0 — KMDF Driver (Work in Progress)
+# MagicMouseDriver (KMDF) — PID 0x0323 only
 
-**STATUS: WORK IN PROGRESS — NOT PRODUCTION READY**
+**This is the 0323 product.** Double-click `Install-KMDF.cmd`. Success is **pointer and vertical/horizontal surface scroll**.
 
-This directory contains the roadmap and architecture for v2.0.0, a from-scratch KMDF (Kernel Mode Driver Framework) filter driver implementation. v2 replaces the v1 binary patch with native source code, eliminating dependency on Apple firmware patching.
+Magic Tray clones this repo’s `main` branch and runs **`v2-kmdf-driver/Install-KMDF.cmd`**. Do not vendor this tree into `magic-tray`. There is no prebuilt `.sys` on GitHub (Linux cannot compile a kernel driver); on Windows the one-click task builds FileVersion **2.0.4.0** when a WDK/EWDK is present.
 
-## Why v2?
+Windows still installs KMDF as **`MagicMouseDriver.sys`**. Package names are different so they cannot be mixed with PATH-A:
 
-### v1 Limitations
+| Package / backup filename | FileVersion | Role |
+|---------------------------|-------------|------|
+| **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`** | not 2.0.4.0 | **Pointer-only.** SHA `AD5D244B…`. Scroll dead. Leave on the live PC. |
+| **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`** | 2.0.2.0 | **Pointer-dead.** Installer refuses this SHA. |
+| **`MagicMouseDriver-kmdf-2.0.4-scroll.sys`** | **2.0.4.0** | **Scroll candidate** from this source. Hash after Windows WDK build. |
+| **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`** | PATH-A v1 | **SHIP-BLOCKER.** Lives in `v1-binary-patch/`. Never this product. Never `MagicMouseDriver.sys`. |
 
-| Issue | v1 Binary Patch | v2 KMDF Source |
-|-------|---|---|
-| Transparency | Binary only (opaque) | Full source code |
-| Apple dependency | Patches Apple firmware | Independent implementation |
-| Signing | Self-signed cert | Windows-signed (future) |
-| Maintainability | Requires re-patching firmware | Direct source modifications |
-| SmartScreen | Warnings on new systems | Better reputation over time |
-| Compliance | Custom certificate trust | Standard driver signing |
+Do not install PATH-A. Do not install May 20. Do not stack filters. No dual-filter.
 
-### v2 Advantages
+Magic Tray SELECT for 0323 must pull this package and run `Install-KMDF.cmd`. Do not vendor the KMDF tree into `magic-tray`.
 
-1. **Open source:** Full implementation visible for audit and modification
-2. **No Apple dependency:** Standalone KMDF driver, no firmware patching
-3. **Better signing:** Compatible with Microsoft code signing and certification
-4. **Cleaner deployment:** No custom certificate imports, standard Windows driver model
-5. **Long-term support:** Source code can be maintained across Windows versions
-6. **Transparency:** Security research and third-party review possible
+## One click
 
-## Architecture
+1. Clone this repo on Windows.
+2. Double-click **`v2-kmdf-driver/Install-KMDF.cmd`**.
+3. The **first** run asks for Administrator **once**. That registers two SYSTEM scheduled tasks (`MM-Kmdf-Install`, `MM-Kmdf-PostBoot`). Later clicks only run the task — **no UAC**.
+4. The SYSTEM task then, unattended:
+   - Builds `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion 2.0.4.0) if it is missing and a WDK/EWDK is installed, then stages it as `MagicMouseDriver.sys` for INF
+   - Turns on test signing if needed
+   - Creates a local `CN=MagicMouseDriver` certificate, signs `.sys` + `.cat`, trusts the publisher
+   - `pnputil` installs the package
+   - Binds **PID 0323 only**, `LowerFilters=MagicMouseDriver` **sole** (never `applewirelessmouse`, never 030D)
+   - Bounces Bluetooth (disable then enable the radio, then restart the 0323 node)
+   - Reboots if test signing just changed or PnP asked for it
+   - After boot, `MM-Kmdf-PostBoot` checks: service Running, stack `HidBth` / `MagicMouseDriver`, HID started
+5. Read **`C:\ProgramData\MagicMouseDriver\RESULT.txt`** — `PASS` or `FAIL`.
 
-### KMDF vs WDM
+Uninstall: double-click `Uninstall-KMDF.cmd`.
 
-| Aspect | v1 (WDM Lower Filter) | v2 (KMDF Filter) |
-|--------|---|---|
-| Framework | Windows Driver Model (WDM) | Kernel Mode Driver Framework (KMDF) |
-| Code size | ~66 KB binary | ~150 KB source (compiled similar size) |
-| Complexity | Direct IRP handling | Object-oriented framework |
-| Debuggability | Standard kernel debugging | KMDF-aware tools |
-| Best practice | Older, but functional | Modern Windows driver development |
+## Honest limits
 
-### File Structure
+| Topic | What actually happens |
+|-------|------------------------|
+| **No `.sys` on GitHub** | This environment cannot compile a kernel driver. The repo ships **source + INF + vcxproj + the one-click scripts**. On Windows + WDK the SYSTEM task builds `MagicMouseDriver-kmdf-2.0.4-scroll.sys` (FileVersion 2.0.4.0) and INF copies it as `MagicMouseDriver.sys`. |
+| **Test signing** | A self-signed `.sys` will not load until `bcdedit /set testsigning on` and a reboot. A "Test Mode" watermark on the desktop is expected. |
+| **HVCI / Memory Integrity** | Windows 11 Core isolation **blocks** self-signed kernel drivers. The task **fails** with a clear RESULT if HVCI is on. Turn Memory integrity **off**, reboot, click again. There is no Microsoft-signed binary in this repo yet. |
+| **Apr 30 live KMDF** | Package name **`MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys`**. Installed as `MagicMouseDriver.sys`, 24536 bytes, SHA256 `AD5D244B…`, `CN=MagicMouseFix` thumb `B902C286…`. **Pointer-only.** Keep installed. FileVersion is **not** 2.0.4.0. |
+| **Live HID 2026-08-30 21:23 MDT** | On that Apr 30 binary: `HidD_GetInputReport(0x90)` on **COL02** works (`[90 04 2F …]` → 47% at `buf[2]`). **Feat 0x47 fails** on COL01 and COL02. **COL01 Input 0x12 is X/Y only** — no Wheel usage `0x0038`. All other InRpt/Feat fail. Product battery = RID **0x90**, not 0x47. Product scroll = Wheel/AC Pan on the **0x12** path HidBth delivers, not a convert-to-0x02. |
+| **May 20 WDKTestCert** | Package name **`MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys`**. 29184 bytes, SHA256 `559B136A…`, FileVersion **2.0.2.0**. HID started, **pointer dead**. The one-click task **refuses** it. |
+| **PATH-A** | Package name **`applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`**. Windows name `applewirelessmouse.sys`. **SHIP-BLOCKER** (BSOD 0xD1). Not the 0323 product. |
+
+## What magic-tray should install
+
+For **0323** (live USB-C Magic Mouse):
+
+- Source of truth: `LesleyMurfin/magic-mouse-v3-windows-fix` / `v2-kmdf-driver/`
+- User action in the tray: same as `Install-KMDF.cmd` (register/start `MM-Kmdf-Install`), **or** download this folder and run that cmd
+- Do **not** default 0323 to `sbagirici` / Boot Camp `applewirelessmouse.sys`
+- Do **not** copy this tree into `magic-tray/driver/`
+
+## Layout
 
 ```
 v2-kmdf-driver/
-├── README.md (this file)
-├── src/
-│   ├── main.c            # DriverEntry, device creation
-│   ├── filter.c          # Filter dispatch routines
-│   ├── magic_mouse.c     # Magic Mouse-specific logic
-│   ├── ioctl_handlers.c  # Device I/O control handling
-│   └── common.h          # Shared definitions
-├── inc/
-│   ├── filter.h
-│   ├── magic_mouse.h
-│   └── version.h
-├── magic_mouse_v3.vcxproj    # Visual Studio project
-├── magic_mouse_v3.sln        # Visual Studio solution
-├── build.cmd                 # Build script
-├── BUILDING.md               # Build instructions
-└── docs/
-    ├── KMDF_MIGRATION.md     # Migration notes from WDM
-    └── TEST_PLAN.md          # Comprehensive test plan
+  Install-KMDF.cmd          ← one click
+  Install-KMDF.ps1          ← register/start SYSTEM task (UAC once)
+  Uninstall-KMDF.cmd
+  MagicMouseDriver.inf      ← 0323 only
+  MagicMouseDriver.vcxproj
+  Driver.c / GestureEngine.c / AclTranslate.c / ...
+  scripts/
+    Invoke-KmdfInstall.ps1  ← runs as SYSTEM
+    Invoke-KmdfPostBoot.ps1
+    Kmdf-Common.ps1
 ```
 
-## Development Status
+There is **no** `mm-dev.ps1` and **no** `Phase=Full` that `sc delete`s MagicMouseDriver globally or sets a dual filter.
 
-### Completed
+## Manual build (optional)
 
-- [ ] Architecture design (pending)
-- [ ] KMDF framework skeleton (pending)
-- [ ] Magic Mouse PID detection (pending)
-- [ ] IRP filtering logic (pending)
-- [ ] DynamicCachedServices interception (pending)
-- [ ] Error handling (pending)
-- [ ] Unit tests (pending)
-- [ ] Integration tests (pending)
-- [ ] Code review (pending)
-
-### In Progress
-
-- KMDF initialization
-- Device enumeration and filtering
-
-### Planned
-
-- IRP interception and validation
-- Registry manipulation safeguards
-- Comprehensive testing (all 6 test scenarios)
-- Public source code release
-- Microsoft signing certification
-
-## Building v2 (When Available)
-
-### Prerequisites
-
-- Windows Driver Kit (WDK) 10.0 or later
-- Visual Studio 2019 or later
-- .NET Framework 4.7+ (for build tools)
-
-### Build Steps
-
-```powershell
-# Open Visual Studio as Administrator
-# File → Open Solution → magic_mouse_v3.sln
-# Build → Build Solution (F7)
-# Output: magic_mouse_v3.sys in output directory
-
-# Or command-line:
-msbuild magic_mouse_v3.sln /p:Configuration=Release /p:Platform=x64
-```
-
-### Signing (Pre-Release)
-
-```powershell
-# Test-sign for development
-signtool sign /f MagicMouseFix.pfx /p password /t http://timestamp.server.com ^
-  magic_mouse_v3.sys
-
-# Production (pending Microsoft certification)
-# Will be signed by Revive Business Solutions' code signing certificate
-```
-
-## Testing (When Available)
-
-v2 will be tested with the same 6-scenario test suite as v1:
-
-1. **Power off/on:** Scroll persists
-2. **69-minute idle:** Scroll stable after extended idle
-3. **pnputil rescan:** Device rescan compatible
-4. **Sleep/wake:** Cache integrity maintained
-5. **UsoClient force-DSM:** DSM property scan blocked
-6. **Cold reboot:** Multiple DSM runs don't trigger collapse
-
-See `docs/TEST_PLAN.md` for detailed procedures.
-
-## Deployment Roadmap
-
-### Phase 1: Internal Testing (Target: Q3 2026)
-
-- Complete source implementation
-- Run all 6 test scenarios
-- Code review and security audit
-- Document building and testing process
-
-### Phase 2: Beta Release (Target: Q4 2026)
-
-- Source code published to GitHub (this repo)
-- Beta version for experienced users
-- Feedback collection
-- Bug fixes based on testing
-
-### Phase 3: Production Release (Target: Q1 2027)
-
-- Microsoft code signing certification
-- v2.0.0 final release
-- v1.0.0 marked as deprecated (still supported)
-- Migration guide for v1 → v2
-
-## Design Principles
-
-### v2 KMDF Implementation Will Follow:
-
-1. **Minimal interception:** Only intercept critical DSM property queries, pass all others through
-2. **Fast path:** No complex algorithms, early exit for non-Magic Mouse devices
-3. **Error safety:** If uncertainty exists, allow request (fail-open for stability)
-4. **Logging:** Debug tracing for issue diagnosis without performance penalty
-5. **Isolation:** Device-specific filtering (PID 0x0323 only), no impact on other HID devices
-6. **Compliance:** Follow Windows Driver Frameworks best practices
-
-## Comparison: v1 vs v2
-
-### v1 (Binary Patch) — Current Production
-
-**Use v1 if:**
-- You need a fix now (before v2 is available)
-- You're comfortable with binary patches
-- You're not concerned about certificate trust prompts
-
-**Install:** See `/v1-binary-patch/README.md`
-
-### v2 (KMDF Source) — Future
-
-**Use v2 when:**
-- You want to audit the source code
-- You prefer open-source drivers
-- Microsoft-signed binaries become available
-- You're building a derivative project
-
-**Timeline:** v2 becomes available Q3 2026 (beta), Q1 2027 (production)
-
-## Migration Path: v1 → v2
-
-When v2.0.0 is released:
-
-1. **v1 continues to work:** v1.0.0 will remain available and supported
-2. **Side-by-side installation:** v1 and v2 can coexist (though only one should be active)
-3. **Migration script:** Uninstall v1, install v2 (simple PowerShell script)
-4. **No breaking changes:** v2 maintains same functionality and registry interface
-
-## Contributing
-
-v2 development will welcome contributions for:
-- Code implementation (KMDF driver skeleton, dispatch routines, etc.)
-- Testing on additional hardware configurations
-- Documentation improvements
-- Code review and security audit
-
-**Process:**
-1. Fork this repository
-2. Create feature branch: `git checkout -b ai/v2-feature-name`
-3. Implement feature + tests
-4. Open pull request with test evidence
-5. Code review before merge
-
-See `CONTRIBUTING.md` for details.
-
-## FAQ
-
-### Q: Why not release v2 now?
-
-A: KMDF driver development requires:
-- WDK environment setup
-- Driver architecture design
-- IRP routing and interception logic
-- Comprehensive testing on multiple Windows versions
-- Security audit before public release
-
-Releasing an untested driver would be irresponsible.
-
-### Q: When will v2 be ready?
-
-A: Target timeline:
-- **Architecture & design:** May–June 2026
-- **Implementation:** July–August 2026
-- **Testing:** September 2026
-- **Beta release:** October 2026
-- **Production release:** January 2027
-
-### Q: Can I help build v2?
-
-A: Yes! Contributors welcome once the source skeleton is available. See `CONTRIBUTING.md`.
-
-### Q: Will v1 stop working when v2 is released?
-
-A: No. v1 will continue to work and be supported. v2 is an alternative, not a replacement. You choose which to install.
-
-### Q: What about Windows 12 / ARM64?
-
-A: v2 architecture will support:
-- Windows 11 22H2+
-- Windows 10 build 14393+ (best-effort)
-- x64 architecture (primary target)
-- ARM64 (secondary, pending testing)
-
-v1 works on these now; v2 will maintain same compatibility.
-
-## Current Users (v1.0.0)
-
-If you've installed v1.0.0 and it's working, **no action is required**. v1 remains production-ready and fully supported.
-
-When v2 becomes available, you can optionally upgrade by:
-1. Uninstalling v1 (`Uninstall-MagicMousePatch.ps1`)
-2. Installing v2 (PowerShell or WiX installer)
-3. Rebooting
-
----
-
-## Resources
-
-### Windows Driver Development
-
-- [Microsoft Windows Driver Kit](https://learn.microsoft.com/en-us/windows-hardware/drivers/)
-- [KMDF Documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/wdf/kmdf-version-history)
-- [Windows Driver Samples](https://github.com/microsoft/Windows-driver-samples)
-
-### Related Projects
-
-- [WDF Filter Driver Sample](https://github.com/microsoft/Windows-driver-samples/tree/master/general/filter)
-- [HID Class Driver](https://github.com/microsoft/Windows-driver-samples/tree/master/input/hid)
-
----
-
-**Document Version:** 1.0.0 (WIP)  
-**Last Updated:** 2026-05-18  
-**Status:** Not production ready — do not install on production systems  
-**Author:** Revive Business Solutions  
-**License:** MIT (when source is released)
+See `BUILDING.md`. Not required if you only use the one-click task on a machine that already has WDK.

--- a/v2-kmdf-driver/TrackpadPtp.c
+++ b/v2-kmdf-driver/TrackpadPtp.c
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+//
+// Magic Trackpad → Windows Precision Touchpad.
+// Linux hid-magicmouse.c: report IDs, 4+9N / 12+9N layout, 13-bit x/y,
+// v1 vs v2 id/down packing, surface min/max. No GPL code.
+//
+// Injected COL01 is Digitizer/Touch Pad RID 0x01 with 3 fingers so Windows
+// can 1/2/3-finger tap. COL02 RID 0x90 battery matches 0323. Descriptor
+// length must be ≤ 249 (SDP 1-byte TEXT_STRING: 6+N ≤ 255).
+
+#include "TrackpadPtp.h"
+
+#define TP_V1_MIN_X   (-2909)
+#define TP_V1_MAX_X   3167
+#define TP_V1_MIN_Y   (-2456)
+#define TP_V1_MAX_Y   2565
+
+#define TP_V2_MIN_X   (-3678)
+#define TP_V2_MAX_X   3934
+#define TP_V2_MIN_Y   (-2478)
+#define TP_V2_MAX_Y   2587
+
+#define TP_X_LOG_MAX  7612  /* 3934 - (-3678) */
+#define TP_Y_LOG_MAX  5065  /* 2587 - (-2478) */
+
+#define TP_STATE_MASK 0xF0u
+#define TP_V2_DOWN    0x80u
+#define TP_V2_STATE   0xC0u
+
+#define TP_FINGER_COLLECTION \
+    0x09, 0x22, \
+    0xA1, 0x02, \
+    0x15, 0x00, \
+    0x25, 0x01, \
+    0x75, 0x01, \
+    0x95, 0x02, \
+    0x09, 0x42, \
+    0x09, 0x47, \
+    0x81, 0x02, \
+    0x95, 0x06, \
+    0x81, 0x03, \
+    0x75, 0x08, \
+    0x95, 0x01, \
+    0x25, 0x0F, \
+    0x09, 0x51, \
+    0x81, 0x02, \
+    0x05, 0x01, \
+    0x75, 0x10, \
+    0x26, 0xBC, 0x1D, \
+    0x09, 0x30, \
+    0x81, 0x02, \
+    0x26, 0xC9, 0x13, \
+    0x09, 0x31, \
+    0x81, 0x02, \
+    0x05, 0x0D, \
+    0xC0
+
+const UCHAR g_PtpHidDescriptor[] = {
+    0x05, 0x0D,
+    0x09, 0x05,
+    0xA1, 0x01,
+    0x85, 0x01,
+
+    TP_FINGER_COLLECTION,
+    TP_FINGER_COLLECTION,
+    TP_FINGER_COLLECTION,
+
+    0x09, 0x54,
+    0x75, 0x08,
+    0x95, 0x01,
+    0x25, 0x03,
+    0x81, 0x02,
+
+    0x09, 0x56,
+    0x75, 0x10,
+    0x81, 0x02,
+
+    0x05, 0x09,
+    0x09, 0x01,
+    0x15, 0x00,
+    0x25, 0x01,
+    0x75, 0x01,
+    0x95, 0x01,
+    0x81, 0x02,
+    0x95, 0x07,
+    0x81, 0x03,
+
+    0x05, 0x0D,
+    0x09, 0x55,
+    0x25, 0x03,
+    0x75, 0x08,
+    0x95, 0x01,
+    0xB1, 0x03,
+    0xC0,
+
+    0x05, 0x01,
+    0x09, 0x06,
+    0x05, 0x06,
+    0x09, 0x20,
+    0xA1, 0x01,
+    0x85, 0x90,
+    0x75, 0x08,
+    0x95, 0x01,
+    0x81, 0x03,
+    0x15, 0x00,
+    0x25, 0x64,
+    0x09, 0x20,
+    0x95, 0x01,
+    0x81, 0x02,
+    0xC0,
+};
+
+const ULONG g_PtpHidDescriptorSize = sizeof(g_PtpHidDescriptor);
+
+BOOLEAN
+MmIsTrackpadPid(_In_ USHORT pid)
+{
+    return (BOOLEAN)(pid == MM_PID_TRACKPAD_V1 ||
+                     pid == MM_PID_TRACKPAD_V2 ||
+                     pid == MM_PID_TRACKPAD_V3);
+}
+
+BOOLEAN
+TrackpadFillMtEnable(
+    _In_ USHORT pid,
+    _Out_writes_bytes_(*outLen) PUCHAR out,
+    _Inout_ PULONG outLen)
+{
+    if (out == NULL || outLen == NULL)
+    {
+        return FALSE;
+    }
+
+    if (pid == MM_PID_TRACKPAD_V1)
+    {
+        if (*outLen < 2) { return FALSE; }
+        out[0] = 0xD7;
+        out[1] = 0x01;
+        *outLen = 2;
+        return TRUE;
+    }
+
+    if (pid == MM_PID_TRACKPAD_V2 || pid == MM_PID_TRACKPAD_V3)
+    {
+        if (*outLen < 3) { return FALSE; }
+        out[0] = 0xF1;
+        out[1] = 0x02;
+        out[2] = 0x01;
+        *outLen = 3;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+static INT
+TpClamp(_In_ INT v, _In_ INT lo, _In_ INT hi)
+{
+    if (v < lo) { return lo; }
+    if (v > hi) { return hi; }
+    return v;
+}
+
+static INT
+TpReadI13X(_In_reads_(2) const UCHAR *t)
+{
+    INT v = (INT)(((ULONG)t[1] << 27) | ((ULONG)t[0] << 19));
+    return v >> 19;
+}
+
+static INT
+TpReadI13Y(_In_reads_(3) const UCHAR *t)
+{
+    INT v = (INT)(((ULONG)t[3] << 30) | ((ULONG)t[2] << 22) | ((ULONG)t[1] << 14));
+    return -(v >> 19);
+}
+
+static VOID
+TpWriteI16Le(_Out_writes_bytes_(2) PUCHAR p, _In_ INT v)
+{
+    USHORT u = (USHORT)v;
+    p[0] = (UCHAR)(u & 0xFF);
+    p[1] = (UCHAR)((u >> 8) & 0xFF);
+}
+
+static BOOLEAN
+TpIsV1Layout(_In_ UCHAR rid, _In_ USHORT pid)
+{
+    if (rid == TP_RID_V1) { return TRUE; }
+    if (rid == TP_RID_V2_BT || rid == TP_RID_V2_USB) { return FALSE; }
+    return (BOOLEAN)(pid == MM_PID_TRACKPAD_V1);
+}
+
+static NTSTATUS
+TpTranslateOne(
+    _In_reads_bytes_(inLen) PUCHAR in,
+    _In_ SIZE_T inLen,
+    _Out_writes_bytes_(*outLen) PUCHAR out,
+    _Inout_ PULONG outLen,
+    _In_ USHORT productId,
+    _Inout_opt_ PULONG scanTime)
+{
+    UCHAR rid;
+    ULONG header;
+    BOOLEAN v1;
+    INT minX, maxX, minY, maxY;
+    ULONG npoints;
+    ULONG i;
+    ULONG count;
+    USHORT scan;
+    UCHAR clicks;
+
+    if (in == NULL || out == NULL || outLen == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (*outLen < TP_PTP_REPORT_LEN)
+    {
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+    if (inLen < 1)
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    rid = in[0];
+    if (rid == TP_RID_BATTERY || rid == 0x12 || rid == 0x27)
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    if (rid == TP_RID_V2_USB)
+    {
+        header = TP_USB_HEADER;
+    }
+    else if (rid == TP_RID_V1 || rid == TP_RID_V2_BT)
+    {
+        header = TP_BT_HEADER;
+    }
+    else
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    if (inLen < header || ((inLen - header) % TP_TOUCH_BYTES) != 0)
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    npoints = (ULONG)((inLen - header) / TP_TOUCH_BYTES);
+    if (npoints > 15)
+    {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    v1 = TpIsV1Layout(rid, productId);
+    if (v1)
+    {
+        minX = TP_V1_MIN_X; maxX = TP_V1_MAX_X;
+        minY = TP_V1_MIN_Y; maxY = TP_V1_MAX_Y;
+    }
+    else
+    {
+        minX = TP_V2_MIN_X; maxX = TP_V2_MAX_X;
+        minY = TP_V2_MIN_Y; maxY = TP_V2_MAX_Y;
+    }
+
+    clicks = (inLen >= 2) ? (UCHAR)(in[1] & 0x01) : 0;
+
+    RtlZeroMemory(out, TP_PTP_REPORT_LEN);
+    out[0] = TP_PTP_RID;
+
+    count = 0;
+    for (i = 0; i < npoints && count < TP_PTP_CONTACTS; i++)
+    {
+        PUCHAR t = in + header + i * TP_TOUCH_BYTES;
+        UCHAR id;
+        BOOLEAN down;
+        INT x;
+        INT y;
+        INT xPtp;
+        INT yPtp;
+        ULONG base;
+
+        if (v1)
+        {
+            id = (UCHAR)((((ULONG)t[7] << 2) | ((ULONG)t[6] >> 6)) & 0xFu);
+            down = (BOOLEAN)((t[8] & TP_STATE_MASK) != 0);
+        }
+        else
+        {
+            id = (UCHAR)(t[8] & 0x0Fu);
+            down = (BOOLEAN)((t[3] & TP_V2_STATE) == TP_V2_DOWN);
+        }
+
+        if (!down)
+        {
+            continue;
+        }
+
+        x = TpReadI13X(t);
+        y = TpReadI13Y(t);
+        xPtp = TpClamp(x - minX, 0, TP_X_LOG_MAX);
+        yPtp = TpClamp(maxY - y, 0, TP_Y_LOG_MAX);
+        (void)maxX;
+        (void)minY;
+
+        base = 1 + count * 6;
+        out[base + 0] = 0x03;
+        out[base + 1] = id;
+        TpWriteI16Le(out + base + 2, xPtp);
+        TpWriteI16Le(out + base + 4, yPtp);
+        count++;
+    }
+
+    out[19] = (UCHAR)count;
+
+    scan = 0;
+    if (scanTime != NULL)
+    {
+        *scanTime += 10;
+        scan = (USHORT)(*scanTime);
+    }
+    out[20] = (UCHAR)(scan & 0xFF);
+    out[21] = (UCHAR)((scan >> 8) & 0xFF);
+    out[22] = clicks;
+
+    *outLen = TP_PTP_REPORT_LEN;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+TranslateTrackpadToPtp(
+    _In_reads_bytes_(inLen) PUCHAR in,
+    _In_ SIZE_T inLen,
+    _Out_writes_bytes_(*outLen) PUCHAR out,
+    _Inout_ PULONG outLen,
+    _In_ USHORT productId,
+    _Inout_opt_ PULONG scanTime)
+{
+    if (in == NULL || inLen < 1)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    if (in[0] == TP_RID_DOUBLE && inLen >= 2)
+    {
+        UCHAR firstLen = in[1];
+        ULONG innerOff;
+        ULONG innerLen;
+
+        if ((ULONG)firstLen + 2u > (ULONG)inLen)
+        {
+            return STATUS_NO_MORE_ENTRIES;
+        }
+
+        innerOff = 2u + (ULONG)firstLen;
+        innerLen = (ULONG)inLen - innerOff;
+        if (innerLen >= 1 &&
+            (in[innerOff] == TP_RID_V1 ||
+             in[innerOff] == TP_RID_V2_BT ||
+             in[innerOff] == TP_RID_V2_USB))
+        {
+            return TpTranslateOne(in + innerOff, innerLen, out, outLen,
+                                  productId, scanTime);
+        }
+        if (firstLen >= 1)
+        {
+            return TpTranslateOne(in + 2, firstLen, out, outLen,
+                                  productId, scanTime);
+        }
+        return STATUS_NO_MORE_ENTRIES;
+    }
+
+    return TpTranslateOne(in, inLen, out, outLen, productId, scanTime);
+}

--- a/v2-kmdf-driver/TrackpadPtp.h
+++ b/v2-kmdf-driver/TrackpadPtp.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#ifdef MM_USERLAND_TEST
+#include "kernel-stubs.h"
+#else
+#include "Driver.h"
+#endif
+
+// Magic Trackpad Bluetooth PIDs. INF binds these; 0323 mouse is not a trackpad.
+#ifndef MM_PID_TRACKPAD_V1
+#define MM_PID_TRACKPAD_V1  0x030Eu
+#define MM_PID_TRACKPAD_V2  0x0265u
+#define MM_PID_TRACKPAD_V3  0x0324u
+#endif
+
+// Linux hid-magicmouse.c report IDs (numeric facts only).
+#define TP_RID_V1           0x28
+#define TP_RID_V2_BT        0x31
+#define TP_RID_V2_USB       0x02
+#define TP_RID_DOUBLE       0xF7
+#define TP_RID_BATTERY      0x90
+
+#define TP_PTP_RID          0x01
+#define TP_PTP_REPORT_LEN   23
+#define TP_PTP_CONTACTS     3
+#define TP_TOUCH_BYTES      9
+#define TP_BT_HEADER        4
+#define TP_USB_HEADER       12
+
+#define TP_PTP_DESC_MAX     249
+
+extern const UCHAR g_PtpHidDescriptor[];
+extern const ULONG g_PtpHidDescriptorSize;
+
+BOOLEAN MmIsTrackpadPid(_In_ USHORT pid);
+
+// Feature bytes Linux sends to start 0x28/0x31 (not transmitted this vertical).
+BOOLEAN TrackpadFillMtEnable(
+    _In_ USHORT pid,
+    _Out_writes_bytes_(*outLen) PUCHAR out,
+    _Inout_ PULONG outLen);
+
+// Apple 0x28/0x31/0x02/0xF7 → PTP RID 0x01 (23 bytes). 0x90 and mouse 0x12: no.
+NTSTATUS TranslateTrackpadToPtp(
+    _In_reads_bytes_(inLen) PUCHAR in,
+    _In_ SIZE_T inLen,
+    _Out_writes_bytes_(*outLen) PUCHAR out,
+    _Inout_ PULONG outLen,
+    _In_ USHORT productId,
+    _Inout_opt_ PULONG scanTime);

--- a/v2-kmdf-driver/Uninstall-KMDF.cmd
+++ b/v2-kmdf-driver/Uninstall-KMDF.cmd
@@ -1,0 +1,5 @@
+@echo off
+cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Install-KMDF.ps1" -Uninstall
+echo.
+pause

--- a/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
@@ -1,0 +1,412 @@
+<#
+.SYNOPSIS
+Unattended KMDF install path. Run by the MM-Kmdf-Install SYSTEM task.
+
+.DESCRIPTION
+Does not prompt. Writes C:\ProgramData\MagicMouseDriver\install.log and RESULT.txt.
+
+  1. Optional build (WDK/EWDK on a fixed path — Session 0 cannot see a user-mounted ISO)
+  2. Enable test signing if needed
+  3. Create/reuse CN=MagicMouseFix (thumb B902C286…) code-signing cert
+  4. Catalog + sign .sys/.cat — refuse the May 20 WDKTestCert (pointer-dead)
+  5. pnputil install; LowerFilters=MagicMouseDriver sole on PID 0323 only
+  6. Bluetooth bounce only if 0323 HID did not start
+  7. Reboot if test signing just changed or pnputil asked for it
+  8. Otherwise verify now
+
+Never writes LowerFilters=MagicMouseDriver,applewirelessmouse.
+Never binds PID 030D.
+#>
+[CmdletBinding()]
+param(
+    [string]$PackageRoot = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+if (-not $PackageRoot) {
+    $PackageRoot = Split-Path -Parent $PSScriptRoot
+}
+
+. (Join-Path $PSScriptRoot 'Kmdf-Common.ps1')
+
+Initialize-KmdfDataDir
+Write-KmdfLog -Message "=== Invoke-KmdfInstall (SYSTEM unattended) ===" -Level 'HEAD'
+Write-KmdfLog -Message "PackageRoot=$PackageRoot User=$([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)" -Level 'INFO'
+
+function Get-KmdfFileSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToUpperInvariant()
+}
+
+function Test-KmdfForbiddenSys {
+    param([Parameter(Mandatory)][string]$Path)
+    $name = [System.IO.Path]::GetFileName($Path)
+    if ($name -like '*may20-pointerdead*' -or $name -eq $script:KmdfArtifactMay20) {
+        Write-KmdfLog -Message "Refusing labeled May 20 pointer-dead artifact $name — installer never installs this SHA." -Level 'ERROR'
+        return $true
+    }
+    if ($name -like 'applewirelessmouse*') {
+        Write-KmdfLog -Message "Refusing PATH-A package $name — never install as MagicMouseDriver.sys / 0323 product." -Level 'ERROR'
+        return $true
+    }
+    $sha = Get-KmdfFileSha256 -Path $Path
+    if ($sha -eq $script:KmdfShaPointerDead) {
+        Write-KmdfLog -Message "Refusing May 20 WDKTestCert ($script:KmdfArtifactMay20 / $sha) — pointer-dead. Will not install it." -Level 'ERROR'
+        return $true
+    }
+    return $false
+}
+
+function Get-KmdfArtifactLabel {
+    param([Parameter(Mandatory)][string]$Path)
+    $sha = Get-KmdfFileSha256 -Path $Path
+    $name = [System.IO.Path]::GetFileName($Path)
+    if ($sha -eq $script:KmdfShaPointerDead -or $name -eq $script:KmdfArtifactMay20) {
+        return $script:KmdfArtifactMay20
+    }
+    if ($sha -eq $script:KmdfShaPointerOk -or $name -eq $script:KmdfArtifactApr30) {
+        return $script:KmdfArtifactApr30
+    }
+    if ($name -eq $script:KmdfArtifactScroll -or $name -like 'MagicMouseDriver-kmdf-2.0.4-scroll*') {
+        return $script:KmdfArtifactScroll
+    }
+    return $script:KmdfArtifactScroll
+}
+
+function Find-KmdfSys {
+    $hints = @(
+        (Join-Path $PackageRoot $script:KmdfArtifactScroll),
+        (Join-Path $PackageRoot "x64\Release\$($script:KmdfArtifactScroll)"),
+        (Join-Path $PackageRoot $script:KmdfInstallSysName),
+        (Join-Path $PackageRoot "x64\Release\$($script:KmdfInstallSysName)"),
+        (Join-Path $PackageRoot "x64\Release\MagicMouseDriver\$($script:KmdfInstallSysName)"),
+        (Join-Path $PackageRoot "x64\Debug\$($script:KmdfInstallSysName)"),
+        (Join-Path $PackageRoot $script:KmdfArtifactApr30)
+    )
+    $apr30 = $null
+    foreach ($h in $hints) {
+        if (-not (Test-Path -LiteralPath $h)) { continue }
+        $full = (Resolve-Path -LiteralPath $h).Path
+        if (Test-KmdfForbiddenSys -Path $full) { continue }
+        $sha = Get-KmdfFileSha256 -Path $full
+        if ($sha -eq $script:KmdfShaPointerOk) {
+            if (-not $apr30) { $apr30 = $full }
+            continue
+        }
+        return $full
+    }
+    if ($apr30) {
+        Write-KmdfLog -Message "Only $($script:KmdfArtifactApr30) is available (pointer OK, scroll dead). Prefer $($script:KmdfArtifactScroll) FileVersion 2.0.4.0." -Level 'WARN'
+        return $apr30
+    }
+    return $null
+}
+
+function Backup-KmdfLiveSys {
+    $live = Join-Path $env:SystemRoot "System32\drivers\$($script:KmdfInstallSysName)"
+    if (-not (Test-Path -LiteralPath $live)) { return }
+    if (-not (Test-Path -LiteralPath $script:KmdfBackupDir)) {
+        New-Item -ItemType Directory -Path $script:KmdfBackupDir -Force | Out-Null
+    }
+    $label = Get-KmdfArtifactLabel -Path $live
+    $dst = Join-Path $script:KmdfBackupDir $label
+    Copy-Item -LiteralPath $live -Destination $dst -Force
+    Write-KmdfLog -Message "Backed up live $live as $dst (package name; Windows file stays $($script:KmdfInstallSysName))" -Level 'OK'
+}
+
+function Publish-KmdfScrollArtifact {
+    param([Parameter(Mandatory)][string]$SysPath)
+    $sha = Get-KmdfFileSha256 -Path $SysPath
+    if ($sha -eq $script:KmdfShaPointerOk -or $sha -eq $script:KmdfShaPointerDead) {
+        return
+    }
+    $labeled = Join-Path $PackageRoot $script:KmdfArtifactScroll
+    if ((Resolve-Path -LiteralPath $SysPath).Path -ne (Join-Path $PackageRoot $script:KmdfArtifactScroll)) {
+        Copy-Item -LiteralPath $SysPath -Destination $labeled -Force
+        Write-KmdfLog -Message "Labeled scroll artifact $labeled (FileVersion 2.0.4.0). INF still installs as $($script:KmdfInstallSysName)." -Level 'OK'
+    }
+}
+
+function Invoke-KmdfBuildIfNeeded {
+    $sys = Find-KmdfSys
+    if ($sys) {
+        Write-KmdfLog -Message "Using existing .sys: $sys" -Level 'OK'
+        return $sys
+    }
+
+    $proj = Join-Path $PackageRoot 'MagicMouseDriver.vcxproj'
+    if (-not (Test-Path -LiteralPath $proj)) {
+        throw "MagicMouseDriver.vcxproj not found under $PackageRoot"
+    }
+
+    $msbuild = Find-KmdfMsBuild
+    if (-not $msbuild) {
+        throw "$($script:KmdfArtifactScroll) is not in the package and no WDK/EWDK MSBuild was found. Build on Windows with the WDK (FileVersion 2.0.4.0), copy $($script:KmdfArtifactScroll) next to the INF (INF still installs as $($script:KmdfInstallSysName)), then run Install-KMDF.cmd again."
+    }
+
+    Write-KmdfLog -Message "Building $proj ($msbuild)" -Level 'INFO'
+    $outDir = Join-Path $PackageRoot 'x64\Release'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    if ($msbuild -like 'EWDK:*') {
+        $setup = $msbuild.Substring(5)
+        $cmd = '"' + $setup + '" && msbuild "' + $proj + '" /m /nr:false /v:minimal /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off /p:RunCodeAnalysis=false'
+        & cmd.exe /c $cmd 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+        if ($LASTEXITCODE -ne 0) { throw "EWDK msbuild exited $LASTEXITCODE" }
+    } else {
+        & $msbuild $proj /m /nr:false /v:minimal /p:Configuration=Release /p:Platform=x64 /p:SignMode=Off /p:RunCodeAnalysis=false 2>&1 |
+            ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+        if ($LASTEXITCODE -ne 0) { throw "msbuild exited $LASTEXITCODE" }
+    }
+
+    $sys = Find-KmdfSys
+    if (-not $sys) { throw "Build finished but $($script:KmdfInstallSysName) was not produced." }
+    Publish-KmdfScrollArtifact -SysPath $sys
+    $labeled = Find-KmdfSys
+    if ($labeled) { $sys = $labeled }
+    Write-KmdfLog -Message "Built $sys (artifact $($script:KmdfArtifactScroll), installs as $($script:KmdfInstallSysName))" -Level 'OK'
+    return $sys
+}
+
+function Get-KmdfSigningCert {
+    $byThumb = Get-ChildItem Cert:\LocalMachine\My |
+        Where-Object { $_.Thumbprint -eq $script:KmdfCertThumb -and $_.HasPrivateKey } |
+        Select-Object -First 1
+    if ($byThumb) {
+        Write-KmdfLog -Message "Reusing MagicMouseFix thumb $($byThumb.Thumbprint)" -Level 'OK'
+        return $byThumb
+    }
+    $existing = Get-ChildItem Cert:\LocalMachine\My |
+        Where-Object { $_.Subject -eq $script:KmdfCertSubject -and $_.HasPrivateKey } |
+        Select-Object -First 1
+    if ($existing) {
+        Write-KmdfLog -Message "Reusing cert $($existing.Subject) $($existing.Thumbprint)" -Level 'OK'
+        return $existing
+    }
+    Write-KmdfLog -Message "Creating $script:KmdfCertSubject code-signing certificate" -Level 'INFO'
+    $cert = New-SelfSignedCertificate `
+        -Type CodeSigningCert `
+        -Subject $script:KmdfCertSubject `
+        -CertStoreLocation Cert:\LocalMachine\My `
+        -KeyUsage DigitalSignature `
+        -NotAfter (Get-Date).AddYears(10)
+    Write-KmdfLog -Message "Created cert $($cert.Thumbprint)" -Level 'OK'
+    return $cert
+}
+
+function Install-KmdfTrust {
+    param($Cert)
+    $cer = Join-Path $script:KmdfDataDir 'MagicMouseDriver.cer'
+    Export-Certificate -Cert $Cert -FilePath $cer -Force | Out-Null
+    Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\TrustedPublisher | Out-Null
+    Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+    Write-KmdfLog -Message "Trusted $script:KmdfCertSubject in TrustedPublisher and Root" -Level 'OK'
+}
+
+function New-KmdfSignedPackage {
+    param(
+        [Parameter(Mandatory)][string]$SysPath,
+        $Cert
+    )
+    $stage = Join-Path $script:KmdfDataDir 'pkg'
+    if (Test-Path -LiteralPath $stage) { Remove-Item -LiteralPath $stage -Recurse -Force }
+    New-Item -ItemType Directory -Path $stage -Force | Out-Null
+
+    $infSrc = Join-Path $PackageRoot 'MagicMouseDriver.inf'
+    Copy-Item -LiteralPath $SysPath -Destination (Join-Path $stage 'MagicMouseDriver.sys') -Force
+    Copy-Item -LiteralPath $infSrc -Destination (Join-Path $stage 'MagicMouseDriver.inf') -Force
+
+    $cat = Join-Path $stage 'MagicMouseDriver.cat'
+    $inf2cat = Find-KmdfInf2Cat
+    if ($inf2cat) {
+        Write-KmdfLog -Message "inf2cat $stage" -Level 'INFO'
+        & $inf2cat /driver:$stage /os:10_X64 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+        if ($LASTEXITCODE -ne 0) { throw "inf2cat exited $LASTEXITCODE" }
+    } else {
+        Write-KmdfLog -Message "inf2cat not found — New-FileCatalog fallback" -Level 'WARN'
+        New-FileCatalog -Path $stage -CatalogFilePath $cat -CatalogVersion 2.0 | Out-Null
+    }
+    if (-not (Test-Path -LiteralPath $cat)) { throw "Catalog was not created." }
+
+    $signtool = Find-KmdfSignTool
+    $sysDst = Join-Path $stage 'MagicMouseDriver.sys'
+    if ($signtool) {
+        Write-KmdfLog -Message "signtool $signtool" -Level 'INFO'
+        foreach ($f in @($sysDst, $cat)) {
+            & $signtool sign /fd sha256 /sm /sha1 $Cert.Thumbprint /tr http://timestamp.digicert.com /td sha256 $f 2>&1 |
+                ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+            if ($LASTEXITCODE -ne 0) {
+                Write-KmdfLog -Message "Timestamped sign failed on $f — retry without timestamp" -Level 'WARN'
+                & $signtool sign /fd sha256 /sm /sha1 $Cert.Thumbprint $f 2>&1 |
+                    ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+                if ($LASTEXITCODE -ne 0) { throw "signtool failed on $f" }
+            }
+        }
+    } else {
+        Write-KmdfLog -Message "signtool not found — Set-AuthenticodeSignature" -Level 'WARN'
+        foreach ($f in @($sysDst, $cat)) {
+            $sig = Set-AuthenticodeSignature -FilePath $f -Certificate $Cert
+            Write-KmdfLog -Message "$f Authenticode=$($sig.Status)" -Level 'INFO'
+            if ($sig.Status -ne 'Valid' -and $sig.Status -ne 'UnknownError') {
+                # UnknownError is common without a trusted timestamp on a fresh cert.
+                Write-KmdfLog -Message "Signature status $($sig.Status) on $f (test signing will still load it)" -Level 'WARN'
+            }
+        }
+    }
+    return $stage
+}
+
+function Install-KmdfPnputil {
+    param([Parameter(Mandatory)][string]$StageDir)
+    $inf = Join-Path $StageDir 'MagicMouseDriver.inf'
+
+    $pnpRaw = & pnputil.exe /enum-drivers 2>$null | Out-String
+    $existing = ($pnpRaw -split '(?=Published Name:)') |
+        Where-Object { $_ -match 'MagicMouseDriver\.inf' } |
+        ForEach-Object { if ($_ -match 'Published Name:\s+(oem\d+\.inf)') { $Matches[1] } }
+    foreach ($oem in $existing) {
+        Write-KmdfLog -Message "Removing prior $oem" -Level 'INFO'
+        & pnputil.exe /delete-driver $oem /uninstall /force 2>&1 |
+            ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+    }
+
+    Write-KmdfLog -Message "pnputil /add-driver $inf /install" -Level 'INFO'
+    & pnputil.exe /add-driver $inf /install 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+    $rc = $LASTEXITCODE
+    if ($rc -eq 0) { return $false }
+    if ($rc -eq 3010) {
+        Write-KmdfLog -Message "pnputil 3010 — reboot required" -Level 'WARN'
+        return $true
+    }
+    throw "pnputil /add-driver exited $rc"
+}
+
+function Bind-Kmdf0323Only {
+    $mice = @(Get-Kmdf0323Device)
+    if ($mice.Count -eq 0) {
+        Write-KmdfLog -Message "PID 0323 not enumerated yet — package is staged. Pair the mouse; post-boot verify will bind." -Level 'WARN'
+        return
+    }
+    foreach ($m in $mice) {
+        Write-KmdfLog -Message "0323 instance $($m.InstanceId) status=$($m.Status)" -Level 'INFO'
+        Set-KmdfSoleLowerFilter -InstanceId $m.InstanceId | Out-Null
+    }
+}
+
+function Test-KmdfInstallNow {
+    $fail = @()
+    $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) {
+        $fail += 'service MagicMouseDriver missing'
+    } elseif ($svc.Status -ne 'Running') {
+        try { Start-Service -Name $script:KmdfServiceName -ErrorAction Stop } catch { $fail += "service not Running ($($svc.Status))" }
+        $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+        if ($svc -and $svc.Status -ne 'Running') { $fail += "service still $($svc.Status)" }
+    }
+
+    $mice = @(Get-Kmdf0323Device)
+    if ($mice.Count -eq 0) {
+        $fail += 'no BTHENUM PID&0323 device'
+    } else {
+        foreach ($m in $mice) {
+            $stack = Get-KmdfDeviceStack -InstanceId $m.InstanceId
+            Write-KmdfLog -Message "stack[$($m.InstanceId)]=$stack" -Level 'INFO'
+            if (-not $stack) {
+                $fail += "no DEVPKEY_Device_Stack for $($m.InstanceId)"
+                continue
+            }
+            if ($stack -notmatch 'HidBth') { $fail += 'stack missing HidBth' }
+            if ($stack -notmatch 'MagicMouseDriver') { $fail += 'stack missing MagicMouseDriver' }
+            if ($stack -match 'applewirelessmouse') { $fail += 'stack still has applewirelessmouse (dual-filter)' }
+            $lfPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($m.InstanceId)"
+            $lf = (Get-ItemProperty -LiteralPath $lfPath -ErrorAction SilentlyContinue).LowerFilters
+            $lfList = @($lf)
+            if ($lfList -contains 'applewirelessmouse') { $fail += 'LowerFilters still lists applewirelessmouse' }
+            if ($lfList.Count -ne 1 -or $lfList[0] -ne 'MagicMouseDriver') { $fail += "LowerFilters=$($lfList -join ',')" }
+            if ($m.Status -notmatch 'Started|OK') { $fail += "0323 status=$($m.Status)" }
+        }
+    }
+
+    if ($fail.Count -gt 0) {
+        Write-KmdfResult -Status 'FAIL' -Detail ($fail -join '; ')
+        return $false
+    }
+    Write-KmdfResult -Status 'PASS' -Detail 'Service Running; 0323 stack HidBth/MagicMouseDriver; sole LowerFilters; HID started.'
+    return $true
+}
+
+try {
+    $os = Get-CimInstance -ClassName Win32_OperatingSystem
+    if ([int]$os.BuildNumber -lt 14393) {
+        throw "Windows build 14393 or later required (got $($os.BuildNumber))"
+    }
+
+    if (Test-KmdfHvci) {
+        Write-KmdfLog -Message "HVCI / Memory Integrity is ON. Windows 11 will refuse this self-signed .sys. Turn it off: Settings → Privacy & security → Windows Security → Device security → Core isolation → Memory integrity OFF, then reboot and click Install-KMDF.cmd again." -Level 'ERROR'
+        Write-KmdfResult -Status 'FAIL' -Detail 'HVCI / Memory Integrity is enabled. Disable it, reboot, run Install-KMDF.cmd again.'
+        exit 2
+    }
+
+    $needReboot = $false
+    if (Enable-KmdfTestSigning) { $needReboot = $true }
+
+    $sys = Invoke-KmdfBuildIfNeeded
+    if (Test-KmdfForbiddenSys -Path $sys) {
+        throw "Chosen .sys is $($script:KmdfArtifactMay20) (May 20 pointer-dead WDKTestCert). Build $($script:KmdfArtifactScroll) FileVersion 2.0.4.0 from this tree instead."
+    }
+    $sha = Get-KmdfFileSha256 -Path $sys
+    $label = Get-KmdfArtifactLabel -Path $sys
+    Write-KmdfLog -Message "Installing $sys as $($script:KmdfInstallSysName) (package label $label) SHA256=$sha" -Level 'INFO'
+    if ($sha -eq $script:KmdfShaPointerOk) {
+        Write-KmdfLog -Message "This is $($script:KmdfArtifactApr30) (pointer OK, scroll dead). Prefer $($script:KmdfArtifactScroll) FileVersion 2.0.4.0. Installing only because no other .sys is available." -Level 'WARN'
+    } else {
+        Publish-KmdfScrollArtifact -SysPath $sys
+    }
+    Backup-KmdfLiveSys
+
+    $cert = Get-KmdfSigningCert
+    Install-KmdfTrust -Cert $cert
+    $stage = New-KmdfSignedPackage -SysPath $sys -Cert $cert
+    if (Install-KmdfPnputil -StageDir $stage) { $needReboot = $true }
+    Bind-Kmdf0323Only
+
+    $hidStarted = $true
+    foreach ($m in @(Get-Kmdf0323Device)) {
+        if ($m.Status -notmatch 'Started|OK') { $hidStarted = $false }
+    }
+    if (-not $hidStarted) {
+        Write-KmdfLog -Message "0323 HID not started — Bluetooth bounce" -Level 'WARN'
+        Invoke-KmdfBluetoothBounce
+        Bind-Kmdf0323Only
+    } else {
+        Write-KmdfLog -Message "0323 HID started — skipping Bluetooth bounce" -Level 'OK'
+    }
+
+    Save-KmdfState -State @{
+        NeedReboot   = $needReboot
+        InstalledUtc = (Get-Date).ToUniversalTime().ToString('o')
+        SysPath      = $sys
+    }
+
+    if ($needReboot) {
+        Write-KmdfResult -Status 'PENDING' -Detail 'Driver staged. Rebooting so test signing / PnP can load MagicMouseDriver. Post-boot task MM-Kmdf-PostBoot will verify.'
+        Write-KmdfLog -Message "Rebooting in 15 seconds." -Level 'WARN'
+        & shutdown.exe /r /t 15 /c "MagicMouseDriver KMDF: reboot to load test-signed driver"
+        exit 0
+    }
+
+    if (Test-KmdfInstallNow) {
+        Write-KmdfLog -Message "Install verified without reboot." -Level 'OK'
+        exit 0
+    }
+    Write-KmdfLog -Message "Immediate verify failed — scheduling reboot so the stack can rebuild." -Level 'WARN'
+    Write-KmdfResult -Status 'PENDING' -Detail 'Install finished; verify failed before reboot. Rebooting for MM-Kmdf-PostBoot.'
+    & shutdown.exe /r /t 15 /c "MagicMouseDriver KMDF: reboot to rebuild 0323 stack"
+    exit 0
+} catch {
+    Write-KmdfLog -Message "$_" -Level 'ERROR'
+    Write-KmdfResult -Status 'FAIL' -Detail "$_"
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfInstall.ps1
@@ -5,10 +5,10 @@ Unattended KMDF install path. Run by the MM-Kmdf-Install SYSTEM task.
 .DESCRIPTION
 Does not prompt. Writes C:\ProgramData\MagicMouseDriver\install.log and RESULT.txt.
 
-  1. Optional build (WDK/EWDK on a fixed path — Session 0 cannot see a user-mounted ISO)
+  1. Optional build (WDK/EWDK on a fixed path - Session 0 cannot see a user-mounted ISO)
   2. Enable test signing if needed
-  3. Create/reuse CN=MagicMouseFix (thumb B902C286…) code-signing cert
-  4. Catalog + sign .sys/.cat — refuse the May 20 WDKTestCert (pointer-dead)
+  3. Create/reuse CN=MagicMouseFix (thumb B902C286...) code-signing cert
+  4. Catalog + sign .sys/.cat - refuse the May 20 WDKTestCert (pointer-dead)
   5. pnputil install; LowerFilters=MagicMouseDriver sole on PID 0323 only
   6. Bluetooth bounce only if 0323 HID did not start
   7. Reboot if test signing just changed or pnputil asked for it
@@ -44,16 +44,16 @@ function Test-KmdfForbiddenSys {
     param([Parameter(Mandatory)][string]$Path)
     $name = [System.IO.Path]::GetFileName($Path)
     if ($name -like '*may20-pointerdead*' -or $name -eq $script:KmdfArtifactMay20) {
-        Write-KmdfLog -Message "Refusing labeled May 20 pointer-dead artifact $name — installer never installs this SHA." -Level 'ERROR'
+        Write-KmdfLog -Message "Refusing labeled May 20 pointer-dead artifact $name - installer never installs this SHA." -Level 'ERROR'
         return $true
     }
     if ($name -like 'applewirelessmouse*') {
-        Write-KmdfLog -Message "Refusing PATH-A package $name — never install as MagicMouseDriver.sys / 0323 product." -Level 'ERROR'
+        Write-KmdfLog -Message "Refusing PATH-A package $name - never install as MagicMouseDriver.sys / 0323 product." -Level 'ERROR'
         return $true
     }
     $sha = Get-KmdfFileSha256 -Path $Path
     if ($sha -eq $script:KmdfShaPointerDead) {
-        Write-KmdfLog -Message "Refusing May 20 WDKTestCert ($script:KmdfArtifactMay20 / $sha) — pointer-dead. Will not install it." -Level 'ERROR'
+        Write-KmdfLog -Message "Refusing May 20 WDKTestCert ($script:KmdfArtifactMay20 / $sha) - pointer-dead. Will not install it." -Level 'ERROR'
         return $true
     }
     return $false
@@ -225,7 +225,7 @@ function New-KmdfSignedPackage {
         & $inf2cat /driver:$stage /os:10_X64 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
         if ($LASTEXITCODE -ne 0) { throw "inf2cat exited $LASTEXITCODE" }
     } else {
-        Write-KmdfLog -Message "inf2cat not found — New-FileCatalog fallback" -Level 'WARN'
+        Write-KmdfLog -Message "inf2cat not found - New-FileCatalog fallback" -Level 'WARN'
         New-FileCatalog -Path $stage -CatalogFilePath $cat -CatalogVersion 2.0 | Out-Null
     }
     if (-not (Test-Path -LiteralPath $cat)) { throw "Catalog was not created." }
@@ -238,14 +238,14 @@ function New-KmdfSignedPackage {
             & $signtool sign /fd sha256 /sm /sha1 $Cert.Thumbprint /tr http://timestamp.digicert.com /td sha256 $f 2>&1 |
                 ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
             if ($LASTEXITCODE -ne 0) {
-                Write-KmdfLog -Message "Timestamped sign failed on $f — retry without timestamp" -Level 'WARN'
+                Write-KmdfLog -Message "Timestamped sign failed on $f - retry without timestamp" -Level 'WARN'
                 & $signtool sign /fd sha256 /sm /sha1 $Cert.Thumbprint $f 2>&1 |
                     ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
                 if ($LASTEXITCODE -ne 0) { throw "signtool failed on $f" }
             }
         }
     } else {
-        Write-KmdfLog -Message "signtool not found — Set-AuthenticodeSignature" -Level 'WARN'
+        Write-KmdfLog -Message "signtool not found - Set-AuthenticodeSignature" -Level 'WARN'
         foreach ($f in @($sysDst, $cat)) {
             $sig = Set-AuthenticodeSignature -FilePath $f -Certificate $Cert
             Write-KmdfLog -Message "$f Authenticode=$($sig.Status)" -Level 'INFO'
@@ -277,16 +277,16 @@ function Install-KmdfPnputil {
     $rc = $LASTEXITCODE
     if ($rc -eq 0) { return $false }
     if ($rc -eq 3010) {
-        Write-KmdfLog -Message "pnputil 3010 — reboot required" -Level 'WARN'
+        Write-KmdfLog -Message "pnputil 3010 - reboot required" -Level 'WARN'
         return $true
     }
     throw "pnputil /add-driver exited $rc"
 }
 
-function Bind-Kmdf0323Only {
+function Set-Kmdf0323Binding {
     $mice = @(Get-Kmdf0323Device)
     if ($mice.Count -eq 0) {
-        Write-KmdfLog -Message "PID 0323 not enumerated yet — package is staged. Pair the mouse; post-boot verify will bind." -Level 'WARN'
+        Write-KmdfLog -Message "PID 0323 not enumerated yet - package is staged. Pair the mouse; post-boot verify will bind." -Level 'WARN'
         return
     }
     foreach ($m in $mice) {
@@ -344,7 +344,7 @@ try {
     }
 
     if (Test-KmdfHvci) {
-        Write-KmdfLog -Message "HVCI / Memory Integrity is ON. Windows 11 will refuse this self-signed .sys. Turn it off: Settings → Privacy & security → Windows Security → Device security → Core isolation → Memory integrity OFF, then reboot and click Install-KMDF.cmd again." -Level 'ERROR'
+        Write-KmdfLog -Message "HVCI / Memory Integrity is ON. Windows 11 will refuse this self-signed .sys. Turn it off: Settings -> Privacy & security -> Windows Security -> Device security -> Core isolation -> Memory integrity OFF, then reboot and click Install-KMDF.cmd again." -Level 'ERROR'
         Write-KmdfResult -Status 'FAIL' -Detail 'HVCI / Memory Integrity is enabled. Disable it, reboot, run Install-KMDF.cmd again.'
         exit 2
     }
@@ -370,18 +370,18 @@ try {
     Install-KmdfTrust -Cert $cert
     $stage = New-KmdfSignedPackage -SysPath $sys -Cert $cert
     if (Install-KmdfPnputil -StageDir $stage) { $needReboot = $true }
-    Bind-Kmdf0323Only
+    Set-Kmdf0323Binding
 
     $hidStarted = $true
     foreach ($m in @(Get-Kmdf0323Device)) {
         if ($m.Status -notmatch 'Started|OK') { $hidStarted = $false }
     }
     if (-not $hidStarted) {
-        Write-KmdfLog -Message "0323 HID not started — Bluetooth bounce" -Level 'WARN'
+        Write-KmdfLog -Message "0323 HID not started - Bluetooth bounce" -Level 'WARN'
         Invoke-KmdfBluetoothBounce
-        Bind-Kmdf0323Only
+        Set-Kmdf0323Binding
     } else {
-        Write-KmdfLog -Message "0323 HID started — skipping Bluetooth bounce" -Level 'OK'
+        Write-KmdfLog -Message "0323 HID started - skipping Bluetooth bounce" -Level 'OK'
     }
 
     Save-KmdfState -State @{
@@ -401,7 +401,7 @@ try {
         Write-KmdfLog -Message "Install verified without reboot." -Level 'OK'
         exit 0
     }
-    Write-KmdfLog -Message "Immediate verify failed — scheduling reboot so the stack can rebuild." -Level 'WARN'
+    Write-KmdfLog -Message "Immediate verify failed - scheduling reboot so the stack can rebuild." -Level 'WARN'
     Write-KmdfResult -Status 'PENDING' -Detail 'Install finished; verify failed before reboot. Rebooting for MM-Kmdf-PostBoot.'
     & shutdown.exe /r /t 15 /c "MagicMouseDriver KMDF: reboot to rebuild 0323 stack"
     exit 0

--- a/v2-kmdf-driver/scripts/Invoke-KmdfPostBoot.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfPostBoot.ps1
@@ -36,7 +36,7 @@ try {
     }
 
     if (-not $stackOk -or -not $svc -or $svc.Status -ne 'Running') {
-        Write-KmdfLog -Message "Stack/service not ready — Bluetooth bounce + rebind" -Level 'WARN' -LogPath $script:KmdfVerifyLog
+        Write-KmdfLog -Message "Stack/service not ready - Bluetooth bounce + rebind" -Level 'WARN' -LogPath $script:KmdfVerifyLog
         Invoke-KmdfBluetoothBounce
         Start-Sleep -Seconds 8
         $mice = @(Get-Kmdf0323Device)

--- a/v2-kmdf-driver/scripts/Invoke-KmdfPostBoot.ps1
+++ b/v2-kmdf-driver/scripts/Invoke-KmdfPostBoot.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+Post-boot verify for MagicMouseDriver. Run by MM-Kmdf-PostBoot (SYSTEM, AtStartup).
+
+.DESCRIPTION
+Waits for the Bluetooth stack, re-applies sole LowerFilters on PID 0323,
+bounces Bluetooth once if the stack is wrong, then writes RESULT.txt.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+. (Join-Path $PSScriptRoot 'Kmdf-Common.ps1')
+
+Initialize-KmdfDataDir
+Write-KmdfLog -Message "=== Invoke-KmdfPostBoot ===" -Level 'HEAD' -LogPath $script:KmdfVerifyLog
+Write-KmdfLog -Message "Waiting 45s for BTHENUM / HidBth..." -Level 'INFO' -LogPath $script:KmdfVerifyLog
+Start-Sleep -Seconds 45
+
+try {
+    $mice = @(Get-Kmdf0323Device)
+    foreach ($m in $mice) {
+        Set-KmdfSoleLowerFilter -InstanceId $m.InstanceId | Out-Null
+    }
+
+    $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+    $stackOk = $false
+    foreach ($m in $mice) {
+        $stack = Get-KmdfDeviceStack -InstanceId $m.InstanceId
+        Write-KmdfLog -Message "stack=$stack status=$($m.Status)" -Level 'INFO' -LogPath $script:KmdfVerifyLog
+        if ($stack -match 'HidBth' -and $stack -match 'MagicMouseDriver' -and $stack -notmatch 'applewirelessmouse') {
+            $stackOk = $true
+        }
+    }
+
+    if (-not $stackOk -or -not $svc -or $svc.Status -ne 'Running') {
+        Write-KmdfLog -Message "Stack/service not ready — Bluetooth bounce + rebind" -Level 'WARN' -LogPath $script:KmdfVerifyLog
+        Invoke-KmdfBluetoothBounce
+        Start-Sleep -Seconds 8
+        $mice = @(Get-Kmdf0323Device)
+        foreach ($m in $mice) { Set-KmdfSoleLowerFilter -InstanceId $m.InstanceId | Out-Null }
+    }
+
+    $fail = @()
+    $svc = Get-Service -Name $script:KmdfServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) { $fail += 'service missing' }
+    elseif ($svc.Status -ne 'Running') { $fail += "service $($svc.Status)" }
+
+    $mice = @(Get-Kmdf0323Device)
+    if ($mice.Count -eq 0) { $fail += 'no PID 0323 device' }
+    foreach ($m in $mice) {
+        $stack = Get-KmdfDeviceStack -InstanceId $m.InstanceId
+        Write-KmdfLog -Message "final stack[$($m.InstanceId)]=$stack" -Level 'INFO' -LogPath $script:KmdfVerifyLog
+        if ($stack -notmatch 'HidBth') { $fail += 'stack missing HidBth' }
+        if ($stack -notmatch 'MagicMouseDriver') { $fail += 'stack missing MagicMouseDriver' }
+        if ($stack -match 'applewirelessmouse') { $fail += 'dual-filter applewirelessmouse still present' }
+        $lf = @((Get-ItemProperty -LiteralPath "HKLM:\SYSTEM\CurrentControlSet\Enum\$($m.InstanceId)" -ErrorAction SilentlyContinue).LowerFilters)
+        if ($lf -contains 'applewirelessmouse') { $fail += 'LowerFilters still has applewirelessmouse' }
+        if ($lf.Count -ne 1 -or $lf[0] -ne 'MagicMouseDriver') { $fail += "LowerFilters=$($lf -join ',')" }
+        if ($m.Status -notmatch 'Started|OK') { $fail += "HID status=$($m.Status)" }
+    }
+
+    if ($fail.Count -gt 0) {
+        Write-KmdfResult -Status 'FAIL' -Detail ($fail -join '; ')
+        exit 1
+    }
+    Write-KmdfResult -Status 'PASS' -Detail 'Post-boot: service Running; 0323 HidBth/MagicMouseDriver; sole filter; HID started. Confirm pointer AND vertical/horizontal surface scroll.'
+    exit 0
+} catch {
+    Write-KmdfLog -Message "$_" -Level 'ERROR' -LogPath $script:KmdfVerifyLog
+    Write-KmdfResult -Status 'FAIL' -Detail "$_"
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/Kmdf-Common.ps1
+++ b/v2-kmdf-driver/scripts/Kmdf-Common.ps1
@@ -1,0 +1,256 @@
+# Shared helpers for the KMDF one-click path.
+# Dot-sourced by Invoke-KmdfInstall.ps1 / Invoke-KmdfPostBoot.ps1 / Install-KMDF.ps1.
+# Not meant to be run directly.
+
+$script:KmdfDataDir    = 'C:\ProgramData\MagicMouseDriver'
+$script:KmdfInstallDir = 'C:\Program Files\MagicMouseDriver'
+$script:KmdfLog        = Join-Path $script:KmdfDataDir 'install.log'
+$script:KmdfVerifyLog  = Join-Path $script:KmdfDataDir 'verify.log'
+$script:KmdfResult     = Join-Path $script:KmdfDataDir 'RESULT.txt'
+$script:KmdfState      = Join-Path $script:KmdfDataDir 'state.json'
+$script:KmdfTaskInstall  = 'MM-Kmdf-Install'
+$script:KmdfTaskPostBoot = 'MM-Kmdf-PostBoot'
+$script:KmdfCertSubject  = 'CN=MagicMouseFix'
+$script:KmdfCertThumb    = 'B902C2864315E2DE359450024768CE7D01715C38'
+# Apr 30 live binary: pointer OK, scroll dead. Keep as fallback, do not treat as final product.
+$script:KmdfShaPointerOk = 'AD5D244B176D650961594EDED153C46F9A52004C424DABFD86E50844E447546B'
+# May 20 2.0.2.0 WDKTestCert — HID started, pointer dead. Never install.
+$script:KmdfShaPointerDead = '559B136AEB869D1B85EE21583BB7BFD72782A31EE476A2622014D87CE6762F30'
+$script:KmdfPidPattern   = 'BTHENUM\\\{00001124.*PID&0323'
+$script:KmdfServiceName  = 'MagicMouseDriver'
+# Windows / INF / service name — do not change. Package artifacts use the labels below.
+$script:KmdfInstallSysName = 'MagicMouseDriver.sys'
+$script:KmdfArtifactScroll = 'MagicMouseDriver-kmdf-2.0.4-scroll.sys'
+$script:KmdfArtifactApr30  = 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys'
+$script:KmdfArtifactMay20  = 'MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys'
+$script:KmdfPathAShipBlocker = 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys'
+$script:KmdfBackupDir    = Join-Path $script:KmdfDataDir 'backup'
+
+function Initialize-KmdfDataDir {
+    if (-not (Test-Path -LiteralPath $script:KmdfDataDir)) {
+        New-Item -ItemType Directory -Path $script:KmdfDataDir -Force | Out-Null
+    }
+}
+
+function Write-KmdfLog {
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [ValidateSet('INFO', 'OK', 'WARN', 'ERROR', 'HEAD')]
+        [string]$Level = 'INFO',
+        [string]$LogPath = $script:KmdfLog
+    )
+    Initialize-KmdfDataDir
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][$Level] $Message"
+    Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8
+    $color = switch ($Level) {
+        'ERROR' { 'Red' }
+        'WARN'  { 'Yellow' }
+        'OK'    { 'Green' }
+        'HEAD'  { 'Cyan' }
+        default { 'Gray' }
+    }
+    Write-Host $line -ForegroundColor $color
+}
+
+function Write-KmdfResult {
+    param(
+        [Parameter(Mandatory)][ValidateSet('PASS', 'FAIL', 'PENDING')][string]$Status,
+        [Parameter(Mandatory)][string]$Detail
+    )
+    Initialize-KmdfDataDir
+    $body = @(
+        "MagicMouseDriver KMDF (PID 0323)"
+        "Status : $Status"
+        "Time   : $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+        "Detail : $Detail"
+        "Log    : $script:KmdfLog"
+        "Verify : $script:KmdfVerifyLog"
+    ) -join [Environment]::NewLine
+    Set-Content -LiteralPath $script:KmdfResult -Value $body -Encoding UTF8
+    Write-KmdfLog -Message "RESULT=$Status $Detail" -Level $(if ($Status -eq 'FAIL') { 'ERROR' } elseif ($Status -eq 'PASS') { 'OK' } else { 'WARN' })
+}
+
+function Test-KmdfIsAdmin {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-Kmdf0323Device {
+    $out = & pnputil.exe /enum-devices 2>&1 | Out-String
+    $blocks = $out -split '(?=Instance ID:)'
+    $found = @()
+    foreach ($block in $blocks) {
+        if ($block -notmatch $script:KmdfPidPattern) { continue }
+        $id = $null
+        if ($block -match 'Instance ID:\s+(\S+)') { $id = $Matches[1].Trim() }
+        if (-not $id) { continue }
+        $status = 'Unknown'
+        if ($block -match 'Status:\s+(\S.+)') { $status = $Matches[1].Trim() }
+        $found += [pscustomobject]@{ InstanceId = $id; Status = $status; Raw = $block }
+    }
+    return $found
+}
+
+function Get-KmdfDeviceStack {
+    param([Parameter(Mandatory)][string]$InstanceId)
+    $dev = Get-PnpDevice -InstanceId $InstanceId -ErrorAction SilentlyContinue
+    if (-not $dev) { return $null }
+    try {
+        $prop = Get-PnpDeviceProperty -InstanceId $InstanceId -KeyName 'DEVPKEY_Device_Stack' -ErrorAction Stop
+        return [string]$prop.Data
+    } catch {
+        return $null
+    }
+}
+
+function Set-KmdfSoleLowerFilter {
+    param([Parameter(Mandatory)][string]$InstanceId)
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$InstanceId"
+    if (-not (Test-Path -LiteralPath $regPath)) {
+        Write-KmdfLog -Message "Enum key missing: $regPath" -Level 'ERROR'
+        return $false
+    }
+    $existing = $null
+    try { $existing = (Get-ItemProperty -LiteralPath $regPath -ErrorAction Stop).LowerFilters } catch { $existing = $null }
+
+    $wanted = @($script:KmdfServiceName)
+    $same = $false
+    if ($existing -is [string]) {
+        $same = ($existing -eq $script:KmdfServiceName)
+    } elseif ($existing) {
+        $arr = @($existing)
+        $same = ($arr.Count -eq 1 -and $arr[0] -eq $script:KmdfServiceName)
+    }
+
+    if ($same) {
+        Write-KmdfLog -Message "LowerFilters already sole MagicMouseDriver on $InstanceId" -Level 'OK'
+        return $true
+    }
+
+    if ($existing) {
+        Write-KmdfLog -Message "Replacing LowerFilters '$($existing -join ',')' with MagicMouseDriver only" -Level 'WARN'
+    }
+    Set-ItemProperty -LiteralPath $regPath -Name 'LowerFilters' -Value $wanted -Type MultiString
+    Write-KmdfLog -Message "LowerFilters=MagicMouseDriver (sole) on $InstanceId" -Level 'OK'
+    return $true
+}
+
+function Test-KmdfHvci {
+    $key = 'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity'
+    if (Test-Path -LiteralPath $key) {
+        $enabled = (Get-ItemProperty -LiteralPath $key -Name 'Enabled' -ErrorAction SilentlyContinue).Enabled
+        if ($enabled -eq 1) { return $true }
+    }
+    return $false
+}
+
+function Test-KmdfTestSigning {
+    $out = & bcdedit.exe /enum '{current}' 2>&1 | Out-String
+    return [bool]($out -match '(?im)^\s*testsigning\s+Yes\s*$')
+}
+
+function Enable-KmdfTestSigning {
+    if (Test-KmdfTestSigning) {
+        Write-KmdfLog -Message "Test signing already ON" -Level 'OK'
+        return $false
+    }
+    Write-KmdfLog -Message "Enabling test signing (bcdedit /set testsigning on). Desktop watermark is expected. Reboot required before the self-signed .sys will load." -Level 'WARN'
+    & bcdedit.exe /set testsigning on | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-KmdfLog -Message "bcdedit testsigning failed (exit $LASTEXITCODE)" -Level 'ERROR'
+        throw "bcdedit /set testsigning on failed"
+    }
+    return $true
+}
+
+function Find-KmdfSignTool {
+    $candidates = @(
+        'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+        'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe',
+        'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64\signtool.exe',
+        'C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe'
+    )
+    foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+        $candidates += (Join-Path $drv.RootDirectory.FullName 'Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe')
+    }
+    foreach ($c in $candidates) {
+        if (Test-Path -LiteralPath $c) { return $c }
+    }
+    $found = Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin' -Filter 'signtool.exe' -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -match '\\x64$' } |
+        Select-Object -First 1
+    if ($found) { return $found.FullName }
+    return $null
+}
+
+function Find-KmdfInf2Cat {
+    $found = Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin' -Filter 'inf2cat.exe' -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -match '\\x86$|\\x64$' } |
+        Select-Object -First 1
+    if ($found) { return $found.FullName }
+    return $null
+}
+
+function Find-KmdfMsBuild {
+    $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+    if (Test-Path -LiteralPath $vswhere) {
+        $msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find 'MSBuild\**\Bin\MSBuild.exe' 2>$null |
+            Select-Object -First 1
+        if ($msbuild -and (Test-Path -LiteralPath $msbuild)) { return $msbuild }
+    }
+    foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+        $setup = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+        if (Test-Path -LiteralPath $setup) { return "EWDK:$setup" }
+    }
+    return $null
+}
+
+function Invoke-KmdfBluetoothBounce {
+    Write-KmdfLog -Message "Bouncing Bluetooth (disable then enable). This is required for HidBth to rebuild the 0323 stack around MagicMouseDriver." -Level 'HEAD'
+
+    $adapters = @(Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object {
+            $_.InterfaceDescription -match 'Bluetooth' -or $_.Name -match 'Bluetooth'
+        })
+    foreach ($a in $adapters) {
+        Write-KmdfLog -Message "Disable-NetAdapter $($a.Name)" -Level 'INFO'
+        try {
+            Disable-NetAdapter -Name $a.Name -Confirm:$false -ErrorAction Stop
+        } catch {
+            Write-KmdfLog -Message "Disable-NetAdapter $($a.Name): $_" -Level 'WARN'
+        }
+    }
+    Start-Sleep -Seconds 4
+    foreach ($a in $adapters) {
+        Write-KmdfLog -Message "Enable-NetAdapter $($a.Name)" -Level 'INFO'
+        try {
+            Enable-NetAdapter -Name $a.Name -Confirm:$false -ErrorAction Stop
+        } catch {
+            Write-KmdfLog -Message "Enable-NetAdapter $($a.Name): $_" -Level 'WARN'
+        }
+    }
+    Start-Sleep -Seconds 5
+
+    $mice = @(Get-Kmdf0323Device)
+    foreach ($m in $mice) {
+        Write-KmdfLog -Message "pnputil /restart-device $($m.InstanceId)" -Level 'INFO'
+        & pnputil.exe /restart-device $m.InstanceId 2>&1 | ForEach-Object { Write-KmdfLog -Message "$_" -Level 'INFO' }
+    }
+    Start-Sleep -Seconds 3
+}
+
+function Save-KmdfState {
+    param([hashtable]$State)
+    Initialize-KmdfDataDir
+    ($State | ConvertTo-Json -Compress) | Set-Content -LiteralPath $script:KmdfState -Encoding UTF8
+}
+
+function Read-KmdfState {
+    if (-not (Test-Path -LiteralPath $script:KmdfState)) { return @{} }
+    try {
+        return Get-Content -LiteralPath $script:KmdfState -Raw | ConvertFrom-Json
+    } catch {
+        return @{}
+    }
+}

--- a/v2-kmdf-driver/scripts/Kmdf-Common.ps1
+++ b/v2-kmdf-driver/scripts/Kmdf-Common.ps1
@@ -14,11 +14,11 @@ $script:KmdfCertSubject  = 'CN=MagicMouseFix'
 $script:KmdfCertThumb    = 'B902C2864315E2DE359450024768CE7D01715C38'
 # Apr 30 live binary: pointer OK, scroll dead. Keep as fallback, do not treat as final product.
 $script:KmdfShaPointerOk = 'AD5D244B176D650961594EDED153C46F9A52004C424DABFD86E50844E447546B'
-# May 20 2.0.2.0 WDKTestCert — HID started, pointer dead. Never install.
+# May 20 2.0.2.0 WDKTestCert - HID started, pointer dead. Never install.
 $script:KmdfShaPointerDead = '559B136AEB869D1B85EE21583BB7BFD72782A31EE476A2622014D87CE6762F30'
 $script:KmdfPidPattern   = 'BTHENUM\\\{00001124.*PID&0323'
 $script:KmdfServiceName  = 'MagicMouseDriver'
-# Windows / INF / service name — do not change. Package artifacts use the labels below.
+# Windows / INF / service name - do not change. Package artifacts use the labels below.
 $script:KmdfInstallSysName = 'MagicMouseDriver.sys'
 $script:KmdfArtifactScroll = 'MagicMouseDriver-kmdf-2.0.4-scroll.sys'
 $script:KmdfArtifactApr30  = 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys'

--- a/v2-kmdf-driver/tests/kernel-stubs.h
+++ b/v2-kmdf-driver/tests/kernel-stubs.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#define _In_
+#define _In_opt_
+#define _Inout_
+#define _Inout_opt_
+#define _Out_
+#define _Out_opt_
+#define _In_reads_(x)
+#define _In_reads_bytes_(x)
+#define _Inout_updates_bytes_(x)
+#define _Out_writes_bytes_(x)
+#define _Out_writes_bytes_all_(x)
+#define UNREFERENCED_PARAMETER(x) ((void)(x))
+
+typedef unsigned char       UCHAR;
+typedef unsigned char      *PUCHAR;
+typedef unsigned long       ULONG;
+typedef unsigned long      *PULONG;
+typedef unsigned short      USHORT;
+typedef int                 BOOLEAN;
+typedef int                 INT;
+typedef short               INT16;
+typedef void                VOID;
+typedef void               *PVOID;
+typedef long                NTSTATUS;
+typedef size_t              SIZE_T;
+
+#define TRUE  1
+#define FALSE 0
+
+#define STATUS_SUCCESS                   ((NTSTATUS)0x00000000L)
+#define STATUS_NO_MORE_ENTRIES           ((NTSTATUS)0x8000001AL)
+#define STATUS_INVALID_PARAMETER         ((NTSTATUS)0xC000000DL)
+#define STATUS_BUFFER_TOO_SMALL          ((NTSTATUS)0xC0000023L)
+#define STATUS_NOT_FOUND                 ((NTSTATUS)0xC0000225L)
+#define STATUS_MORE_PROCESSING_REQUIRED  ((NTSTATUS)0xC0000016L)
+
+#define NT_SUCCESS(s) (((NTSTATUS)(s)) >= 0)
+
+#define RtlMoveMemory(dst, src, n)  memmove((dst), (src), (n))
+#define RtlCopyMemory(dst, src, n)  memcpy((dst), (src), (n))
+#define RtlZeroMemory(dst, n)       memset((dst), 0, (n))
+#define DbgPrint(fmt, ...)          printf("[DbgPrint] " fmt, ##__VA_ARGS__)

--- a/v2-kmdf-driver/tests/test-trackpad-ptp.c
+++ b/v2-kmdf-driver/tests/test-trackpad-ptp.c
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+//
+// Slice tests for TrackpadPtp.c (PTP descriptor + Apple to PTP translate).
+//
+// gcc -Wall -Wextra -Werror -DMM_USERLAND_TEST -I tests -I .
+//     -o /tmp/test-trackpad-ptp tests/test-trackpad-ptp.c TrackpadPtp.c
+// /tmp/test-trackpad-ptp
+
+#define MM_USERLAND_TEST 1
+#include "kernel-stubs.h"
+#include "TrackpadPtp.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int g_pass;
+static int g_fail;
+
+#define PASS(name) do { printf("PASS  %s\n", (name)); g_pass++; } while (0)
+#define FAIL(name, reason) do { printf("FAIL  %s - %s\n", (name), (reason)); g_fail++; } while (0)
+
+#define ASSERT_TRUE(name, expr) do { \
+    if (expr) { PASS(name); } else { FAIL(name, "expected TRUE"); } \
+} while (0)
+
+#define ASSERT_EQ_UL(name, expected, actual) do { \
+    unsigned long _e = (unsigned long)(expected); \
+    unsigned long _a = (unsigned long)(actual); \
+    if (_e == _a) { PASS(name); } \
+    else { \
+        char _buf[96]; \
+        snprintf(_buf, sizeof(_buf), "expected %lu got %lu", _e, _a); \
+        FAIL(name, _buf); \
+    } \
+} while (0)
+
+static INT16
+ReadI16Le(const UCHAR *p)
+{
+    return (INT16)((USHORT)p[0] | ((USHORT)p[1] << 8));
+}
+
+static BOOLEAN
+DescContains(const UCHAR *d, ULONG n, UCHAR a, UCHAR b)
+{
+    ULONG i;
+    if (n < 2) { return FALSE; }
+    for (i = 0; i + 1 < n; i++)
+    {
+        if (d[i] == a && d[i + 1] == b) { return TRUE; }
+    }
+    return FALSE;
+}
+
+static VOID
+PackV1Touch(UCHAR *t, UCHAR id, INT x, UCHAR state)
+{
+    memset(t, 0, 9);
+    t[0] = (UCHAR)(x & 0xFF);
+    t[1] = (UCHAR)((x >> 8) & 0x1F);
+    t[6] = (UCHAR)((id & 0x03) << 6);
+    t[7] = (UCHAR)((id >> 2) & 0x3F);
+    t[8] = state;
+}
+
+static VOID
+PackV2Touch(UCHAR *t, UCHAR id, INT x, BOOLEAN down)
+{
+    memset(t, 0, 9);
+    t[0] = (UCHAR)(x & 0xFF);
+    t[1] = (UCHAR)((x >> 8) & 0x1F);
+    if (down) { t[3] = 0x80; }
+    t[8] = (UCHAR)(id & 0x0F);
+}
+
+int
+main(void)
+{
+    UCHAR out[TP_PTP_REPORT_LEN];
+    ULONG outLen;
+    NTSTATUS st;
+    UCHAR mt[4];
+    ULONG mtLen;
+    UCHAR v1[4 + 9];
+    UCHAR v1three[4 + 27];
+    UCHAR v2two[4 + 18];
+    ULONG scan;
+    INT xPtp;
+
+    ASSERT_TRUE("ptp desc size <= 249",
+                g_PtpHidDescriptorSize > 0 &&
+                g_PtpHidDescriptorSize <= TP_PTP_DESC_MAX);
+    ASSERT_TRUE("ptp desc Touch Pad 0x09 0x05",
+                DescContains(g_PtpHidDescriptor, g_PtpHidDescriptorSize, 0x09, 0x05));
+    ASSERT_TRUE("ptp desc RID 0x85 0x01",
+                DescContains(g_PtpHidDescriptor, g_PtpHidDescriptorSize, 0x85, 0x01));
+    ASSERT_TRUE("ptp desc battery RID 0x90",
+                DescContains(g_PtpHidDescriptor, g_PtpHidDescriptorSize, 0x85, 0x90));
+    ASSERT_TRUE("ptp desc Contact Count Max feature const",
+                DescContains(g_PtpHidDescriptor, g_PtpHidDescriptorSize, 0x09, 0x55) &&
+                DescContains(g_PtpHidDescriptor, g_PtpHidDescriptorSize, 0xB1, 0x03));
+
+    ASSERT_TRUE("030E is trackpad", MmIsTrackpadPid(0x030E));
+    ASSERT_TRUE("0265 is trackpad", MmIsTrackpadPid(0x0265));
+    ASSERT_TRUE("0324 is trackpad", MmIsTrackpadPid(0x0324));
+    ASSERT_TRUE("0323 is not trackpad", !MmIsTrackpadPid(0x0323));
+    ASSERT_TRUE("030D is not trackpad", !MmIsTrackpadPid(0x030D));
+
+    mtLen = sizeof(mt);
+    ASSERT_TRUE("v1 MT enable", TrackpadFillMtEnable(0x030E, mt, &mtLen));
+    ASSERT_EQ_UL("v1 MT len", 2, mtLen);
+    ASSERT_EQ_UL("v1 MT b0", 0xD7, mt[0]);
+    ASSERT_EQ_UL("v1 MT b1", 0x01, mt[1]);
+
+    mtLen = sizeof(mt);
+    ASSERT_TRUE("v2 MT enable", TrackpadFillMtEnable(0x0265, mt, &mtLen));
+    ASSERT_EQ_UL("v2 MT len", 3, mtLen);
+    ASSERT_EQ_UL("v2 MT b0", 0xF1, mt[0]);
+    ASSERT_EQ_UL("v2 MT b1", 0x02, mt[1]);
+    ASSERT_EQ_UL("v2 MT b2", 0x01, mt[2]);
+
+    mtLen = sizeof(mt);
+    ASSERT_TRUE("v3 MT enable same as v2", TrackpadFillMtEnable(0x0324, mt, &mtLen));
+    ASSERT_EQ_UL("v3 MT b0", 0xF1, mt[0]);
+
+    memset(v1, 0, sizeof(v1));
+    v1[0] = TP_RID_V1;
+    v1[1] = 0x00;
+    PackV1Touch(v1 + 4, 1, 100, 0x40);
+    outLen = sizeof(out);
+    scan = 0;
+    st = TranslateTrackpadToPtp(v1, sizeof(v1), out, &outLen, 0x030E, &scan);
+    ASSERT_TRUE("v1 one contact STATUS_SUCCESS", NT_SUCCESS(st));
+    ASSERT_EQ_UL("v1 out len 23", TP_PTP_REPORT_LEN, outLen);
+    ASSERT_EQ_UL("v1 RID 0x01", TP_PTP_RID, out[0]);
+    ASSERT_EQ_UL("v1 contact count 1", 1, out[19]);
+    ASSERT_EQ_UL("v1 tip+conf", 0x03, out[1]);
+    ASSERT_EQ_UL("v1 contact id 1", 1, out[2]);
+    xPtp = ReadI16Le(out + 3);
+    ASSERT_TRUE("v1 X 0-based (100 - MIN_X)", xPtp == (100 - (-2909)));
+    ASSERT_EQ_UL("v1 button 0", 0, out[22]);
+    ASSERT_EQ_UL("scan time +10", 10, scan);
+
+    memset(v1three, 0, sizeof(v1three));
+    v1three[0] = TP_RID_V1;
+    v1three[1] = 0x01;
+    PackV1Touch(v1three + 4, 0, 10, 0x40);
+    PackV1Touch(v1three + 13, 1, 20, 0x40);
+    PackV1Touch(v1three + 22, 2, 30, 0x40);
+    outLen = sizeof(out);
+    st = TranslateTrackpadToPtp(v1three, sizeof(v1three), out, &outLen, 0x030E, NULL);
+    ASSERT_TRUE("v1 three contacts ok", NT_SUCCESS(st));
+    ASSERT_EQ_UL("v1 three → count 3", 3, out[19]);
+    ASSERT_EQ_UL("v1 three ids 0,1,2", 0, out[2]);
+    ASSERT_EQ_UL("v1 finger1 id 1", 1, out[8]);
+    ASSERT_EQ_UL("v1 finger2 id 2", 2, out[14]);
+    ASSERT_EQ_UL("v1 physical click → button1", 1, out[22]);
+    ASSERT_EQ_UL("v1 finger2 tip", 0x03, out[13]);
+
+    memset(v2two, 0, sizeof(v2two));
+    v2two[0] = TP_RID_V2_BT;
+    PackV2Touch(v2two + 4, 3, 50, TRUE);
+    PackV2Touch(v2two + 13, 4, 60, TRUE);
+    outLen = sizeof(out);
+    st = TranslateTrackpadToPtp(v2two, sizeof(v2two), out, &outLen, 0x0265, NULL);
+    ASSERT_TRUE("v2 two contacts ok", NT_SUCCESS(st));
+    ASSERT_EQ_UL("v2 count 2", 2, out[19]);
+    ASSERT_EQ_UL("v2 id0", 3, out[2]);
+    ASSERT_EQ_UL("v2 id1", 4, out[8]);
+
+    {
+        UCHAR bat[3] = { 0x90, 0x04, 0x2F };
+        outLen = sizeof(out);
+        st = TranslateTrackpadToPtp(bat, sizeof(bat), out, &outLen, 0x0324, NULL);
+        ASSERT_TRUE("0x90 not PTP", st == STATUS_NO_MORE_ENTRIES);
+    }
+    {
+        UCHAR mouse[8] = { 0x12, 0x01, 0, 0, 0, 0, 0, 0 };
+        outLen = sizeof(out);
+        st = TranslateTrackpadToPtp(mouse, sizeof(mouse), out, &outLen, 0x030E, NULL);
+        ASSERT_TRUE("0x12 not PTP", st == STATUS_NO_MORE_ENTRIES);
+    }
+    {
+        UCHAR tooSmall[4];
+        ULONG tiny = 4;
+        memset(v1, 0, sizeof(v1));
+        v1[0] = TP_RID_V1;
+        PackV1Touch(v1 + 4, 1, 1, 0x40);
+        st = TranslateTrackpadToPtp(v1, sizeof(v1), tooSmall, &tiny, 0x030E, NULL);
+        ASSERT_TRUE("short out BUFFER_TOO_SMALL", st == STATUS_BUFFER_TOO_SMALL);
+    }
+
+    printf("%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/v2-kmdf-driver/tests/test_mouse_multitouch_click.py
+++ b/v2-kmdf-driver/tests/test_mouse_multitouch_click.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Host-side 0323 2/3-finger click + surface-scroll still from touch delta.
+
+No live mouse. Ports GestureEngine.c TranslateMouse2ToHid for this tree
+(any-finger scroll, MM_SCROLL_STEP 64) plus mechanical contact-count remap.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GESTURE = ROOT / "GestureEngine.c"
+GESTURE_H = ROOT / "GestureEngine.h"
+HID_DESC = ROOT / "HidDescriptor.c"
+
+MM2_HEADER_LEN = 14
+MM2_COMPACT_LEN = 8
+MM2_TOUCH_BYTES = 8
+MM_MOUSE_REPORT_LEN = 8
+MM_REPORT_ID_MOUSE = 0x12
+MM_TOUCH_SLOTS = 16
+MM_SCROLL_STEP = 64
+TOUCH_STATE_MASK = 0xF0
+TOUCH_STATE_NONE = 0x00
+TOUCH_STATE_START = 0x30
+TOUCH_STATE_DRAG = 0x40
+MM_BTN_LEFT = 0x01
+MM_BTN_RIGHT = 0x02
+MM_BTN_MIDDLE = 0x04
+MM2_BTN_MASK = 0x03
+
+
+def _code(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//.*?$", "", text, flags=re.M)
+
+
+def _i32(u: int) -> int:
+    u &= 0xFFFFFFFF
+    return u - 0x100000000 if u >= 0x80000000 else u
+
+
+def _clamp_i8(value: int) -> int:
+    if value > 127:
+        return 127
+    if value < -127:
+        return -127
+    return value
+
+
+def _read_i12le(t0: int, t1: int) -> int:
+    return _i32((t1 << 28) | (t0 << 20)) >> 20
+
+
+def _read_y(t1: int, t2: int) -> int:
+    return -(_i32((t2 << 24) | (t1 << 16)) >> 20)
+
+
+def pack_touch(x: int, y: int, tid: int, state: int) -> bytes:
+    x12 = x & 0xFFF
+    y12 = (-y) & 0xFFF
+    t = bytearray(MM2_TOUCH_BYTES)
+    t[0] = x12 & 0xFF
+    t[1] = ((x12 >> 8) & 0x0F) | ((y12 & 0x0F) << 4)
+    t[2] = (y12 >> 4) & 0xFF
+    t[5] = (tid & 3) << 6
+    t[6] = (tid >> 2) & 0xFF
+    t[7] = state & TOUCH_STATE_MASK
+    return bytes(t)
+
+
+def make_mt(touches: list[bytes], buttons: int = 0) -> bytearray:
+    buf = bytearray(MM2_HEADER_LEN + MM2_TOUCH_BYTES * len(touches))
+    buf[0] = MM_REPORT_ID_MOUSE
+    buf[1] = buttons & 0xFF
+    for i, t in enumerate(touches):
+        off = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES
+        buf[off : off + MM2_TOUCH_BYTES] = t
+    return buf
+
+
+class Ctx:
+    def __init__(self) -> None:
+        self.TouchAnchorX = [0] * MM_TOUCH_SLOTS
+        self.TouchAnchorY = [0] * MM_TOUCH_SLOTS
+        self.TouchAnchorValid = [False] * MM_TOUCH_SLOTS
+        self.ClickHeld = False
+        self.ClickLatched = 0
+
+
+def accumulate_surface_scroll(inp: bytes, ctx: Ctx) -> tuple[int, int]:
+    """Port of AccumulateSurfaceScroll in this tree (any finger, step 64)."""
+    out_wheel = 0
+    out_hwheel = 0
+    if len(inp) < MM2_HEADER_LEN:
+        return out_wheel, out_hwheel
+    n_touches = (len(inp) - MM2_HEADER_LEN) // MM2_TOUCH_BYTES
+    if n_touches == 0:
+        return out_wheel, out_hwheel
+    for i in range(n_touches):
+        off = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES
+        if off + MM2_TOUCH_BYTES > len(inp):
+            break
+        t = inp[off : off + MM2_TOUCH_BYTES]
+        tid = ((t[6] << 2) | (t[5] >> 6)) & 0xF
+        if tid >= MM_TOUCH_SLOTS:
+            continue
+        x = _read_i12le(t[0], t[1])
+        y = _read_y(t[1], t[2])
+        state = t[7] & TOUCH_STATE_MASK
+        if state == TOUCH_STATE_START:
+            ctx.TouchAnchorX[tid] = x
+            ctx.TouchAnchorY[tid] = y
+            ctx.TouchAnchorValid[tid] = True
+            continue
+        if state != TOUCH_STATE_DRAG or not ctx.TouchAnchorValid[tid]:
+            if state == 0x00:
+                ctx.TouchAnchorValid[tid] = False
+            continue
+        step_y = ctx.TouchAnchorY[tid] - y
+        step_x = ctx.TouchAnchorX[tid] - x
+        if step_y >= MM_SCROLL_STEP or step_y <= -MM_SCROLL_STEP:
+            out_wheel += 1 if step_y > 0 else -1
+            ctx.TouchAnchorY[tid] = y
+        if step_x >= MM_SCROLL_STEP or step_x <= -MM_SCROLL_STEP:
+            out_hwheel += -1 if step_x > 0 else 1
+            ctx.TouchAnchorX[tid] = x
+    return out_wheel, out_hwheel
+
+
+def count_active_touches(inp: bytes) -> int:
+    if len(inp) < MM2_HEADER_LEN:
+        return 0
+    n_touches = (len(inp) - MM2_HEADER_LEN) // MM2_TOUCH_BYTES
+    n = 0
+    for i in range(n_touches):
+        off = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES
+        if off + MM2_TOUCH_BYTES > len(inp):
+            break
+        state = inp[off + 7] & TOUCH_STATE_MASK
+        if state in (TOUCH_STATE_START, TOUCH_STATE_DRAG):
+            n += 1
+    return n
+
+
+def map_contact_count_to_buttons(contacts: int) -> int:
+    if contacts >= 3:
+        return MM_BTN_MIDDLE
+    if contacts == 2:
+        return MM_BTN_RIGHT
+    if contacts == 1:
+        return MM_BTN_LEFT
+    return 0
+
+
+def remap_mechanical_click(
+    hw: int,
+    contacts: int,
+    have_touch: bool,
+    scrolled: bool,
+    ctx: Ctx,
+) -> int:
+    mech = (hw & MM_BTN_LEFT) != 0
+    if not have_touch:
+        if ctx.ClickHeld and mech:
+            return ctx.ClickLatched
+        ctx.ClickHeld = False
+        ctx.ClickLatched = 0
+        return hw & MM2_BTN_MASK
+    if not mech:
+        ctx.ClickHeld = False
+        ctx.ClickLatched = 0
+        return 0
+    if not ctx.ClickHeld:
+        ctx.ClickHeld = True
+        if scrolled:
+            ctx.ClickLatched = 0
+        elif contacts == 0:
+            ctx.ClickLatched = hw & MM2_BTN_MASK
+        else:
+            ctx.ClickLatched = map_contact_count_to_buttons(contacts)
+    return ctx.ClickLatched
+
+
+def translate_mouse2_to_hid(inp: bytes, ctx: Ctx) -> bytes:
+    n = len(inp)
+    wheel = 0
+    hwheel = 0
+    if n >= MM2_HEADER_LEN:
+        wheel, hwheel = accumulate_surface_scroll(inp, ctx)
+    elif n >= 8:
+        hwheel = inp[6] if inp[6] < 128 else inp[6] - 256
+        wheel = inp[7] if inp[7] < 128 else inp[7] - 256
+    have_touch = n >= MM2_HEADER_LEN
+    contacts = count_active_touches(inp) if have_touch else 0
+    scrolled = wheel != 0 or hwheel != 0
+    buttons = remap_mechanical_click(
+        inp[1] & MM2_BTN_MASK if n >= 2 else 0,
+        contacts,
+        have_touch,
+        scrolled,
+        ctx,
+    )
+    out = bytearray(MM_MOUSE_REPORT_LEN)
+    out[0] = MM_REPORT_ID_MOUSE
+    out[1] = buttons
+    if n >= 4:
+        out[2:4] = inp[2:4]
+    if n >= 6:
+        out[4:6] = inp[4:6]
+    out[6] = _clamp_i8(hwheel) & 0xFF
+    out[7] = _clamp_i8(wheel) & 0xFF
+    return bytes(out)
+
+
+class _Run:
+    def __init__(self) -> None:
+        self.failed: list[str] = []
+
+    def check(self, name: str, ok: bool, detail: str = "") -> None:
+        if ok:
+            print(f"ok  {name}")
+        else:
+            print(f"FAIL {name} {detail}".rstrip())
+            self.failed.append(name)
+
+
+def _i8(b: int) -> int:
+    return b - 256 if b >= 128 else b
+
+
+def test_c_source(run: _Run) -> None:
+    if not GESTURE.is_file():
+        run.check("GestureEngine.c exists", False)
+        return
+    src = _code(GESTURE.read_text(encoding="utf-8"))
+    hdr = _code(GESTURE_H.read_text(encoding="utf-8")) if GESTURE_H.is_file() else ""
+    hid = _code(HID_DESC.read_text(encoding="utf-8")) if HID_DESC.is_file() else ""
+    run.check("AccumulateSurfaceScroll still called", "AccumulateSurfaceScroll" in src)
+    run.check("MM_SCROLL_STEP present", "MM_SCROLL_STEP" in src or "MM_SCROLL_STEP" in hdr)
+    run.check("CountActiveTouches present", "CountActiveTouches" in src)
+    run.check("MapContactCountToButtons present", "MapContactCountToButtons" in src)
+    run.check("RemapMechanicalClick present", "RemapMechanicalClick" in src)
+    run.check("MM_BTN_RIGHT in header", "MM_BTN_RIGHT" in hdr)
+    run.check("MM_BTN_MIDDLE in header", "MM_BTN_MIDDLE" in hdr)
+    run.check("no GPL emit_buttons", "magicmouse_emit_buttons" not in src)
+    run.check("no GPL firm_touch", "magicmouse_firm_touch" not in src)
+    run.check("no GPL middle_button_start", "middle_button_start" not in src)
+    run.check(
+        "descriptor Button 3 same length",
+        "0x29, 0x03" in hid.replace(" ", "") or "0x29,0x03" in hid.replace(" ", ""),
+    )
+    run.check(
+        "descriptor report count 3",
+        "0x95, 0x03" in hid.replace(" ", "") or "0x95,0x03" in hid.replace(" ", ""),
+    )
+
+
+def test_one_finger_click_left(run: _Run) -> None:
+    ctx = Ctx()
+    inp = make_mt([pack_touch(0, 0, 1, TOUCH_STATE_START)], buttons=1)
+    out = translate_mouse2_to_hid(inp, ctx)
+    run.check(
+        "1-finger mechanical → left, no wheel",
+        out[1] == MM_BTN_LEFT and out[7] == 0 and out[6] == 0,
+        f"btn={out[1]:#x} wheel={out[7]} pan={out[6]}",
+    )
+
+
+def test_two_finger_click_right(run: _Run) -> None:
+    ctx = Ctx()
+    inp = make_mt(
+        [
+            pack_touch(0, 0, 1, TOUCH_STATE_START),
+            pack_touch(10, 0, 2, TOUCH_STATE_START),
+        ],
+        buttons=1,
+    )
+    out = translate_mouse2_to_hid(inp, ctx)
+    run.check(
+        "2-finger mechanical → right, no wheel",
+        out[1] == MM_BTN_RIGHT and out[7] == 0,
+        f"btn={out[1]:#x} wheel={out[7]}",
+    )
+
+
+def test_three_finger_click_middle(run: _Run) -> None:
+    ctx = Ctx()
+    inp = make_mt(
+        [
+            pack_touch(0, 0, 1, TOUCH_STATE_START),
+            pack_touch(10, 0, 2, TOUCH_STATE_START),
+            pack_touch(20, 0, 3, TOUCH_STATE_START),
+        ],
+        buttons=1,
+    )
+    out = translate_mouse2_to_hid(inp, ctx)
+    run.check(
+        "3-finger mechanical → middle",
+        out[1] == MM_BTN_MIDDLE and out[7] == 0,
+        f"btn={out[1]:#x} wheel={out[7]}",
+    )
+
+
+def test_scroll_drag_not_click(run: _Run) -> None:
+    ctx = Ctx()
+    start = make_mt(
+        [
+            pack_touch(0, 0, 1, TOUCH_STATE_START),
+            pack_touch(10, 0, 2, TOUCH_STATE_START),
+        ],
+        buttons=0,
+    )
+    translate_mouse2_to_hid(start, ctx)
+    drag = make_mt(
+        [
+            pack_touch(0, -MM_SCROLL_STEP, 1, TOUCH_STATE_DRAG),
+            pack_touch(10, -MM_SCROLL_STEP, 2, TOUCH_STATE_DRAG),
+        ],
+        buttons=0,
+    )
+    out = translate_mouse2_to_hid(drag, ctx)
+    run.check(
+        "2-finger DRAG mechanical up → wheel, buttons 0",
+        out[1] == 0 and _i8(out[7]) != 0,
+        f"btn={out[1]:#x} wheel={_i8(out[7])}",
+    )
+
+
+def test_press_during_detent_suppressed(run: _Run) -> None:
+    ctx = Ctx()
+    start = make_mt(
+        [
+            pack_touch(0, 0, 1, TOUCH_STATE_START),
+            pack_touch(10, 0, 2, TOUCH_STATE_START),
+        ],
+        buttons=0,
+    )
+    translate_mouse2_to_hid(start, ctx)
+    press = make_mt(
+        [
+            pack_touch(0, -MM_SCROLL_STEP, 1, TOUCH_STATE_DRAG),
+            pack_touch(10, -MM_SCROLL_STEP, 2, TOUCH_STATE_DRAG),
+        ],
+        buttons=1,
+    )
+    out = translate_mouse2_to_hid(press, ctx)
+    run.check(
+        "press on detent report → buttons 0, wheel kept",
+        out[1] == 0 and _i8(out[7]) != 0,
+        f"btn={out[1]:#x} wheel={_i8(out[7])}",
+    )
+
+
+def test_latch_holds_right(run: _Run) -> None:
+    ctx = Ctx()
+    press = make_mt(
+        [
+            pack_touch(0, 0, 1, TOUCH_STATE_START),
+            pack_touch(10, 0, 2, TOUCH_STATE_START),
+        ],
+        buttons=1,
+    )
+    out1 = translate_mouse2_to_hid(press, ctx)
+    held = make_mt(
+        [
+            pack_touch(0, 0, 1, TOUCH_STATE_DRAG),
+            pack_touch(10, 0, 2, TOUCH_STATE_NONE),
+        ],
+        buttons=1,
+    )
+    out2 = translate_mouse2_to_hid(held, ctx)
+    run.check(
+        "latch: 2-finger press then one NONE still right",
+        out1[1] == MM_BTN_RIGHT and out2[1] == MM_BTN_RIGHT,
+        f"press={out1[1]:#x} held={out2[1]:#x}",
+    )
+
+
+def test_compact_hardware_left(run: _Run) -> None:
+    ctx = Ctx()
+    inp = bytearray(MM2_COMPACT_LEN)
+    inp[0] = MM_REPORT_ID_MOUSE
+    inp[1] = 1
+    out = translate_mouse2_to_hid(bytes(inp), ctx)
+    run.check(
+        "compact mechanical → hardware left",
+        out[1] == MM_BTN_LEFT,
+        f"btn={out[1]:#x}",
+    )
+
+
+def test_one_finger_drag_still_scrolls(run: _Run) -> None:
+    """This tree has no TWO_FINGER gate; 1-finger DRAG of step 64 must wheel."""
+    ctx = Ctx()
+    start = make_mt([pack_touch(0, 0, 1, TOUCH_STATE_START)], buttons=0)
+    translate_mouse2_to_hid(start, ctx)
+    drag = make_mt(
+        [pack_touch(0, -MM_SCROLL_STEP, 1, TOUCH_STATE_DRAG)],
+        buttons=0,
+    )
+    out = translate_mouse2_to_hid(drag, ctx)
+    run.check(
+        "1-finger DRAG step 64 → wheel (scroll path unchanged)",
+        out[1] == 0 and _i8(out[7]) != 0,
+        f"btn={out[1]:#x} wheel={_i8(out[7])}",
+    )
+
+
+def main() -> int:
+    run = _Run()
+    test_c_source(run)
+    test_one_finger_click_left(run)
+    test_two_finger_click_right(run)
+    test_three_finger_click_middle(run)
+    test_scroll_drag_not_click(run)
+    test_press_during_detent_suppressed(run)
+    test_latch_holds_right(run)
+    test_compact_hardware_left(run)
+    test_one_finger_drag_still_scrolls(run)
+    if run.failed:
+        print(f"{len(run.failed)} failed: {', '.join(run.failed)}")
+        return 1
+    print("all passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/v2-kmdf-driver/tests/validate-package.sh
+++ b/v2-kmdf-driver/tests/validate-package.sh
@@ -10,10 +10,15 @@ bad() { echo "FAIL $1"; fail=1; }
 echo "Validating $ROOT"
 
 if grep -q 'PID&0323' "$ROOT/MagicMouseDriver.inf"; then ok "0323 hardware ID in INF"; else bad "0323 hardware ID in INF"; fi
+if grep -q 'PID&030E' "$ROOT/MagicMouseDriver.inf" && grep -q 'PID&0265' "$ROOT/MagicMouseDriver.inf" && grep -q 'PID&0324' "$ROOT/MagicMouseDriver.inf"; then
+  ok "trackpad 030E/0265/0324 hardware IDs in INF"
+else
+  bad "trackpad 030E/0265/0324 hardware IDs in INF"
+fi
 if grep -qE 'PID&030[Dd]|PID&0269|PID&0310' "$ROOT/MagicMouseDriver.inf"; then
   bad "INF hardware IDs must not include 030D/0269/0310"
 else
-  ok "INF hardware IDs are 0323-only"
+  ok "INF does not bind 030D/0269/0310"
 fi
 if grep -q 'LowerFilters",0x00010000,"MagicMouseDriver"' "$ROOT/MagicMouseDriver.inf"; then
   ok "sole LowerFilters=MagicMouseDriver"
@@ -45,6 +50,14 @@ else
 fi
 test -f "$ROOT/Driver.c" && ok "Driver.c present" || bad "Driver.c present"
 test -f "$ROOT/AclTranslate.c" && ok "AclTranslate.c present" || bad "AclTranslate.c present"
+test -f "$ROOT/TrackpadPtp.c" && ok "TrackpadPtp.c present" || bad "TrackpadPtp.c present"
+grep -q '0x09, 0x05' "$ROOT/TrackpadPtp.c" && ok "PTP Touch Pad usage 0x05" || bad "PTP Touch Pad usage 0x05"
+grep -q '0x85, 0x01' "$ROOT/TrackpadPtp.c" && ok "PTP RID 0x01" || bad "PTP RID 0x01"
+if grep -q 'MagicTrackpad.sys\|MagicUtilities' "$ROOT/TrackpadPtp.c"; then
+  bad "TrackpadPtp must not vendor MU"
+else
+  ok "TrackpadPtp does not vendor MU"
+fi
 grep -q '0x85, 0x12' "$ROOT/HidDescriptor.c" && ok "descriptor COL01 RID 0x12" || bad "descriptor COL01 RID 0x12"
 grep -q '0x85, 0x90' "$ROOT/HidDescriptor.c" && ok "descriptor COL02 RID 0x90" || bad "descriptor COL02 RID 0x90"
 grep -q '0x09, 0x38' "$ROOT/HidDescriptor.c" && ok "descriptor Wheel usage 0x38" || bad "descriptor Wheel usage 0x38"

--- a/v2-kmdf-driver/tests/validate-package.sh
+++ b/v2-kmdf-driver/tests/validate-package.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Linux-side package checks. Does not build a .sys.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+ok()  { echo "OK  $1"; }
+bad() { echo "FAIL $1"; fail=1; }
+
+echo "Validating $ROOT"
+
+if grep -q 'PID&0323' "$ROOT/MagicMouseDriver.inf"; then ok "0323 hardware ID in INF"; else bad "0323 hardware ID in INF"; fi
+if grep -qE 'PID&030[Dd]|PID&0269|PID&0310' "$ROOT/MagicMouseDriver.inf"; then
+  bad "INF hardware IDs must not include 030D/0269/0310"
+else
+  ok "INF hardware IDs are 0323-only"
+fi
+if grep -q 'LowerFilters",0x00010000,"MagicMouseDriver"' "$ROOT/MagicMouseDriver.inf"; then
+  ok "sole LowerFilters=MagicMouseDriver"
+else
+  bad "sole LowerFilters=MagicMouseDriver"
+fi
+if grep -q 'LowerFilters.*,"applewirelessmouse"' "$ROOT/MagicMouseDriver.inf"; then
+  bad "INF must not set applewirelessmouse as a filter"
+else
+  ok "INF does not set applewirelessmouse LowerFilters"
+fi
+test -f "$ROOT/Install-KMDF.cmd" && ok "one-click cmd exists" || bad "one-click cmd exists"
+test -f "$ROOT/scripts/Invoke-KmdfInstall.ps1" && ok "SYSTEM install runner exists" || bad "SYSTEM install runner exists"
+test -f "$ROOT/scripts/Invoke-KmdfPostBoot.ps1" && ok "post-boot runner exists" || bad "post-boot runner exists"
+if test -f "$ROOT/mm-dev.ps1" || test -f "$ROOT/scripts/mm-dev.ps1"; then
+  bad "mm-dev.ps1 must not ship"
+else
+  ok "no mm-dev.ps1"
+fi
+if grep -R -n --include='*.ps1' --include='*.cmd' 'Phase=Full' "$ROOT" >/dev/null; then
+  bad "Phase=Full leftover"
+else
+  ok "no Phase=Full leftover"
+fi
+if grep -R -n --include='*.ps1' "MagicMouseDriver', 'applewirelessmouse" "$ROOT" >/dev/null; then
+  bad "dual-filter array in scripts"
+else
+  ok "no dual-filter array in scripts"
+fi
+test -f "$ROOT/Driver.c" && ok "Driver.c present" || bad "Driver.c present"
+test -f "$ROOT/AclTranslate.c" && ok "AclTranslate.c present" || bad "AclTranslate.c present"
+grep -q '0x85, 0x12' "$ROOT/HidDescriptor.c" && ok "descriptor COL01 RID 0x12" || bad "descriptor COL01 RID 0x12"
+grep -q '0x85, 0x90' "$ROOT/HidDescriptor.c" && ok "descriptor COL02 RID 0x90" || bad "descriptor COL02 RID 0x90"
+grep -q '0x09, 0x38' "$ROOT/HidDescriptor.c" && ok "descriptor Wheel usage 0x38" || bad "descriptor Wheel usage 0x38"
+if grep -q '0x85, 0x47' "$ROOT/HidDescriptor.c"; then
+  bad "descriptor must not inject Feature 0x47"
+else
+  ok "descriptor has no Feature 0x47"
+fi
+if grep -q 'out\[0\] = 0x02' "$ROOT/GestureEngine.c"; then
+  bad "GestureEngine must not convert to RID 0x02"
+else
+  ok "GestureEngine does not emit RID 0x02"
+fi
+grep -q 'out\[0\] = MM_REPORT_ID_MOUSE' "$ROOT/GestureEngine.c" && ok "GestureEngine stays on RID 0x12" || bad "GestureEngine stays on RID 0x12"
+grep -q '#define MM_MOUSE_REPORT_LEN 8' "$ROOT/Driver.h" && ok "0x12 report is 8 bytes" || bad "0x12 report is 8 bytes"
+grep -q 'ReadI16Le' "$ROOT/GestureEngine.c" && ok "optical X/Y copied as INT16" || bad "optical X/Y copied as INT16"
+grep -q "UserId 'SYSTEM'" "$ROOT/Install-KMDF.ps1" && ok "SYSTEM principal" || bad "SYSTEM principal"
+grep -q 'MM-Kmdf-Install' "$ROOT/scripts/Kmdf-Common.ps1" && ok "task name MM-Kmdf-Install" || bad "task name MM-Kmdf-Install"
+grep -qi 'magic-tray' "$ROOT/MAGIC-TRAY.md" && ok "magic-tray pull note" || bad "magic-tray pull note"
+grep -q '559B136A' "$ROOT/scripts/Kmdf-Common.ps1" && ok "May 20 pointer-dead SHA banned" || bad "May 20 pointer-dead SHA banned"
+grep -q 'CN=MagicMouseFix' "$ROOT/scripts/Kmdf-Common.ps1" && ok "signs as MagicMouseFix" || bad "signs as MagicMouseFix"
+if grep -q 'ServiceBinary = %12%\\MagicMouseDriver.sys' "$ROOT/MagicMouseDriver.inf" && \
+   grep -q 'MagicMouseDriver.sys = 1' "$ROOT/MagicMouseDriver.inf"; then
+  ok "INF still installs MagicMouseDriver.sys"
+else
+  bad "INF still installs MagicMouseDriver.sys"
+fi
+grep -q 'MagicMouseDriver-kmdf-2.0.4-scroll.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "scroll artifact name" || bad "scroll artifact name"
+grep -q 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "Apr 30 pointer artifact name" || bad "Apr 30 pointer artifact name"
+grep -q 'MagicMouseDriver-kmdf-may20-pointerdead-559B136A.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "May 20 pointer-dead artifact name" || bad "May 20 pointer-dead artifact name"
+grep -q 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys' "$ROOT/scripts/Kmdf-Common.ps1" && ok "PATH-A ship-blocker name" || bad "PATH-A ship-blocker name"
+grep -q 'FILEVERSION    2,0,4,0' "$ROOT/MagicMouseDriver.rc" && ok "FileVersion 2.0.4.0 in VERSIONINFO" || bad "FileVersion 2.0.4.0 in VERSIONINFO"
+grep -q 'OriginalFilename", "MagicMouseDriver-kmdf-2.0.4-scroll.sys' "$ROOT/MagicMouseDriver.rc" && ok "OriginalFilename is scroll artifact" || bad "OriginalFilename is scroll artifact"
+if grep -q '<TargetName>MagicMouseDriver</TargetName>' "$ROOT/MagicMouseDriver.vcxproj"; then
+  ok "vcxproj TargetName still MagicMouseDriver"
+else
+  bad "vcxproj TargetName still MagicMouseDriver"
+fi
+REPO="$(cd "$ROOT/.." && pwd)"
+if grep -q 'MagicMouseDriver-kmdf-apr30-pointer-AD5D244B.sys' "$REPO/README.md" && \
+   grep -q 'MagicMouseDriver-kmdf-2.0.4-scroll.sys' "$REPO/README.md" && \
+   grep -q 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys' "$REPO/README.md"; then
+  ok "root README names pointer-only vs scroll vs SHIP-BLOCKER"
+else
+  bad "root README names pointer-only vs scroll vs SHIP-BLOCKER"
+fi
+if grep -q 'applewirelessmouse-patched-pathA-SHIPBLOCKER.sys' "$REPO/v1-binary-patch/installer/Install-MagicMousePatch.ps1" && \
+   grep -q 'System32\\drivers\\applewirelessmouse.sys' "$REPO/v1-binary-patch/installer/Install-MagicMousePatch.ps1"; then
+  ok "PATH-A package name vs Windows install name"
+else
+  bad "PATH-A package name vs Windows install name"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## Why this targets `main`

GitHub **default HEAD is currently `ai/magic-mouse-initial-release`, not `main`.**
Magic Tray still downloads `refs/heads/main.zip` (`LesleyMurfin/magic-mouse-v3-windows-fix`),
so `v2-kmdf-driver/Install-KMDF.cmd` must land on **`main`**. This PR targets `main` on purpose.

## What Magic Tray SELECT runs

Tray SELECT for PID **0323** clones/unzips `main` and runs:

`v2-kmdf-driver/Install-KMDF.cmd`

That cmd is the **only** 0323 install entrypoint. It launches `Install-KMDF.ps1`
(first click: UAC to register SYSTEM task `MM-Kmdf-Install`; later clicks: no prompt).

## Contract

- PatchedKmdf = `MagicMouseDriver` (INF dest `MagicMouseDriver.sys`).
- Battery = HID Input **0x90** COL02 `buf[2]` (not Feature 0x47).
- Gesture path stays on live HID RID **0x12** (8-byte mouse + Wheel / AC Pan). Keyboard patch requires `-Mac`.
- **PATH-A is unsupported** (`v1-binary-patch/` / `applewirelessmouse-patched-pathA-SHIPBLOCKER.sys`, BSOD 0xD1). Do not merge PATH-A. Do not dual-filter with `applewirelessmouse`.
- No prebuilt `.sys` in this PR. Linux cannot produce one.
- Install requires **Test Mode** and **HVCI off**.

Do not merge until the maintainer is ready; this PR exists so `main.zip` can grow the cmd.
