### PR TITLE
feat(kmdf): park README v2 rewrite and driver helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Magic Mouse v3 Windows Scroll Fix
 
-**STATUS: Production Ready v1.0.0**
+**STATUS: Pre-release (public packaging in progress).**
 
-A Windows kernel driver patch that restores scroll functionality on Apple Magic Mouse v3 (2024) after Bluetooth reconnection.
+Two drivers are available for the Apple Magic Mouse v3 (2024) on Windows. The **v2 KMDF driver** (recommended) restores scroll **and** gestures **and** battery readout, and has been in daily use on developer hardware for months. The **v1 binary patch** is the older fallback (scroll only). No tagged GitHub Release exists yet — install assets are being finalized. See **[Choose Your Driver](#choose-your-driver)** below.
 
 ## What This Fixes
 
@@ -19,6 +19,46 @@ Apple Magic Mouse v3 on Windows 10/11 loses scroll capability after Bluetooth id
 - After ~15–30 min idle + Bluetooth disconnect, scroll stops responding
 - Cursor movement continues normally
 - Issue does not self-recover; requires driver reinstall or device repair
+
+## Choose Your Driver
+
+This repo ships **two** independent drivers. Pick one — you do not install both.
+
+| | **v2 — KMDF driver** ★ recommended | **v1 — binary patch** |
+|---|---|---|
+| **Scroll** | ✅ | ✅ |
+| **Gestures** | ✅ | ❌ |
+| **Battery %** | ✅ native (shows in Windows Settings) | ⚠️ workaround only — *mutually exclusive with scroll* (see below) |
+| **Source** | Full source, auditable | Opaque patched Apple binary |
+| **Apple dependency** | None (written from scratch) | Patches Apple's `applewirelessmouse.sys` |
+| **Maturity** | In daily use on dev hardware for months | Older approach (sbagirici lineage) |
+| **Trade-off** | Adds a KMDF filter to the Bluetooth stack | Redistributes a patched Apple binary (see [DMCA-NOTICE](DMCA-NOTICE.md)) |
+| **Both require** | Test-signing enabled + trust the self-signed cert (shows a "Test Mode" desktop watermark) | same |
+
+### The battery difference (important)
+
+- **v2 KMDF** exposes battery natively (HID Feature report, `RID 0x47`). Scroll, gestures, and battery
+  all work **at the same time**, with no manual steps — battery percentage appears in Windows Settings.
+- **v1 binary patch** cannot do scroll and battery at once. With v1, the two are **mutually exclusive**:
+  one device state gives you scroll (battery unavailable), the other gives you a battery read (scroll
+  broken). Getting a battery reading means manually flipping the device state and flipping back. This is
+  a clunky legacy workaround — it is the main reason the v2 KMDF driver was built.
+
+```
+   v1 — BINARY PATCH                       v2 — KMDF DRIVER  (★ recommended)
+   Scroll  ─┐  MUTUALLY                    Scroll + Gestures + Battery %
+   Battery ─┘  EXCLUSIVE                   ALL AT ONCE, natively
+        │   flip device state to               │   one install, done
+        │   swap scroll ⇄ battery              │
+        ▼                                      ▼
+   ✓ Scroll OR ✓ Battery (never both)      ✓ Scroll  ✓ Gestures  ✓ Battery
+```
+
+**Recommendation:** choose **v2 KMDF** unless you specifically cannot run a kernel filter driver. It is
+the only option that gives scroll + gestures + battery together, and it does not redistribute Apple code.
+
+> **Install:** v1 binary-patch steps are in [Quick Install](#quick-install-3-steps) below. The v2 KMDF
+> installer (`mm-dev.ps1`) and signed binaries ship with the upcoming tagged release.
 
 ## Supported Hardware
 
@@ -39,33 +79,35 @@ Apple Magic Mouse v3 on Windows 10/11 loses scroll capability after Bluetooth id
 
 ## Quick Install (3 Steps)
 
+> **Not yet available — ships with the first tagged release.** The signed v1
+> binary, its `SHA256SUMS` checksum file, and the install script are published as
+> assets on the GitHub release (see [Releases](../../releases)). The steps below
+> describe the flow; the exact filenames and the verified checksum will be filled
+> in from the release assets when the tag is cut. **Do not trust any hash that is
+> not published in the release's `SHA256SUMS`.**
+
 ### Step 1: Download & Verify
 
 ```powershell
-# Download v1.0.0 release
-# Extract to C:\Program Files\MagicMousePatch\
-
-# Verify binary integrity (mandatory)
-$sys = "C:\Program Files\MagicMousePatch\v1-binary-patch\applewirelessmouse.sys"
-(Get-FileHash $sys -Algorithm SHA256).Hash
-# Expected: 370A5555AEBF673C3156EA5B5FBABD8030F2EE7A3A6BD0FCB1B4B6C93FA56A03
+# Download the v1 binary + SHA256SUMS from the tagged GitHub release, then:
+Get-FileHash .\applewirelessmouse.sys -Algorithm SHA256
+# Compare the output against the value in the release's SHA256SUMS file.
 ```
 
 ### Step 2: Run Installer
 
 ```powershell
-# Open PowerShell as Administrator
-cd "C:\Program Files\MagicMousePatch\v1-binary-patch\installer"
-.\Install-MagicMousePatch.ps1
-
-# Accept certificate trust prompt when prompted
+# Open PowerShell as Administrator, in the extracted release folder.
+# The release bundles the signing certificate and an install script; trust the
+# cert (Root + TrustedPublisher) and install the signed package:
+.\install-driver.ps1 -InfPath .\MagicMouseDriver.inf
+# Accept the certificate-trust prompt when prompted.
 ```
 
 ### Step 3: Reboot
 
 ```powershell
-# Follow on-screen instructions, or manually:
-shutdown /r /t 60 /c "MagicMousePatch installer - rebooting"
+shutdown /r /t 60 /c "Magic Mouse driver install - rebooting"
 ```
 
 ## What Changes on Your System
@@ -181,22 +223,15 @@ HKLM\SYSTEM\CurrentControlSet\Enum\BTHENUM\
 - Test 6 (UsoClient force-DSM): scroll preserved — PASS
 - Phase 5 (cold reboot): DSM ran twice post-boot, scroll still working — PASS
 
-## Roadmap
+## Versions
 
-**v1.0.0 (current):** Binary patch of Apple firmware via WDM lower filter.
-- Patched applewirelessmouse.sys (66 KB)
-- PowerShell installer + uninstaller
-- Registry-based LowerFilters registration
-- Requires certificate trust
+Two drivers ship from this repo. Pick one with the [Choose Your Driver](#choose-your-driver) table above.
 
-**v2.0.0 (in progress):** KMDF filter driver rewrite.
-- From-scratch WDF source code
-- No Apple binary dependency
-- Cleaner driver signing process
-- Better Windows Defender SmartScreen integration
-- Windows 11 22H2+ target
+**v2 — KMDF filter driver (recommended, in production):** From-scratch Windows Driver Framework lower filter on the Bluetooth HID stack. Restores scroll + gestures **and** exposes battery percentage natively, all at once. No Apple binary dependency. This is the driver in daily use; signed binaries ship as assets on the tagged release.
 
-See `/v2-kmdf-driver/README.md` for v2 status.
+**v1 — binary patch (legacy fallback):** Patched Apple `applewirelessmouse.sys` as a WDM lower filter. Restores scroll only; battery readout requires a manual, mutually-exclusive registry flip (see the battery note above). Kept for users who cannot run the KMDF driver.
+
+See `v2-kmdf-driver/README.md` for v2 technical detail.
 
 ## Contributing
 

--- a/v2-kmdf-driver/README.md
+++ b/v2-kmdf-driver/README.md
@@ -1,287 +1,69 @@
-# v2.0.0 — KMDF Driver (Work in Progress)
+# v2 — KMDF Filter Driver
 
-**STATUS: WORK IN PROGRESS — NOT PRODUCTION READY**
+**STATUS: In production.** This is the recommended driver for the Apple Magic Mouse 2024 (Bluetooth PID `0x0323`) on Windows. It has been in daily use for months and restores scroll, gestures, **and** battery percentage at the same time.
 
-This directory contains the roadmap and architecture for v2.0.0, a from-scratch KMDF (Kernel Mode Driver Framework) filter driver implementation. v2 replaces the v1 binary patch with native source code, eliminating dependency on Apple firmware patching.
+> Packaging note: the signed binary (`MagicMouseDriver.sys` + `MagicMouseDriver.cat`) ships as an asset on the tagged GitHub release. Full source is published alongside it. This README describes the real, shipping driver — not a roadmap.
 
-## Why v2?
+## What it does
 
-### v1 Limitations
+A Kernel Mode Driver Framework (KMDF) **lower filter** on the Bluetooth HID stack
+(`HidClass → HidBth → [this filter] → BTHENUM`). Instead of patching any Apple
+binary, it intercepts the device's SDP service-attribute query and substitutes a
+corrected HID report descriptor, so Windows sees a device that scrolls *and*
+reports battery.
 
-| Issue | v1 Binary Patch | v2 KMDF Source |
-|-------|---|---|
-| Transparency | Binary only (opaque) | Full source code |
-| Apple dependency | Patches Apple firmware | Independent implementation |
-| Signing | Self-signed cert | Windows-signed (future) |
-| Maintainability | Requires re-patching firmware | Direct source modifications |
-| SmartScreen | Warnings on new systems | Better reputation over time |
-| Compliance | Custom certificate trust | Standard driver signing |
+- **Scroll + gestures:** the injected descriptor exposes a Generic Desktop Mouse
+  TLC (Report ID `0x02`) with X/Y, vertical Wheel, and AC Pan (Consumer `0x0238`)
+  horizontal scroll.
+- **Battery:** exposed as a **Feature report, Report ID `0x47`** (Generic Device
+  Controls page `0x06`, Usage `0x20`), value `0–100` = battery percent. Read from
+  user space with `HidD_GetFeature`. No filter flipping, no workaround — it is
+  live at the same time as scroll.
 
-### v2 Advantages
+This is the key difference from the v1 binary patch, where scroll and battery were
+mutually exclusive and required a manual registry flip. See the repo-root README's
+"Choose Your Driver" section.
 
-1. **Open source:** Full implementation visible for audit and modification
-2. **No Apple dependency:** Standalone KMDF driver, no firmware patching
-3. **Better signing:** Compatible with Microsoft code signing and certification
-4. **Cleaner deployment:** No custom certificate imports, standard Windows driver model
-5. **Long-term support:** Source code can be maintained across Windows versions
-6. **Transparency:** Security research and third-party review possible
+## Mechanism
 
-## Architecture
+- Installs as the sole `LowerFilters` entry (`MagicMouseDriver`) on the v3
+  `BTHENUM` stack, class `HIDClass`.
+- Intercepts `IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE` (`0x410210`) and injects the
+  corrected HID report descriptor into SDP attribute `0x0206`.
+- Device-scoped to Magic Mouse 2024 only
+  (`BTHENUM\…_VID&0001004C_PID&0323`); other HID devices are untouched.
 
-### KMDF vs WDM
-
-| Aspect | v1 (WDM Lower Filter) | v2 (KMDF Filter) |
-|--------|---|---|
-| Framework | Windows Driver Model (WDM) | Kernel Mode Driver Framework (KMDF) |
-| Code size | ~66 KB binary | ~150 KB source (compiled similar size) |
-| Complexity | Direct IRP handling | Object-oriented framework |
-| Debuggability | Standard kernel debugging | KMDF-aware tools |
-| Best practice | Older, but functional | Modern Windows driver development |
-
-### File Structure
+## Source layout
 
 ```
-v2-kmdf-driver/
-├── README.md (this file)
-├── src/
-│   ├── main.c            # DriverEntry, device creation
-│   ├── filter.c          # Filter dispatch routines
-│   ├── magic_mouse.c     # Magic Mouse-specific logic
-│   ├── ioctl_handlers.c  # Device I/O control handling
-│   └── common.h          # Shared definitions
-├── inc/
-│   ├── filter.h
-│   ├── magic_mouse.h
-│   └── version.h
-├── magic_mouse_v3.vcxproj    # Visual Studio project
-├── magic_mouse_v3.sln        # Visual Studio solution
-├── build.cmd                 # Build script
-├── BUILDING.md               # Build instructions
-└── docs/
-    ├── KMDF_MIGRATION.md     # Migration notes from WDM
-    └── TEST_PLAN.md          # Comprehensive test plan
+v2-kmdf-source/                 (in the private backup; published with the release)
+├── Driver.c / Driver.h         # DriverEntry, device add, IOCTL filtering
+├── HidDescriptor.c / .h        # The injected report descriptor (scroll + battery)
+├── InputHandler.c / .h         # Input report handling
+├── GestureEngine.c / .h        # Gesture mapping
+├── MagicMouseDriver.inf        # Lower-filter install, HIDClass
+├── MagicMouseDriver.vcxproj    # Visual Studio / WDK project
+└── (signed MagicMouseDriver.sys + .cat ship as release assets)
 ```
 
-## Development Status
-
-### Completed
-
-- [ ] Architecture design (pending)
-- [ ] KMDF framework skeleton (pending)
-- [ ] Magic Mouse PID detection (pending)
-- [ ] IRP filtering logic (pending)
-- [ ] DynamicCachedServices interception (pending)
-- [ ] Error handling (pending)
-- [ ] Unit tests (pending)
-- [ ] Integration tests (pending)
-- [ ] Code review (pending)
-
-### In Progress
-
-- KMDF initialization
-- Device enumeration and filtering
-
-### Planned
-
-- IRP interception and validation
-- Registry manipulation safeguards
-- Comprehensive testing (all 6 test scenarios)
-- Public source code release
-- Microsoft signing certification
-
-## Building v2 (When Available)
-
-### Prerequisites
-
-- Windows Driver Kit (WDK) 10.0 or later
-- Visual Studio 2019 or later
-- .NET Framework 4.7+ (for build tools)
-
-### Build Steps
+## Install (signed binary)
 
 ```powershell
-# Open Visual Studio as Administrator
-# File → Open Solution → magic_mouse_v3.sln
-# Build → Build Solution (F7)
-# Output: magic_mouse_v3.sys in output directory
-
-# Or command-line:
-msbuild magic_mouse_v3.sln /p:Configuration=Release /p:Platform=x64
+pnputil /add-driver MagicMouseDriver.inf /install
 ```
 
-### Signing (Pre-Release)
+The shipped binary is self-signed; trusting the signing certificate and enabling
+test-signing is covered in the repo-root install docs. Battery reads work as soon
+as the device re-enumerates under the filter — no extra step.
 
-```powershell
-# Test-sign for development
-signtool sign /f MagicMouseFix.pfx /p password /t http://timestamp.server.com ^
-  magic_mouse_v3.sys
+## Signing
 
-# Production (pending Microsoft certification)
-# Will be signed by Revive Business Solutions' code signing certificate
-```
+The shipping `.sys`/`.cat` are self-signed. The exact signed binary is shipped
+as-is and is **not** rebuilt from source for release: the private key that signed
+it is not reproducible from the build host, so a rebuild would not reproduce the
+same signature. Build-from-source is supported for developers who want to audit or
+modify and re-sign with their own certificate.
 
-## Testing (When Available)
+## License
 
-v2 will be tested with the same 6-scenario test suite as v1:
-
-1. **Power off/on:** Scroll persists
-2. **69-minute idle:** Scroll stable after extended idle
-3. **pnputil rescan:** Device rescan compatible
-4. **Sleep/wake:** Cache integrity maintained
-5. **UsoClient force-DSM:** DSM property scan blocked
-6. **Cold reboot:** Multiple DSM runs don't trigger collapse
-
-See `docs/TEST_PLAN.md` for detailed procedures.
-
-## Deployment Roadmap
-
-### Phase 1: Internal Testing (Target: Q3 2026)
-
-- Complete source implementation
-- Run all 6 test scenarios
-- Code review and security audit
-- Document building and testing process
-
-### Phase 2: Beta Release (Target: Q4 2026)
-
-- Source code published to GitHub (this repo)
-- Beta version for experienced users
-- Feedback collection
-- Bug fixes based on testing
-
-### Phase 3: Production Release (Target: Q1 2027)
-
-- Microsoft code signing certification
-- v2.0.0 final release
-- v1.0.0 marked as deprecated (still supported)
-- Migration guide for v1 → v2
-
-## Design Principles
-
-### v2 KMDF Implementation Will Follow:
-
-1. **Minimal interception:** Only intercept critical DSM property queries, pass all others through
-2. **Fast path:** No complex algorithms, early exit for non-Magic Mouse devices
-3. **Error safety:** If uncertainty exists, allow request (fail-open for stability)
-4. **Logging:** Debug tracing for issue diagnosis without performance penalty
-5. **Isolation:** Device-specific filtering (PID 0x0323 only), no impact on other HID devices
-6. **Compliance:** Follow Windows Driver Frameworks best practices
-
-## Comparison: v1 vs v2
-
-### v1 (Binary Patch) — Current Production
-
-**Use v1 if:**
-- You need a fix now (before v2 is available)
-- You're comfortable with binary patches
-- You're not concerned about certificate trust prompts
-
-**Install:** See `/v1-binary-patch/README.md`
-
-### v2 (KMDF Source) — Future
-
-**Use v2 when:**
-- You want to audit the source code
-- You prefer open-source drivers
-- Microsoft-signed binaries become available
-- You're building a derivative project
-
-**Timeline:** v2 becomes available Q3 2026 (beta), Q1 2027 (production)
-
-## Migration Path: v1 → v2
-
-When v2.0.0 is released:
-
-1. **v1 continues to work:** v1.0.0 will remain available and supported
-2. **Side-by-side installation:** v1 and v2 can coexist (though only one should be active)
-3. **Migration script:** Uninstall v1, install v2 (simple PowerShell script)
-4. **No breaking changes:** v2 maintains same functionality and registry interface
-
-## Contributing
-
-v2 development will welcome contributions for:
-- Code implementation (KMDF driver skeleton, dispatch routines, etc.)
-- Testing on additional hardware configurations
-- Documentation improvements
-- Code review and security audit
-
-**Process:**
-1. Fork this repository
-2. Create feature branch: `git checkout -b ai/v2-feature-name`
-3. Implement feature + tests
-4. Open pull request with test evidence
-5. Code review before merge
-
-See `CONTRIBUTING.md` for details.
-
-## FAQ
-
-### Q: Why not release v2 now?
-
-A: KMDF driver development requires:
-- WDK environment setup
-- Driver architecture design
-- IRP routing and interception logic
-- Comprehensive testing on multiple Windows versions
-- Security audit before public release
-
-Releasing an untested driver would be irresponsible.
-
-### Q: When will v2 be ready?
-
-A: Target timeline:
-- **Architecture & design:** May–June 2026
-- **Implementation:** July–August 2026
-- **Testing:** September 2026
-- **Beta release:** October 2026
-- **Production release:** January 2027
-
-### Q: Can I help build v2?
-
-A: Yes! Contributors welcome once the source skeleton is available. See `CONTRIBUTING.md`.
-
-### Q: Will v1 stop working when v2 is released?
-
-A: No. v1 will continue to work and be supported. v2 is an alternative, not a replacement. You choose which to install.
-
-### Q: What about Windows 12 / ARM64?
-
-A: v2 architecture will support:
-- Windows 11 22H2+
-- Windows 10 build 14393+ (best-effort)
-- x64 architecture (primary target)
-- ARM64 (secondary, pending testing)
-
-v1 works on these now; v2 will maintain same compatibility.
-
-## Current Users (v1.0.0)
-
-If you've installed v1.0.0 and it's working, **no action is required**. v1 remains production-ready and fully supported.
-
-When v2 becomes available, you can optionally upgrade by:
-1. Uninstalling v1 (`Uninstall-MagicMousePatch.ps1`)
-2. Installing v2 (PowerShell or WiX installer)
-3. Rebooting
-
----
-
-## Resources
-
-### Windows Driver Development
-
-- [Microsoft Windows Driver Kit](https://learn.microsoft.com/en-us/windows-hardware/drivers/)
-- [KMDF Documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/wdf/kmdf-version-history)
-- [Windows Driver Samples](https://github.com/microsoft/Windows-driver-samples)
-
-### Related Projects
-
-- [WDF Filter Driver Sample](https://github.com/microsoft/Windows-driver-samples/tree/master/general/filter)
-- [HID Class Driver](https://github.com/microsoft/Windows-driver-samples/tree/master/input/hid)
-
----
-
-**Document Version:** 1.0.0 (WIP)  
-**Last Updated:** 2026-05-18  
-**Status:** Not production ready — do not install on production systems  
-**Author:** Revive Business Solutions  
-**License:** MIT (when source is released)
+MIT.

--- a/v2-kmdf-driver/build-driver.ps1
+++ b/v2-kmdf-driver/build-driver.ps1
@@ -1,0 +1,48 @@
+# build-driver.ps1 — Build the KMDF Magic Mouse driver (M13).
+# Standalone: powershell -ExecutionPolicy Bypass -File build-driver.ps1
+# Via queue: BUILD|<nonce>|Release|x64
+#
+# Requires EWDK ISO mounted (task runner mounts it automatically when called via queue).
+# When running standalone, ensure EWDK is mounted first.
+param(
+    [string]$Config   = 'Release',
+    [string]$Platform = 'x64',
+    [string]$SlnPath  = ''
+)
+
+$ErrorActionPreference = 'Continue'
+
+# Ensure queue dir exists for build log
+if (-not (Test-Path 'C:\mm-dev-queue')) {
+    New-Item -ItemType Directory -Force -Path 'C:\mm-dev-queue' | Out-Null
+}
+
+$ewdkSetup = $null
+foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+    $c = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+    if (Test-Path $c) { $ewdkSetup = $c; break }
+}
+
+if (-not $ewdkSetup) {
+    Write-Error "EWDK not found on any mounted drive. Mount the EWDK ISO first."
+    exit 1
+}
+
+if (-not $SlnPath) {
+    # Default to WSL2 path — requires WSL2 to be running
+    $SlnPath = '\\wsl.localhost\Ubuntu\home\lesley\projects\magic-mouse-tray\driver\MagicMouseDriver.sln'
+}
+
+if (-not (Test-Path $SlnPath)) {
+    Write-Error "Solution not found: $SlnPath"
+    exit 2
+}
+
+$buildLog = 'C:\mm-dev-queue\build-standalone.log'
+$cmdLine = '"' + $ewdkSetup + '" && msbuild "' + $SlnPath + '" /m /nr:false /v:minimal /p:Configuration=' + $Config + ' /p:Platform=' + $Platform + ' /p:RunCodeAnalysis=false /p:SignMode=Off'
+Write-Host "Building: $SlnPath ($Config|$Platform)"
+"=== $cmdLine ===" | Set-Content $buildLog -Encoding ASCII
+& cmd.exe /c $cmdLine 2>&1 | Add-Content $buildLog -Encoding ASCII
+$rc = $LASTEXITCODE
+Write-Host "Build exited $rc. Log: $buildLog"
+exit $rc

--- a/v2-kmdf-driver/install-driver.ps1
+++ b/v2-kmdf-driver/install-driver.ps1
@@ -1,0 +1,27 @@
+# install-driver.ps1 — Install a pre-signed driver package via pnputil.
+# Standalone: powershell -ExecutionPolicy Bypass -File install-driver.ps1 -InfPath <path>
+# Via queue: INSTALL-DRIVER|<nonce>|<inf-path>
+# Pre-requisite: driver package must already be signed (use sign-driver.ps1 first).
+# Pre-requisite: CN=MagicMouseFix cert must be in LocalMachine\TrustedPublisher.
+# Note: if applewirelessmouse LowerFilter is active, verify no RID sweep is running first
+#       (prior BSOD 0x0000013A from brute-force RID sweep with LowerFilter active 2026-05-09).
+param(
+    [Parameter(Mandatory)][string]$InfPath
+)
+
+if (-not (Test-Path $InfPath)) {
+    Write-Error "INF not found: $InfPath"
+    exit 2
+}
+
+Write-Host "Installing driver from $InfPath ..."
+& pnputil /add-driver $InfPath /install
+$rc = $LASTEXITCODE
+if ($rc -eq 0) {
+    Write-Host "Driver installed successfully."
+} elseif ($rc -eq 3010) {
+    Write-Host "Driver installed — REBOOT REQUIRED to activate."
+} else {
+    Write-Error "pnputil failed ($rc)"
+}
+exit $rc

--- a/v2-kmdf-driver/mm-dev.ps1
+++ b/v2-kmdf-driver/mm-dev.ps1
@@ -1,0 +1,769 @@
+<#
+.SYNOPSIS
+    Magic Mouse driver development cycle - state/build/sign/install/capture in one script.
+
+.DESCRIPTION
+    Enforces the loop: Understand state -> Implement -> Test -> Understand state.
+    Every step is timestamped and logged to $SessionLog.
+
+    Run from WSL:
+        powershell.exe -ExecutionPolicy Bypass -File "D:\mm3-driver\scripts\mm-dev.ps1" -Phase Full
+
+    Run directly (Admin PowerShell):
+        .\mm-dev.ps1 -Phase Full
+        .\mm-dev.ps1 -Phase State
+        .\mm-dev.ps1 -Phase Build
+        .\mm-dev.ps1 -Phase Install
+        .\mm-dev.ps1 -Phase Capture
+
+.PARAMETER Phase
+    State    - Snapshot current PnP + driver state
+    Build    - EWDK msbuild (Rebuild)
+    Sign     - signtool sign .sys + .cat
+    Install  - Remove old driver, install new, restart device
+    Verify   - Post-install health check (LowerFilters, COL01 status, oem package)
+    Rollback - Remove our filter driver entirely (recovery path)
+    Restore  - Re-apply LowerFilters without rebuild (use after BT reconnect)
+    Capture  - (Re)start DebugView capturing to $DebugLog
+    Full     - State -> Build -> Sign -> Install -> Verify -> State
+    Log      - Tail last 40 lines of session log
+    Debug    - Tail last 40 MagicMouse lines from debug log
+#>
+param(
+    [ValidateSet('State','Build','Sign','Install','Verify','Rollback','Restore','Capture','Full','Log','Debug')]
+    [string]$Phase = 'Full',
+
+    [string]$EwdkRoot   = 'F:\',
+    [string]$PkgDir     = 'D:\mm3-pkg',
+    [string]$SessionLog = 'C:\mm-dev-session.log',
+    [string]$DebugLog   = 'C:\mm3-debug.log',
+    [string]$Thumbprint = 'B902C2864315E2DE359450024768CE7D01715C38',
+    [string]$TimestampUrl = 'http://timestamp.digicert.com',
+    [string]$VendorPid  = 'VID&0001004c_PID&0323',  # Magic Mouse 2024 - used for device autodetect
+    [string]$DbgViewExe = 'C:\SysinternalsSuite\Dbgview.exe',
+    [string]$SignToolExe = 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+    [switch]$NoElevate    # internal flag - set when re-launched as admin to prevent infinite recursion
+)
+
+# ---------------------------------------------------------------------------
+# Self-elevation - re-launch as admin if needed (UAC prompt once per call)
+# ---------------------------------------------------------------------------
+function Test-IsAdmin {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-IsAdmin) -and -not $NoElevate) {
+    Write-Host "[mm-dev] Not Administrator - elevating via UAC (accept the prompt)..." -ForegroundColor Yellow
+
+    # Build relaunch arg list - preserve all bound params + add -NoElevate sentinel
+    $relaunchArgs = @('-NoProfile','-ExecutionPolicy','Bypass','-File',"$PSCommandPath",'-NoElevate')
+    foreach ($k in $PSBoundParameters.Keys) {
+        $v = $PSBoundParameters[$k]
+        if ($v -is [switch]) {
+            if ($v.IsPresent) { $relaunchArgs += "-$k" }
+        } else {
+            $relaunchArgs += "-$k"
+            $relaunchArgs += "$v"
+        }
+    }
+    if (-not ($PSBoundParameters.ContainsKey('Phase'))) {
+        $relaunchArgs += '-Phase'; $relaunchArgs += "$Phase"
+    }
+
+    try {
+        $proc = Start-Process -FilePath 'powershell.exe' `
+                              -ArgumentList $relaunchArgs `
+                              -Verb RunAs -Wait -PassThru `
+                              -WindowStyle Normal
+        Write-Host "[mm-dev] Elevated phase exited with code $($proc.ExitCode)" -ForegroundColor Cyan
+        Write-Host "[mm-dev] Session log: $SessionLog" -ForegroundColor Cyan
+        exit $proc.ExitCode
+    } catch {
+        Write-Host "[mm-dev] Elevation cancelled or failed: $_" -ForegroundColor Red
+        exit 2
+    }
+}
+
+# Auto-detect device ID by VID/PID (avoids hardcoded MAC that breaks on re-pair)
+function Resolve-DeviceId {
+    $devs = pnputil /enum-devices /connected 2>&1 | Out-String
+    $blocks = $devs -split "(?=Instance ID:)"
+    foreach ($b in $blocks) {
+        if ($b -match "Instance ID:\s+(BTHENUM\\\{00001124[^\r\n]*$VendorPid[^\r\n]*)" ) {
+            return $Matches[1].Trim()
+        }
+    }
+    return $null
+}
+
+# Derive driver source root from script location (scripts\ -> repo root).
+# Guard against $PSScriptRoot being null when called from a scheduled task context.
+$DriverRoot = if ($PSScriptRoot) { Split-Path -Parent $PSScriptRoot } else { 'D:\mm3-driver' }
+$BuildOut   = Join-Path $DriverRoot 'x64\Debug'
+$VcxProj    = Join-Path $DriverRoot 'MagicMouseDriver.vcxproj'
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+function Write-Log {
+    param([string]$Msg, [string]$Level = 'INFO')
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][$Level] $Msg"
+    Add-Content -Path $SessionLog -Value $line -Encoding UTF8
+    switch ($Level) {
+        'ERROR' { Write-Host $line -ForegroundColor Red }
+        'WARN'  { Write-Host $line -ForegroundColor Yellow }
+        'OK'    { Write-Host $line -ForegroundColor Green }
+        'HEAD'  { Write-Host "`n$line" -ForegroundColor Cyan }
+        default { Write-Host $line }
+    }
+}
+
+function Write-Section {
+    param([string]$Title)
+    $bar = '=' * 60
+    $line = "$bar`n=== $Title`n$bar"
+    Add-Content -Path $SessionLog -Value $line -Encoding UTF8
+    Write-Host "`n$line" -ForegroundColor Cyan
+}
+
+# ---------------------------------------------------------------------------
+# STATE
+# ---------------------------------------------------------------------------
+function Get-DriverState {
+    Write-Section "STATE SNAPSHOT - $(Get-Date -Format 'HH:mm:ss')"
+
+    # PnP devices matching our mouse
+    Write-Log "--- PnP devices (Magic Mouse 0x0323) ---"
+    $devs = pnputil /enum-devices /connected 2>&1
+    $relevant = $devs | Select-String -Pattern '0323|MagicMouse|Magic Mouse|COL01|COL02|oem52' -Context 0,5
+    if ($relevant) {
+        $relevant | ForEach-Object { Write-Log $_.Line }
+    } else {
+        Write-Log "(no matching connected devices)" 'WARN'
+    }
+
+    # Our driver package
+    Write-Log "--- Installed driver package ---"
+    $pkgs = pnputil /enum-drivers 2>&1
+    $ourPkg = ($pkgs | Select-String -Pattern 'MagicMouse|magicmouse' -Context 0,6)
+    if ($ourPkg) {
+        $ourPkg | ForEach-Object { Write-Log $_.Line }
+    } else {
+        Write-Log "(MagicMouseDriver not installed)" 'WARN'
+    }
+
+    # COL01 / COL02 status
+    Write-Log "--- HID child devices ---"
+    $col = pnputil /enum-devices 2>&1 | Select-String 'COL01|COL02' -Context 0,4
+    if ($col) {
+        $col | ForEach-Object { Write-Log $_.Line }
+    } else {
+        Write-Log "(COL01/COL02 not found)" 'WARN'
+    }
+
+    # LowerFilters registry
+    Write-Log "--- LowerFilters registry ---"
+    $regPath = 'HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&0323\9&73b8b28&0&D0C050CC8C4D_C00000000'
+    try {
+        $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        Write-Log "LowerFilters = $($lf -join ', ')" $(if ($lf -contains 'MagicMouseDriver') {'OK'} else {'WARN'})
+    } catch {
+        Write-Log "Registry key not found (device not paired?)" 'WARN'
+    }
+
+    # Built artifact info
+    Write-Log "--- Build artifact ---"
+    $sys = Join-Path $BuildOut 'MagicMouseDriver.sys'
+    if (Test-Path $sys) {
+        $fi = Get-Item $sys
+        Write-Log "MagicMouseDriver.sys  size=$($fi.Length)  modified=$($fi.LastWriteTime)" 'OK'
+    } else {
+        Write-Log "MagicMouseDriver.sys not found at $BuildOut" 'WARN'
+    }
+
+    # Last debug entries
+    Write-Log "--- Last 15 MagicMouse debug lines ---"
+    if (Test-Path $DebugLog) {
+        $lines = Get-Content $DebugLog | Select-String 'MagicMouse' | Select-Object -Last 15
+        if ($lines) { $lines | ForEach-Object { Write-Log $_.Line } }
+        else { Write-Log "(no MagicMouse entries yet)" }
+    } else {
+        Write-Log "(debug log not found - DebugView not running?)" 'WARN'
+    }
+
+    Write-Log "State snapshot complete." 'OK'
+}
+
+# ---------------------------------------------------------------------------
+# BUILD
+# ---------------------------------------------------------------------------
+function Build-Driver {
+    Write-Section "BUILD - $(Get-Date -Format 'HH:mm:ss')"
+
+    if (-not (Test-Path $VcxProj)) {
+        Write-Log "vcxproj not found: $VcxProj" 'ERROR'
+        return $false
+    }
+
+    # Use SetupBuildEnv.cmd directly (sets env vars and returns).
+    # NOT LaunchBuildEnv.cmd: that wraps SetupBuildEnv in `cmd /k` which spawns
+    # an interactive shell that never exits, hanging the entire pipeline.
+    $ewdkSetup = Join-Path $EwdkRoot 'BuildEnv\SetupBuildEnv.cmd'
+
+    # If not found at $EwdkRoot, scan all ready drives (handles ISO mounted to any letter).
+    if (-not (Test-Path $ewdkSetup)) {
+        Write-Log "EWDK not at $ewdkSetup - scanning drives..." 'WARN'
+        foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+            $candidate = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+            if (Test-Path $candidate) {
+                $ewdkSetup = $candidate
+                Write-Log "Found EWDK at $ewdkSetup" 'OK'
+                break
+            }
+        }
+    }
+
+    if (-not (Test-Path $ewdkSetup)) {
+        Write-Log "EWDK SetupBuildEnv.cmd not found on any drive. Mount the ISO first." 'ERROR'
+        return $false
+    }
+
+    Write-Log "Running EWDK msbuild (Rebuild) via temp batch file..."
+    # Write a temp .bat to avoid PowerShell→cmd double-quote mangling.
+    # cmd /c with embedded quotes produces '""' is not recognized errors.
+    $tempBat = [System.IO.Path]::GetTempFileName() -replace '\.tmp$','.bat'
+    @"
+@echo off
+call "$ewdkSetup" >NUL 2>&1
+if errorlevel 1 (
+    echo [BUILD] EWDK SetupBuildEnv.cmd failed >&2
+    exit /b 1
+)
+msbuild "$VcxProj" /p:Configuration=Debug /p:Platform=x64 /t:Rebuild /nologo /v:minimal /p:SignFiles=false /p:EnableCodeSigning=false
+"@ | Out-File -FilePath $tempBat -Encoding ASCII
+    Write-Log "Batch file: $tempBat"
+    $output = cmd /c $tempBat 2>&1
+    Remove-Item $tempBat -Force -ErrorAction SilentlyContinue
+    $output | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+
+    $sys     = Join-Path $BuildOut 'MagicMouseDriver.sys'
+    $presign = 'C:\mm3-presign\MagicMouseDriver.sys'
+
+    if (Test-Path $sys) {
+        Write-Log "Build succeeded: $sys" 'OK'
+        return $true
+    } elseif (Test-Path $presign) {
+        # SIGNTASK failed and deleted the .sys, but BackupPreSign saved it before sign ran.
+        Write-Log "SIGNTASK deleted .sys - restoring from BackupPreSign ($presign)" 'WARN'
+        Copy-Item $presign $sys -Force
+        Write-Log "Build succeeded (presign restored): $sys" 'OK'
+        return $true
+    } else {
+        Write-Log "Build FAILED - .sys not produced and no presign backup found." 'ERROR'
+        # Show last 20 lines of build output
+        $output | Select-Object -Last 20 | ForEach-Object { Write-Log $_ 'ERROR' }
+        return $false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# SIGN
+# ---------------------------------------------------------------------------
+function Sign-Driver {
+    Write-Section "SIGN - $(Get-Date -Format 'HH:mm:ss')"
+
+    if (-not (Test-Path $SignToolExe)) {
+        # Try to find signtool in common WDK locations
+        $candidates = @(
+            'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+            'C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe'
+        )
+        $SignToolExe = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $SignToolExe) {
+            Write-Log "signtool.exe not found - install Windows SDK/WDK" 'ERROR'
+            return $false
+        }
+    }
+
+    $targets = @(
+        (Join-Path $BuildOut 'MagicMouseDriver.sys'),
+        (Join-Path $BuildOut 'MagicMouseDriver.cat')
+    )
+
+    $ok = $true
+    foreach ($target in $targets) {
+        if (-not (Test-Path $target)) {
+            Write-Log "Not found, skipping: $target" 'WARN'
+            continue
+        }
+        Write-Log "Signing: $(Split-Path -Leaf $target)"
+        $result = & $SignToolExe sign /sm /v /sha1 $Thumbprint /fd SHA256 /t $TimestampUrl $target 2>&1
+        $result | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "Signed OK: $(Split-Path -Leaf $target)" 'OK'
+        } else {
+            Write-Log "Sign FAILED: $(Split-Path -Leaf $target)" 'ERROR'
+            $ok = $false
+        }
+    }
+    return $ok
+}
+
+# ---------------------------------------------------------------------------
+# INSTALL
+# ---------------------------------------------------------------------------
+function Get-CurrentOemPackage {
+    # Robust line-by-line parse of pnputil /enum-drivers to find our oem*.inf number.
+    # Used only for informational Verify checks; Install no longer calls pnputil /add-driver
+    # (it hangs in SYSTEM context due to silent cert-trust dialogs).
+    $out = pnputil /enum-drivers 2>&1
+    $currentOem = $null
+    $candidate  = $null
+    foreach ($line in $out) {
+        if ($line -match 'Published Name:\s+(oem\d+\.inf)') {
+            $candidate = $Matches[1]
+        }
+        if ($line -match 'magicmousedriver\.inf' -and $candidate) {
+            $currentOem = $candidate
+            break
+        }
+    }
+    return $currentOem
+}
+
+function Uninstall-DriverDirect {
+    # Order matters: remove LowerFilters FIRST, restart device (unloads .sys from stack),
+    # THEN sc.exe delete + Remove-Item .sys. Trying to delete a loaded .sys fails with
+    # "used by another process" even after sc.exe delete marks the service for deletion.
+    $devId = Resolve-DeviceId
+    if ($devId) {
+        $rp = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+        try {
+            $lf = (Get-ItemProperty $rp -ErrorAction Stop).LowerFilters
+            if ($lf -contains 'MagicMouseDriver') {
+                $newLf = @($lf | Where-Object { $_ -ne 'MagicMouseDriver' })
+                if ($newLf.Count -gt 0) {
+                    Set-ItemProperty $rp -Name LowerFilters -Value $newLf -Type MultiString
+                } else {
+                    Remove-ItemProperty $rp -Name LowerFilters -ErrorAction SilentlyContinue
+                }
+                Write-Log "LowerFilters: removed MagicMouseDriver - restarting device to unload driver" 'OK'
+                pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+                Start-Sleep -Seconds 2
+            }
+        } catch { }
+    }
+
+    Write-Log "Stopping service..."
+    sc.exe stop MagicMouseDriver 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    Write-Log "Deleting service..."
+    $scDel = sc.exe delete MagicMouseDriver 2>&1
+    $scDel | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+
+    $sysDest = 'C:\Windows\System32\drivers\MagicMouseDriver.sys'
+    if (Test-Path $sysDest) {
+        Remove-Item $sysDest -Force -ErrorAction SilentlyContinue
+        if (Test-Path $sysDest) {
+            Write-Log "$sysDest still locked after device restart - attempting rename workaround" 'WARN'
+            Rename-Item $sysDest "$sysDest.old" -Force -ErrorAction SilentlyContinue
+        } else {
+            Write-Log "Removed $sysDest" 'OK'
+        }
+    }
+}
+
+function Install-Driver {
+    Write-Section "INSTALL - $(Get-Date -Format 'HH:mm:ss')"
+
+    # Uninstall any previous install (no pnputil; direct sc.exe + registry).
+    Uninstall-DriverDirect
+
+    # Step 1: Copy .sys to System32\drivers (INF DestinationDir 12 = drivers\).
+    $sysSrc  = Join-Path $BuildOut 'MagicMouseDriver.sys'
+    $sysDest = 'C:\Windows\System32\drivers\MagicMouseDriver.sys'
+    if (-not (Test-Path $sysSrc)) {
+        Write-Log ".sys not found at $sysSrc" 'ERROR'
+        return $false
+    }
+    Copy-Item $sysSrc $sysDest -Force
+    Write-Log "Copied .sys to $sysDest" 'OK'
+
+    # Step 2: Register kernel service (replaces INF [Install.Services] AddService).
+    # sc.exe requires spaces after '=' - this is intentional PowerShell sc.exe syntax.
+    # Retry once on exit 1072 (marked for deletion): the previous service object may still
+    # be draining references when we arrive here, cleared within ~2s of device restart.
+    Write-Log "Creating kernel service MagicMouseDriver"
+    $scCreateArgs = @('create','MagicMouseDriver','type=','kernel','start=','demand',
+                      'binPath=','system32\drivers\MagicMouseDriver.sys',
+                      'DisplayName=','Magic Mouse Driver')
+    $scOut = sc.exe @scCreateArgs 2>&1
+    $scOut | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    if ($LASTEXITCODE -eq 1072) {
+        Write-Log "sc.exe create returned 1072 (service marked for deletion) - waiting 3s and retrying" 'WARN'
+        Start-Sleep -Seconds 3
+        $scOut = sc.exe @scCreateArgs 2>&1
+        $scOut | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Log "Service created." 'OK'
+    } else {
+        Write-Log "sc.exe create exited $LASTEXITCODE" 'WARN'
+    }
+
+    # Step 3: Resolve device and apply LowerFilters + restart.
+    $devId = Resolve-DeviceId
+    if (-not $devId) {
+        Write-Log "Device not currently connected - driver staged; connect mouse and run Verify" 'WARN'
+        return $true
+    }
+    Write-Log "Device: $devId"
+
+    # Set LowerFilters — MagicMouseDriver(0) below applewirelessmouse(1).
+    # Our driver at index 0 patches SDP completion first; applewirelessmouse sees our
+    # combined descriptor and does not re-patch. Swapping (test ee18af4) confirmed
+    # applewirelessmouse DOES gesture processing but conflicts with our combined descriptor
+    # (produces spurious clicks). Gesture processing is deferred to M14 in our own driver.
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    $targetLf = @('MagicMouseDriver', 'applewirelessmouse')
+    try {
+        $existing = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        $needsUpdate = ($null -eq $existing) -or
+                       ($existing.Count -ne $targetLf.Count) -or
+                       ($existing[0] -ne $targetLf[0]) -or
+                       ($existing[1] -ne $targetLf[1])
+        if ($needsUpdate) {
+            Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+            Write-Log "LowerFilters set: $($targetLf -join ',')" 'OK'
+        } else {
+            Write-Log "LowerFilters already correct: $($existing -join ',')" 'OK'
+        }
+    } catch {
+        Write-Log "Cannot set LowerFilters at $regPath : $_" 'ERROR'
+        return $false
+    }
+
+    # Step 4: Restart device to rebuild stack with new lower filter.
+    Write-Log "Restarting device: $devId"
+    $out = pnputil /restart-device $devId 2>&1
+    $out | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Log "Device restart sent." 'OK'
+    } else {
+        Write-Log "pnputil /restart-device exited $LASTEXITCODE" 'WARN'
+    }
+
+    Start-Sleep -Seconds 4
+
+    # Step 5: Re-apply LowerFilters after restart.
+    # pnputil /restart-device triggers a full BTHENUM re-enumeration. PnP re-runs the selected
+    # driver INF (oem0.inf / applewirelessmouse.inf) which has a replace-flag AddReg:
+    #   HKR,,"LowerFilters",0x00010000,"applewirelessmouse"   <- overwrites our entry
+    # The current stack survives the restart with our driver loaded, but the registry is reset.
+    # Re-applying here ensures the registry matches reality so the NEXT restart (BT reconnect,
+    # reboot) also loads MagicMouseDriver.
+    try {
+        $postLf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        $postNeedsUpdate = ($null -eq $postLf) -or
+                           ($postLf.Count -ne $targetLf.Count) -or
+                           ($postLf[0] -ne $targetLf[0]) -or
+                           ($postLf[1] -ne $targetLf[1])
+        if ($postNeedsUpdate) {
+            Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+            Write-Log "LowerFilters re-applied post-restart (oem0.inf reset guard): $($targetLf -join ',')" 'OK'
+        } else {
+            Write-Log "LowerFilters intact post-restart: $($postLf -join ',')" 'OK'
+        }
+    } catch {
+        Write-Log "Cannot re-apply LowerFilters post-restart: $_" 'WARN'
+    }
+
+    Write-Log "Install complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# VERIFY - post-install health check
+# ---------------------------------------------------------------------------
+function Verify-Install {
+    Write-Section "VERIFY - $(Get-Date -Format 'HH:mm:ss')"
+    $allOk = $true
+
+    # 1. oem package (INFO only - we bypass pnputil /add-driver, so no oem entry is expected)
+    $oem = Get-CurrentOemPackage
+    if ($oem) {
+        Write-Log "oem package: $oem" 'OK'
+    } else {
+        Write-Log "No oem package (expected - using direct sc.exe install)" 'INFO'
+    }
+
+    # 2. Service exists and .sys present?
+    $svc = Get-Service MagicMouseDriver -ErrorAction SilentlyContinue
+    if ($svc) {
+        Write-Log "Service MagicMouseDriver: $($svc.Status)" 'OK'
+    } else {
+        Write-Log "Service MagicMouseDriver not found" 'ERROR'
+        $allOk = $false
+    }
+    $sysDest = 'C:\Windows\System32\drivers\MagicMouseDriver.sys'
+    if (Test-Path $sysDest) {
+        $sz = (Get-Item $sysDest).Length
+        Write-Log ".sys present: $sysDest ($sz bytes)" 'OK'
+    } else {
+        Write-Log ".sys missing: $sysDest" 'ERROR'
+        $allOk = $false
+    }
+
+    # 3. Device connected?
+    $devId = Resolve-DeviceId
+    if (-not $devId) {
+        Write-Log "Device not connected - cannot verify runtime state" 'WARN'
+        return $allOk
+    }
+    Write-Log "Device: $devId" 'OK'
+
+    # 4. LowerFilters has MagicMouseDriver?
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    try {
+        $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        if ($lf -contains 'MagicMouseDriver') {
+            Write-Log "LowerFilters: $($lf -join ',') (MagicMouseDriver bound)" 'OK'
+        } else {
+            Write-Log "LowerFilters: $($lf -join ',') - MagicMouseDriver NOT bound" 'ERROR'
+            $allOk = $false
+        }
+    } catch {
+        Write-Log "Cannot read LowerFilters at $regPath" 'ERROR'
+        $allOk = $false
+    }
+
+    # 5. COL01 (HID mouse child) present?
+    # Use pnputil /enum-devices without /connected - HID children are not "Bluetooth-connected"
+    # but do appear as Started devices under the HID bus.
+    $devAll = pnputil /enum-devices 2>&1 | Out-String
+    $col01Found = $devAll -match "VID&0001004c_PID&0323&Col01"
+    if ($col01Found) {
+        Write-Log "COL01 (HID-compliant mouse): enumerated" 'OK'
+    } else {
+        Write-Log "COL01 not found in device list - HID descriptor may be missing scroll collection" 'WARN'
+    }
+
+    # 6. Diag registry keys (written by driver timer at 1Hz to Services\MagicMouseDriver\Diag)
+    $diagPath = "HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag"
+    if (Test-Path $diagPath) {
+        $diag = Get-ItemProperty $diagPath -ErrorAction SilentlyContinue
+        Write-Log "Diag: IoctlInterceptCount=$($diag.IoctlInterceptCount) SdpScanHits=$($diag.SdpScanHits) SdpPatchSuccess=$($diag.SdpPatchSuccess) LastSdpBufSize=$($diag.LastSdpBufSize)" 'OK'
+    } else {
+        Write-Log "Diag key not yet created at Services\MagicMouseDriver\Diag (driver timer may not have fired or driver not attached to device stack)" 'INFO'
+    }
+
+    if ($allOk) {
+        Write-Log "VERIFY PASSED - driver bound, .sys present, LowerFilters set" 'OK'
+    } else {
+        Write-Log "VERIFY FAILED - see findings above" 'ERROR'
+    }
+    return $allOk
+}
+
+# ---------------------------------------------------------------------------
+# ROLLBACK - recovery path: remove our filter entirely
+# ---------------------------------------------------------------------------
+function Rollback-Driver {
+    Write-Section "ROLLBACK - $(Get-Date -Format 'HH:mm:ss')"
+    # Use direct uninstall (no pnputil /delete-driver which hangs in SYSTEM context).
+    Uninstall-DriverDirect
+    $devId = Resolve-DeviceId
+    if ($devId) {
+        Write-Log "Restarting device to drop filter binding..."
+        pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    }
+    Write-Log "Rollback complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# RESTORE - re-apply LowerFilters without rebuild (recovery after BT reconnect)
+# ---------------------------------------------------------------------------
+function Restore-LowerFilters {
+    Write-Section "RESTORE LOWERFILTERS - $(Get-Date -Format 'HH:mm:ss')"
+
+    $devId = Resolve-DeviceId
+    if (-not $devId) {
+        Write-Log "Device not connected - cannot restore LowerFilters" 'WARN'
+        return $false
+    }
+    Write-Log "Device: $devId"
+
+    $regPath  = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    $targetLf = @('applewirelessmouse', 'MagicMouseDriver')
+    try {
+        $existing = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        $needsUpdate = ($null -eq $existing) -or
+                       ($existing.Count -ne $targetLf.Count) -or
+                       ($existing[0] -ne $targetLf[0]) -or
+                       ($existing[1] -ne $targetLf[1])
+        if (-not $needsUpdate) {
+            Write-Log "LowerFilters already correct: $($existing -join ',')" 'OK'
+        } else {
+            Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+            Write-Log "LowerFilters restored: $($targetLf -join ',')" 'OK'
+
+            # Start service if not running
+            $svc = Get-Service MagicMouseDriver -ErrorAction SilentlyContinue
+            if ($svc -and $svc.Status -ne 'Running') {
+                sc.exe start MagicMouseDriver 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+                Start-Sleep -Seconds 2
+                Write-Log "Service start requested." 'OK'
+            }
+
+            # Restart device so stack rebuilds with the filter.
+            Write-Log "Restarting device to apply restored LowerFilters..."
+            pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+            Start-Sleep -Seconds 4
+
+            # Re-apply post-restart guard
+            $postLf = (Get-ItemProperty $regPath -ErrorAction SilentlyContinue).LowerFilters
+            $postNeedsUpdate = ($null -eq $postLf) -or ($postLf[0] -ne $targetLf[0]) -or ($postLf[1] -ne $targetLf[1])
+            if ($postNeedsUpdate) {
+                Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+                Write-Log "LowerFilters re-applied post-restart: $($targetLf -join ',')" 'OK'
+            }
+        }
+    } catch {
+        Write-Log "Cannot restore LowerFilters at $regPath : $_" 'ERROR'
+        return $false
+    }
+
+    Write-Log "Restore complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# DEBUG CAPTURE
+# ---------------------------------------------------------------------------
+function Read-Rid27Captures {
+    # M14: read RID=0x27 ring buffer from registry (no DebugView required).
+    # The driver's 1Hz DiagWorkItem writes:
+    #   Diag\HidReadCount   DWORD   total IRP_MJ_READ completions
+    #   Diag\Rid27Count     DWORD   how many had buf[0]==0x27
+    #   Diag\Rid27SlotsFilled DWORD  slots written (capped at 8)
+    #   Diag\Rid27RingBuf   REG_BINARY  8 x 48 bytes of raw reports
+    Write-Section "CAPTURE (RID=0x27 ring buffer) - $(Get-Date -Format 'HH:mm:ss')"
+
+    $diagKey = 'HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag'
+    if (-not (Test-Path $diagKey)) {
+        Write-Log "Diag registry key not found - driver not loaded or not M14 build" 'ERROR'
+        return $false
+    }
+
+    $props        = Get-ItemProperty $diagKey -ErrorAction SilentlyContinue
+    $hidReads     = $props.HidReadCount
+    $rid27Count   = $props.Rid27Count
+    $slotsFilled  = $props.Rid27SlotsFilled
+    $ringBuf      = $props.Rid27RingBuf   # byte[] or $null
+
+    Write-Log "HidReadCount=$hidReads  Rid27Count=$rid27Count  SlotsFilled=$slotsFilled" 'OK'
+
+    if (-not $slotsFilled -or $slotsFilled -eq 0) {
+        Write-Log "No RID=0x27 captures yet - touch the mouse surface and re-run Capture" 'WARN'
+        return $false
+    }
+
+    if (-not $ringBuf -or $ringBuf.Length -eq 0) {
+        Write-Log "Rid27RingBuf key empty despite SlotsFilled=$slotsFilled" 'WARN'
+        return $false
+    }
+
+    # Dump each filled slot
+    $nSlots = [Math]::Min($slotsFilled, 8)
+    Write-Log "--- RID=0x27 ring buffer: $nSlots slot(s) ---"
+    for ($i = 0; $i -lt $nSlots; $i++) {
+        $offset = $i * 48
+        $slot   = $ringBuf[$offset..($offset + 47)]
+        $hex    = ($slot | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
+        Write-Log "Slot[$i]: $hex"
+
+        # Layout analysis (Linux hid-magicmouse.c reference)
+        $rid     = $slot[0]
+        $flags   = $slot[1]
+        $ts      = [uint16]($slot[2] + ($slot[3] -shl 8))
+        $nFinger = $slot[4]
+        Write-Log "  RID=0x{0:X2}  flags=0x{1:X2}  ts={2}  nFingers={3}" -f $rid,$flags,$ts,$nFinger
+        # Bytes 5..end: per-finger data (7 bytes each in hid-magicmouse v2/v3)
+        if ($nFinger -gt 0) {
+            for ($f = 0; $f -lt $nFinger; $f++) {
+                $foff = 5 + ($f * 9)
+                if ($foff + 8 -ge 48) { break }
+                $absX = [int16]($slot[$foff] + ($slot[$foff+1] -shl 8))
+                $absY = [int16]($slot[$foff+2] + ($slot[$foff+3] -shl 8))
+                Write-Log ("  Finger[$f]: x={0} y={1} raw=[{2}]" -f $absX, $absY,
+                    (($slot[$foff..($foff+8)]) | ForEach-Object { '{0:X2}' -f $_ }) -join ' ')
+            }
+        }
+    }
+
+    Write-Log "Capture complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# SHOW LOGS
+# ---------------------------------------------------------------------------
+function Show-SessionLog {
+    Write-Section "SESSION LOG (last 40 lines)"
+    if (Test-Path $SessionLog) {
+        Get-Content $SessionLog | Select-Object -Last 40
+    } else {
+        Write-Log "No session log yet." 'WARN'
+    }
+}
+
+function Show-DebugLog {
+    Write-Section "DEBUG LOG - MagicMouse entries (last 40)"
+    if (Test-Path $DebugLog) {
+        $lines = Get-Content $DebugLog | Select-String 'MagicMouse' | Select-Object -Last 40
+        if ($lines) { $lines | ForEach-Object { Write-Host $_.Line } }
+        else { Write-Log "(no MagicMouse entries)" 'WARN' }
+    } else {
+        Write-Log "Debug log not found - run: .\mm-dev.ps1 -Phase Capture" 'WARN'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# MAIN
+# ---------------------------------------------------------------------------
+Write-Log "=== mm-dev.ps1 Phase=$Phase ===" 'HEAD'
+
+$exitCode = 0
+switch ($Phase) {
+    'State'    { Get-DriverState }
+    'Build'    { if (-not (Build-Driver))   { $exitCode = 1 } }
+    'Sign'     { if (-not (Sign-Driver))    { $exitCode = 1 } }
+    'Install'  { if (-not (Install-Driver)) { $exitCode = 1 } }
+    'Verify'   { if (-not (Verify-Install)) { $exitCode = 1 } }
+    'Rollback' { if (-not (Rollback-Driver)){ $exitCode = 1 } }
+    'Restore'  { if (-not (Restore-LowerFilters)) { $exitCode = 1 } }
+    'Capture'  { if (-not (Read-Rid27Captures)) { $exitCode = 1 } }
+    'Log'      { Show-SessionLog }
+    'Debug'    { Show-DebugLog }
+    'Full' {
+        Get-DriverState
+        $ok = Build-Driver
+        if ($ok) { $ok = Sign-Driver }
+        if ($ok) { $ok = Install-Driver }
+        if ($ok) { $ok = Verify-Install }
+        Get-DriverState
+        if ($ok) {
+            Read-Rid27Captures | Out-Null
+            Write-Log "Full cycle complete - touch mouse surface then run Capture to read ring buffer." 'OK'
+        } else {
+            Write-Log "Full cycle FAILED - check session log: $SessionLog" 'ERROR'
+            $exitCode = 1
+        }
+    }
+}
+
+Write-Log "Done. Session log: $SessionLog (exit=$exitCode)"
+exit $exitCode


### PR DESCRIPTION
Park unique work from cleanup stash `stash@{0}` (`cleanup-preserve-2026-09-01-LesleyMurfin/magic-mouse-v3-windows-fix`). **Do not merge to main.**

## What this parks
- Root `README.md` choose-your-driver rewrite (v2 KMDF recommended; v1 binary patch as fallback)
- `v2-kmdf-driver/README.md` production description (replaces WIP roadmap copy on main)
- Unique helper scripts not on PRs #3/#4:
  - `v2-kmdf-driver/mm-dev.ps1`
  - `v2-kmdf-driver/build-driver.ps1`
  - `v2-kmdf-driver/install-driver.ps1`

## What this is not
- Not the KMDF 0323/2.0.4.1 packages (those stay on draft PRs #3 / #4)
- CRLF/whitespace-only churn from the same stash was **not** applied
- Session logs (`.ai/`, `.run/`) were **not** committed

## Origin ref
- Branch: `ai/kmdf-driver-scripts`
- Commit: `331d280`

Leave as draft until packaging/review. Do not merge.