### PR TITLE
chore: intake KMDF source from public magic-tray

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -6,6 +6,30 @@
 
         # Internal helper functions (Stop-, Remove-, Set-) are not exported cmdlets
         # and do not need -WhatIf/-Confirm ShouldProcess support.
-        'PSUseShouldProcessForStateChangingFunctions'
+        'PSUseShouldProcessForStateChangingFunctions',
+
+        # This rule's naive English pluralisation misfires on the Windows nouns this
+        # repo is built around, and it offers no allow-list to spell the exceptions:
+        #   * 'Sys' is the .sys driver-file extension (Find-KmdfSys, Backup-KmdfLiveSys)
+        #   * 'Program Files' is a literal Windows directory name
+        #   * 'LowerFilters' is a literal registry value name
+        #   * 'Caps' is the HIDP_CAPS structure (Get-HidCaps)
+        # Renaming to satisfy it would make these helpers describe Windows less
+        # accurately, so the rule is off rather than the names being wrong.
+        'PSUseSingularNouns'
     )
+
+    Rules = @{
+        # Pin the built-in cmdlet inventory to Windows PowerShell 5.1, which is what
+        # actually runs these installers (they are launched by powershell.exe from
+        # .cmd wrappers and scheduled tasks). The analyser otherwise defaults to its
+        # 'core-6.1.0-windows' profile, whose PSDesiredStateConfiguration entry
+        # carries a stray private helper -- Write-Log, listed as CommandType Function
+        # at version 0.0 -- that is not a real PowerShell cmdlet and never shipped as
+        # one. Comparing against the 5.1 inventory drops that phantom while keeping
+        # the rule live for genuine shadowing of real cmdlets.
+        PSAvoidOverwritingBuiltInCmdlets = @{
+            PowerShellVersion = @('desktop-5.1.14393.206-windows')
+        }
+    }
 }

--- a/driver-test/BadSample.c
+++ b/driver-test/BadSample.c
@@ -1,0 +1,11 @@
+// TODO: finish this
+// FIXME: needs proper pool tag
+// helper function to do stuff
+// this is a comment about what the next line does
+// another comment about memory
+static int helper(void *data) { return 0; }
+static int util(void *temp) { return 0; }
+void doSomething(void) {
+    int buffer = 0;
+    int var = 1;
+}

--- a/driver-test/HelloWorld.c
+++ b/driver-test/HelloWorld.c
@@ -1,0 +1,51 @@
+/*
+ * HelloWorld.c - Minimal KMDF driver for EWDK build validation.
+ *
+ * Purpose: prove the BUILD pipeline routes requests to EWDK msbuild
+ * and produces a .sys artifact. Does not install or bind to real hardware.
+ * Target device: USB\VID_FFFF&PID_FFFF (non-existent; build-only test).
+ *
+ * Reference: Microsoft KMDF hello-world sample (WDK samples/kmdf/hello_kmdf)
+ */
+
+#include <ntddk.h>
+#include <wdf.h>
+
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_DEVICE_ADD HelloWorldEvtDeviceAdd;
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT  DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    WDF_DRIVER_CONFIG config;
+    NTSTATUS          status;
+
+    WDF_DRIVER_CONFIG_INIT(&config, HelloWorldEvtDeviceAdd);
+
+    status = WdfDriverCreate(DriverObject,
+                             RegistryPath,
+                             WDF_NO_OBJECT_ATTRIBUTES,
+                             &config,
+                             WDF_NO_HANDLE);
+    return status;
+}
+
+NTSTATUS
+HelloWorldEvtDeviceAdd(
+    _In_    WDFDRIVER       Driver,
+    _Inout_ PWDFDEVICE_INIT DeviceInit
+    )
+{
+    NTSTATUS   status;
+    WDFDEVICE  device;
+
+    UNREFERENCED_PARAMETER(Driver);
+
+    status = WdfDeviceCreate(&DeviceInit,
+                             WDF_NO_OBJECT_ATTRIBUTES,
+                             &device);
+    return status;
+}

--- a/driver-test/HelloWorld.inf
+++ b/driver-test/HelloWorld.inf
@@ -1,0 +1,51 @@
+; HelloWorld.inf - Build-validation INF only.
+; Binds to USB\VID_FFFF&PID_FFFF (non-existent device).
+; Not intended for installation on real hardware.
+
+[Version]
+Signature   = "$WINDOWS NT$"
+Class       = USB
+ClassGuid   = {36FC9E60-C465-11CF-8056-444553540000}
+Provider    = %ManufacturerName%
+DriverVer   = 01/01/2027,1.0.0.0
+CatalogFile = HelloWorld.cat
+PnpLockdown = 1
+
+[Manufacturer]
+%ManufacturerName% = Standard, NTamd64
+
+[Standard.NTamd64]
+%DeviceName% = HelloWorld_Device, USB\VID_FFFF&PID_FFFF
+
+[HelloWorld_Device.NT]
+CopyFiles = HelloWorld_CopyFiles
+
+[HelloWorld_CopyFiles]
+HelloWorld.sys
+
+[HelloWorld_Device.NT.Services]
+AddService = HelloWorld, %SPSVCINST_ASSOCSERVICE%, HelloWorld_Service_Inst
+
+[HelloWorld_Service_Inst]
+DisplayName    = %ServiceDescription%
+ServiceType    = 1
+StartType      = 3
+ErrorControl   = 1
+ServiceBinary  = %12%\HelloWorld.sys
+
+[DestinationDirs]
+DefaultDestDir  = 12
+HelloWorld_CopyFiles = 12
+
+[SourceDisksNames]
+1 = %DiskName%
+
+[SourceDisksFiles]
+HelloWorld.sys = 1
+
+[Strings]
+ManufacturerName   = "Build Test"
+DeviceName         = "HelloWorld Build Test Device"
+ServiceDescription = "HelloWorld Build Test Driver"
+DiskName           = "HelloWorld Driver Disk"
+SPSVCINST_ASSOCSERVICE = 0x00000002

--- a/driver-test/HelloWorld.sln
+++ b/driver-test/HelloWorld.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloWorld", "HelloWorld.vcxproj", "{AAAABBBB-0001-0002-0003-000000000001}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AAAABBBB-0001-0002-0003-000000000001}.Debug|x64.ActiveCfg = Debug|x64
+		{AAAABBBB-0001-0002-0003-000000000001}.Debug|x64.Build.0 = Debug|x64
+		{AAAABBBB-0001-0002-0003-000000000001}.Release|x64.ActiveCfg = Release|x64
+		{AAAABBBB-0001-0002-0003-000000000001}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/driver-test/HelloWorld.vcxproj
+++ b/driver-test/HelloWorld.vcxproj
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  HelloWorld.vcxproj - KMDF EWDK build-validation project.
+  Reference: WDK KMDF driver project template (Visual Studio 2022 / EWDK).
+  Target: x64 Release only (build-pipeline smoke test).
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{AAAABBBB-0001-0002-0003-000000000001}</ProjectGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+    <RootNamespace>HelloWorld</RootNamespace>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)build\int\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>HelloWorld</TargetName>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>/Gz %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="HelloWorld.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="HelloWorld.inf" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/driver-test/LICENSE-M12
+++ b/driver-test/LICENSE-M12
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lesley Murfin / Revive Business Solutions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/driver-test/tests/kernel-stubs.h
+++ b/driver-test/tests/kernel-stubs.h
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+//
+// kernel-stubs.h — minimal userland shims for kernel types/macros used by the
+// pure-logic functions under test (ScanForSdpHidDescriptor, PatchSdpHidDescriptor,
+// TranslateReport12, ClampInt8, TouchX, TouchY).
+//
+// Usage: include this file BEFORE the production C file (or function-copy) in
+// any userland test binary. It deliberately provides only what the tested
+// functions need — not a general-purpose kernel emulation layer.
+//
+// Tested on: GCC 9+ and Clang 10+ on Linux x86-64 (WSL2).
+
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+// ---------------------------------------------------------------------------
+// SAL annotations — stripped to nothing in userland
+// ---------------------------------------------------------------------------
+
+#define _In_
+#define _In_opt_
+#define _Inout_
+#define _Out_
+#define _Out_opt_
+#define _Outptr_
+#define _In_reads_bytes_(x)
+#define _Inout_updates_bytes_(x)
+#define _Out_writes_bytes_(x)
+#define _Out_writes_(x)
+#define _In_reads_(x)
+#define UNREFERENCED_PARAMETER(x)  ((void)(x))
+
+// ---------------------------------------------------------------------------
+// Primitive Windows types
+// ---------------------------------------------------------------------------
+
+typedef unsigned char       UCHAR;
+typedef unsigned char      *PUCHAR;
+typedef unsigned long       ULONG;
+typedef unsigned long      *PULONG;
+typedef int                 BOOLEAN;
+typedef void                VOID;
+typedef void               *PVOID;
+typedef signed int          INT32;
+typedef signed char         INT8;
+typedef unsigned short      USHORT;
+typedef unsigned int        UINT32;
+typedef uintptr_t           ULONG_PTR;
+typedef size_t              SIZE_T;
+
+#define TRUE  1
+#define FALSE 0
+
+// ---------------------------------------------------------------------------
+// Compiler hints
+// ---------------------------------------------------------------------------
+
+#ifdef _MSC_VER
+#define FORCEINLINE __forceinline
+#else
+#define FORCEINLINE __attribute__((always_inline)) inline
+#endif
+
+// ---------------------------------------------------------------------------
+// Kernel memory functions → CRT equivalents
+// ---------------------------------------------------------------------------
+
+#define RtlMoveMemory(dst, src, n)  memmove((dst), (src), (n))
+#define RtlCopyMemory(dst, src, n)  memcpy((dst), (src), (n))
+#define RtlZeroMemory(dst, n)       memset((dst), 0, (n))
+
+// ---------------------------------------------------------------------------
+// Kernel debug print → stdout
+// ---------------------------------------------------------------------------
+
+#define DbgPrint(fmt, ...)          printf("[DbgPrint] " fmt, ##__VA_ARGS__)
+
+// ---------------------------------------------------------------------------
+// WDF / KMDF types — not used by the pure-logic functions but present in
+// the file-level includes of InputHandler.h / Driver.h. Stub them so the
+// preprocessor doesn't choke if the test includes those headers.
+// ---------------------------------------------------------------------------
+
+typedef void *WDFDEVICE;
+typedef void *WDFREQUEST;
+typedef void *WDFIOTARGET;
+typedef void *WDFCONTEXT;
+typedef void *PIRP;
+typedef void *PMDL;
+typedef long  NTSTATUS;
+
+// WDF_DECLARE_CONTEXT_TYPE_WITH_NAME expands to struct + accessor.
+// We don't need GetDeviceContext() in our tests — define it away.
+#define WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(type, accessor)   \
+    static inline type *accessor(WDFDEVICE _d) {             \
+        (void)_d; return NULL;                               \
+    }
+
+// Kernel type we don't use in tested functions — silence typedef errors.
+typedef struct { int dummy; } _DEVICE_CONTEXT;
+typedef _DEVICE_CONTEXT *PDEVICE_CONTEXT;
+

--- a/driver-test/tests/test-sdp-scanner.c
+++ b/driver-test/tests/test-sdp-scanner.c
@@ -1,0 +1,1090 @@
+// SPDX-License-Identifier: MIT
+//
+// test-sdp-scanner.c — userland unit tests for the pure-logic functions in
+// driver/InputHandler.c (sourced from the BRB-interception rewrite on main).
+//
+// Functions under test (copied verbatim from main:driver/InputHandler.c to
+// avoid pulling in WDF/KMDF kernel headers — the production file is untouched):
+//   - ScanForSdpHidDescriptor
+//   - PatchSdpHidDescriptor
+//   - TranslateReport12  (bonus — tested only if present)
+//   - ClampInt8          (bonus)
+//   - TouchX / TouchY    (bonus)
+//
+// Build (see scripts/mm-test.sh for canonical invocation):
+//   gcc -Wall -Wextra -Wno-unused-parameter -Wno-type-limits
+//       -o /tmp/mm-test-sdp tests/test-sdp-scanner.c
+//
+// Run:
+//   ./scripts/mm-test.sh
+//
+// Output: one "PASS  <name>" or "FAIL  <name> - <reason>" line per case.
+// Exit:   0 if all pass, 1 if any fail.
+
+#include "kernel-stubs.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+// ===========================================================================
+// Test harness
+// ===========================================================================
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define PASS(name) do { \
+    printf("PASS  %s\n", (name)); \
+    g_pass++; \
+} while (0)
+
+#define FAIL(name, reason) do { \
+    printf("FAIL  %s - %s\n", (name), (reason)); \
+    g_fail++; \
+} while (0)
+
+#define ASSERT_TRUE(name, expr) do { \
+    if (expr) { PASS(name); } \
+    else       { FAIL(name, "expected TRUE, got FALSE"); } \
+} while (0)
+
+#define ASSERT_FALSE(name, expr) do { \
+    if (!(expr)) { PASS(name); } \
+    else          { FAIL(name, "expected FALSE, got TRUE"); } \
+} while (0)
+
+#define ASSERT_EQ_UL(name, expected, actual) do { \
+    unsigned long _e = (unsigned long)(expected); \
+    unsigned long _a = (unsigned long)(actual);   \
+    if (_e == _a) { PASS(name); }                 \
+    else {                                        \
+        char _buf[128];                           \
+        snprintf(_buf, sizeof(_buf),              \
+                 "expected %lu got %lu", _e, _a); \
+        FAIL(name, _buf);                         \
+    }                                             \
+} while (0)
+
+#define ASSERT_MEM_EQ(name, expected, actual, len) do {    \
+    if (memcmp((expected), (actual), (len)) == 0) {        \
+        PASS(name);                                        \
+    } else {                                              \
+        FAIL(name, "memory mismatch");                    \
+    }                                                     \
+} while (0)
+
+// ===========================================================================
+// g_HidDescriptor fixture (verbatim from main:driver/HidDescriptor.c)
+// 113 bytes (3 TLCs: Mouse 0x01 + Consumer 0x02 + Vendor battery 0x90)
+// ===========================================================================
+
+static const UCHAR g_HidDescriptor[] = {
+    // TLC1: Generic Desktop Mouse — Report ID 0x01
+    0x05, 0x01,        // Usage Page (Generic Desktop)
+    0x09, 0x02,        // Usage (Mouse)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x01,        //   Report ID (1)
+    0x09, 0x01,        //   Usage (Pointer)
+    0xA1, 0x00,        //   Collection (Physical)
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (Button 1)
+    0x29, 0x03,        //     Usage Maximum (Button 3)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x02,        //     Input (Data, Variable, Absolute)
+    0x75, 0x05,        //     Report Size (5) padding
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x03,        //     Input (Constant)
+    0x05, 0x01,        //     Usage Page (Generic Desktop)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x06,        //     Input (Data, Variable, Relative)
+    0x09, 0x38,        //     Usage (Wheel)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data, Variable, Relative)
+    0xC0,              //   End Collection (Physical)
+    0xC0,              // End Collection (Application)
+    // TLC2: Consumer Control — Report ID 0x02
+    0x05, 0x0C,        // Usage Page (Consumer Devices)
+    0x09, 0x01,        // Usage (Consumer Control)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x02,        //   Report ID (2)
+    0x0A, 0x38, 0x02,  //   Usage (AC Pan 0x0238)
+    0x15, 0x81,        //   Logical Minimum (-127)
+    0x25, 0x7F,        //   Logical Maximum (127)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x01,        //   Report Count (1)
+    0x81, 0x06,        //   Input (Data, Variable, Relative)
+    0xC0,              // End Collection (Application)
+    // TLC3: Vendor-Defined Battery — Report ID 0x90
+    0x06, 0x00, 0xFF,  // Usage Page (Vendor-Defined 0xFF00)
+    0x09, 0x14,        // Usage (0x14)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x90,        //   Report ID (0x90)
+    0x09, 0x01,        //   Usage (0x01) flags byte
+    0x09, 0x02,        //   Usage (0x02) battery% byte
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x02,        //   Report Count (2)
+    0x81, 0x02,        //   Input (Data, Variable, Absolute)
+    0xC0,              // End Collection
+};
+static const ULONG g_HidDescriptorSize = sizeof(g_HidDescriptor);
+
+// ===========================================================================
+// Functions under test (verbatim from main:driver/InputHandler.c)
+// Copied to avoid WDF/KMDF kernel headers. Production source is untouched.
+// ===========================================================================
+
+#define SDP_DE_UINT16             0x09
+#define SDP_DE_SEQUENCE_1B        0x35
+#define SDP_DE_UINT8              0x08
+#define SDP_DE_TEXT_1B            0x25
+#define SDP_ATTR_HID_DESC_LIST_HI 0x02
+#define SDP_ATTR_HID_DESC_LIST_LO 0x06
+#define HID_RPT_DESC_TYPE         0x22
+#define SDP_SCAN_MIN_LEN          11
+#define SDP_DESC_MAX_EXPECTED_LEN 512
+
+static BOOLEAN
+ScanForSdpHidDescriptor(
+    PUCHAR  buf,
+    ULONG   bufSize,
+    PULONG  outOffset,
+    PULONG  outLen)
+{
+    if (buf == NULL || bufSize < SDP_SCAN_MIN_LEN) {
+        return FALSE;
+    }
+
+    ULONG limit = bufSize - SDP_SCAN_MIN_LEN;
+    for (ULONG i = 0; i <= limit; i++) {
+        if (buf[i]   != SDP_DE_UINT16              ) continue;
+        if (buf[i+1] != SDP_ATTR_HID_DESC_LIST_HI  ) continue;
+        if (buf[i+2] != SDP_ATTR_HID_DESC_LIST_LO  ) continue;
+        if (buf[i+3] != SDP_DE_SEQUENCE_1B         ) continue;
+
+        UCHAR outer_len = buf[i+4];
+        if (outer_len < 4)                            continue;
+        if ((ULONG)(i + 5 + outer_len) > bufSize)     continue;
+
+        if (buf[i+5] != SDP_DE_SEQUENCE_1B)           continue;
+        UCHAR inner_len = buf[i+6];
+        if (inner_len < 4)                            continue;
+        if ((ULONG)(i + 7 + inner_len) > bufSize)     continue;
+
+        if (buf[i+7] != SDP_DE_UINT8)                 continue;
+        if (buf[i+8] != HID_RPT_DESC_TYPE)            continue;
+        if (buf[i+9] != SDP_DE_TEXT_1B)               continue;
+
+        UCHAR desc_len = buf[i+10];
+        if (desc_len == 0)                            continue;
+        if (desc_len > SDP_DESC_MAX_EXPECTED_LEN)     continue;
+        if ((ULONG)(i + 11 + desc_len) > bufSize)     continue;
+
+        *outOffset = i + 11;
+        *outLen    = desc_len;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static BOOLEAN
+PatchSdpHidDescriptor(
+    PUCHAR buf,
+    ULONG  bufSize,
+    ULONG  descOffset,
+    ULONG  descLen,
+    PULONG newBufUsed)
+{
+    if (descOffset < 6) {
+        return FALSE;
+    }
+
+    ULONG newDescLen = g_HidDescriptorSize;
+    ULONG tailOffset = descOffset + descLen;
+    ULONG tailBytes  = bufSize - tailOffset;
+    ULONG newBufSize = descOffset + newDescLen + tailBytes;
+
+    if (newBufSize > bufSize) {
+        DbgPrint("MagicMouse: SDP patch SKIPPED - buffer too small "
+                 "(need %lu, have %lu).\n",
+                 newBufSize, bufSize);
+        return FALSE;
+    }
+
+    if (newDescLen != descLen) {
+        ULONG newTailOffset = descOffset + newDescLen;
+        if (tailBytes > 0) {
+            RtlMoveMemory(buf + newTailOffset, buf + tailOffset, tailBytes);
+        }
+        if (newDescLen < descLen) {
+            ULONG gapStart = newTailOffset + tailBytes;
+            ULONG gapLen   = descLen - newDescLen;
+            RtlZeroMemory(buf + gapStart, gapLen);
+        }
+    }
+
+    RtlCopyMemory(buf + descOffset, g_HidDescriptor, newDescLen);
+
+    // SDP TLV length-byte fixups (1-byte length form)
+    buf[descOffset - 1] = (UCHAR)newDescLen;
+    ULONG innerPayload = 2 + 2 + newDescLen;
+    if (innerPayload > 0xFF) {
+        DbgPrint("MagicMouse: SDP patch - inner SEQUENCE length overflow (%lu)\n",
+                 innerPayload);
+    }
+    buf[descOffset - 3] = (UCHAR)(innerPayload & 0xFF);
+    ULONG outerPayload = 2 + innerPayload;
+    if (outerPayload > 0xFF) {
+        DbgPrint("MagicMouse: SDP patch - outer SEQUENCE length overflow (%lu)\n",
+                 outerPayload);
+    }
+    buf[descOffset - 5] = (UCHAR)(outerPayload & 0xFF);
+
+    *newBufUsed = descOffset + newDescLen + tailBytes;
+    return TRUE;
+}
+
+// ---------------------------------------------------------------------------
+// Bonus: ClampInt8, TouchX, TouchY, TranslateReport12
+// (verbatim from main:driver/InputHandler.c)
+// ---------------------------------------------------------------------------
+
+#define TOUCH2_HEADER     7
+#define TOUCH2_BLOCK      8
+#define TOUCH_START    0x30
+#define TOUCH_DRAG     0x40
+#define SCALE_POINTER     4
+#define SCALE_SCROLL      8
+#define MM_REPORT_ID_MOUSE 0x01
+#define MM_MOUSE_REPORT_LEN 5
+
+static FORCEINLINE INT8
+ClampInt8(INT32 v)
+{
+    if (v >  127) return  127;
+    if (v < -127) return -127;
+    return (INT8)v;
+}
+
+static FORCEINLINE INT32
+TouchX(PUCHAR t)
+{
+    return (INT32)((((UINT32)t[1] << 28) | ((UINT32)t[0] << 20))) >> 20;
+}
+
+static FORCEINLINE INT32
+TouchY(PUCHAR t)
+{
+    return -((INT32)((((UINT32)t[2] << 24) | ((UINT32)t[1] << 16))) >> 20);
+}
+
+static BOOLEAN
+TranslateReport12(
+    PUCHAR  buf,
+    ULONG   bufSize,
+    INT8   *outWheelH,
+    PULONG  outReportLen)
+{
+    *outReportLen = 0;
+    if (outWheelH) *outWheelH = 0;
+
+    if (bufSize < (ULONG)(TOUCH2_HEADER + 1)) {
+        return FALSE;
+    }
+
+    UCHAR  buttons = buf[1] & 0x03;
+    ULONG  nBlocks = (bufSize - TOUCH2_HEADER) / TOUCH2_BLOCK;
+    INT8   x = 0, y = 0, wheelV = 0, wheelH = 0;
+
+    if (nBlocks >= 1) {
+        PUCHAR t = &buf[TOUCH2_HEADER];
+        INT32  rawX = TouchX(t);
+        INT32  rawY = TouchY(t);
+        UCHAR  state = t[7] & 0xF0;
+
+        if (nBlocks == 1) {
+            x = ClampInt8(rawX / SCALE_POINTER);
+            y = ClampInt8(rawY / SCALE_POINTER);
+        } else {
+            if (state == TOUCH_START || state == TOUCH_DRAG) {
+                wheelV = ClampInt8(rawY / SCALE_SCROLL);
+                wheelH = ClampInt8(rawX / SCALE_SCROLL);
+            }
+        }
+    }
+
+    buf[0] = MM_REPORT_ID_MOUSE;
+    buf[1] = buttons;
+    buf[2] = (UCHAR)x;
+    buf[3] = (UCHAR)y;
+    buf[4] = (UCHAR)wheelV;
+
+    if (outWheelH) *outWheelH = wheelH;
+    *outReportLen = MM_MOUSE_REPORT_LEN;
+    return TRUE;
+}
+
+// ===========================================================================
+// Helper: build a minimal SDP buffer containing the HIDDescriptorList pattern.
+//
+// Layout assembled here:
+//   [preamble bytes]
+//   09 02 06          <- SDP_DE_UINT16, AttrID HIDDescriptorList
+//   35 OO             <- outer SEQUENCE_1B, length OO
+//     35 II           <- inner SEQUENCE_1B, length II
+//       08 22         <- SDP_DE_UINT8, 0x22 (Report descriptor type)
+//       25 NN         <- SDP_DE_TEXT_1B, NN bytes follow
+//         [NN bytes]  <- descriptor payload
+//   [tail bytes]
+//
+// Returns the byte offset of the descriptor payload within outBuf[].
+// ===========================================================================
+
+static ULONG build_sdp_packet(
+    UCHAR *outBuf, ULONG bufSize,
+    ULONG preamble,
+    const UCHAR *desc, ULONG descLen,
+    ULONG tailLen)
+{
+    // innerContent: the payload of the inner SEQUENCE (not counting the 35 II header itself)
+    //   = [08 22](2) + [25 NN](2) + desc(descLen)
+    ULONG innerContent = 2 + 2 + descLen;
+    // outerContent: the payload of the outer SEQUENCE (not counting the 35 OO header itself)
+    //   = [35 II](2) + innerContent
+    ULONG outerContent = 2 + innerContent;
+
+    // Total bytes written:
+    //   preamble + [09 02 06](3) + [35 OO](2) + outerContent + tailLen
+    ULONG total = preamble + 3 + 2 + outerContent + tailLen;
+    if (total > bufSize) return 0; // caller must size properly
+
+    UCHAR *p = outBuf;
+    // preamble fill
+    for (ULONG i = 0; i < preamble; i++) *p++ = 0xAA;
+
+    // SDP attribute header
+    *p++ = 0x09; // SDP_DE_UINT16
+    *p++ = 0x02; // HI
+    *p++ = 0x06; // LO
+
+    // outer SEQUENCE_1B
+    *p++ = 0x35;
+    *p++ = (UCHAR)outerContent;
+
+    // inner SEQUENCE_1B
+    *p++ = 0x35;
+    *p++ = (UCHAR)innerContent;
+
+    // descriptor type element
+    *p++ = 0x08; // SDP_DE_UINT8
+    *p++ = 0x22; // 0x22 = Report descriptor
+
+    // text string element
+    *p++ = 0x25; // SDP_DE_TEXT_1B
+    *p++ = (UCHAR)descLen;
+
+    // descriptor payload
+    ULONG descOffset = (ULONG)(p - outBuf);
+    memcpy(p, desc, descLen);
+    p += descLen;
+
+    // tail bytes
+    for (ULONG i = 0; i < tailLen; i++) *p++ = 0xBB;
+
+    return descOffset;
+}
+
+// ===========================================================================
+// ScanForSdpHidDescriptor tests
+// ===========================================================================
+
+// A small fake "old" descriptor for testing (different from g_HidDescriptor)
+static const UCHAR OLD_DESC[] = {
+    0x05, 0x01, 0x09, 0x02, 0xA1, 0x01,  // 6 bytes — simple fake
+};
+#define OLD_DESC_LEN ((ULONG)sizeof(OLD_DESC))
+
+static void test_scan_null_returns_false(void)
+{
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_null_returns_false",
+                 ScanForSdpHidDescriptor(NULL, 100, &off, &len));
+}
+
+static void test_scan_empty_returns_false(void)
+{
+    UCHAR buf[1] = {0};
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_empty_returns_false",
+                 ScanForSdpHidDescriptor(buf, 0, &off, &len));
+}
+
+static void test_scan_below_min_len_returns_false(void)
+{
+    // SDP_SCAN_MIN_LEN == 11; provide 10 bytes
+    UCHAR buf[10];
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0x09; buf[1] = 0x02; buf[2] = 0x06; // start of pattern
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_below_min_len_returns_false",
+                 ScanForSdpHidDescriptor(buf, 10, &off, &len));
+}
+
+static void test_scan_all_zeros_returns_false(void)
+{
+    UCHAR buf[64];
+    memset(buf, 0, sizeof(buf));
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_all_zeros_returns_false",
+                 ScanForSdpHidDescriptor(buf, sizeof(buf), &off, &len));
+}
+
+static void test_scan_finds_pattern_at_offset0(void)
+{
+    // Build SDP packet with no preamble and OLD_DESC as payload
+    UCHAR buf[128];
+    memset(buf, 0, sizeof(buf));
+    ULONG descOffset = build_sdp_packet(buf, sizeof(buf), 0,
+                                        OLD_DESC, OLD_DESC_LEN, 0);
+    if (descOffset == 0) { FAIL("test_scan_finds_pattern_at_offset0", "build failed"); return; }
+
+    ULONG off = 0, len = 0;
+    BOOLEAN found = ScanForSdpHidDescriptor(buf, sizeof(buf), &off, &len);
+    ASSERT_TRUE("test_scan_finds_pattern_at_offset0 [found]", found);
+    ASSERT_EQ_UL("test_scan_finds_pattern_at_offset0 [offset]", descOffset, off);
+    ASSERT_EQ_UL("test_scan_finds_pattern_at_offset0 [len]", OLD_DESC_LEN, len);
+}
+
+static void test_scan_finds_pattern_with_preamble(void)
+{
+    // Build SDP packet with 7 bytes of preamble junk
+    UCHAR buf[256];
+    memset(buf, 0, sizeof(buf));
+    ULONG preamble = 7;
+    ULONG descOffset = build_sdp_packet(buf, sizeof(buf), preamble,
+                                        OLD_DESC, OLD_DESC_LEN, 0);
+    if (descOffset == 0) { FAIL("test_scan_finds_pattern_with_preamble", "build failed"); return; }
+
+    ULONG off = 0, len = 0;
+    BOOLEAN found = ScanForSdpHidDescriptor(buf, sizeof(buf), &off, &len);
+    ASSERT_TRUE("test_scan_finds_pattern_with_preamble [found]", found);
+    ASSERT_EQ_UL("test_scan_finds_pattern_with_preamble [offset]", descOffset, off);
+    ASSERT_EQ_UL("test_scan_finds_pattern_with_preamble [len]", OLD_DESC_LEN, len);
+}
+
+static void test_scan_truncated_outer_sequence_returns_false(void)
+{
+    // Build a valid-looking packet but truncate so outer SEQUENCE overflows bufSize
+    UCHAR buf[128];
+    memset(buf, 0, sizeof(buf));
+    ULONG descOffset = build_sdp_packet(buf, sizeof(buf), 0,
+                                        OLD_DESC, OLD_DESC_LEN, 0);
+    if (descOffset == 0) { FAIL("test_scan_truncated_outer_sequence_returns_false", "build failed"); return; }
+    // Truncate the buffer right after the outer length byte (byte index 4)
+    // so the outer SEQUENCE content is cut off
+    ULONG truncLen = 5; // 09 02 06 35 LL — LL present but content cut
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_truncated_outer_sequence_returns_false",
+                 ScanForSdpHidDescriptor(buf, truncLen, &off, &len));
+}
+
+static void test_scan_0x36_two_byte_sequence_returns_false(void)
+{
+    // Use 0x36 (2-byte length form) instead of 0x35 for the outer SEQUENCE.
+    // The scanner only handles 1-byte (0x35) — 0x36 should yield FALSE.
+    UCHAR buf[64];
+    memset(buf, 0, sizeof(buf));
+    //   09 02 06  <- attribute header
+    //   36 00 10  <- 2-byte length form (not handled)
+    buf[0] = 0x09; buf[1] = 0x02; buf[2] = 0x06;
+    buf[3] = 0x36; buf[4] = 0x00; buf[5] = 0x10;  // 2-byte length, content = 16 bytes
+    // Fill remaining with valid-looking inner data
+    buf[6]  = 0x35; buf[7]  = 0x08;  // inner SEQUENCE_1B
+    buf[8]  = 0x08; buf[9]  = 0x22;  // UINT8, 0x22
+    buf[10] = 0x25; buf[11] = 0x04;  // TEXT_1B, 4 bytes
+    buf[12] = 0x01; buf[13] = 0x02; buf[14] = 0x03; buf[15] = 0x04; // descriptor
+
+    ULONG off = 0, len = 0;
+    // outer byte at position 3 is 0x36, which != SDP_DE_SEQUENCE_1B (0x35)
+    // → scanner skips → returns FALSE
+    ASSERT_FALSE("test_scan_0x36_two_byte_sequence_returns_false",
+                 ScanForSdpHidDescriptor(buf, 64, &off, &len));
+}
+
+static void test_scan_desc_len_zero_skipped(void)
+{
+    // Construct a pattern where desc_len byte is 0 — must be skipped.
+    UCHAR buf[64];
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0x09; buf[1] = 0x02; buf[2] = 0x06; // attr header
+    buf[3] = 0x35; buf[4] = 0x08;                 // outer SEQUENCE_1B length=8
+    buf[5] = 0x35; buf[6] = 0x06;                 // inner SEQUENCE_1B length=6
+    buf[7] = 0x08; buf[8] = 0x22;                 // UINT8 0x22
+    buf[9] = 0x25; buf[10] = 0x00;                // TEXT_1B, length=0 ← rejected
+    // (remaining bytes don't matter)
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_desc_len_zero_skipped",
+                 ScanForSdpHidDescriptor(buf, 64, &off, &len));
+}
+
+static void test_scan_desc_overflows_buffer_returns_false(void)
+{
+    // Build a valid packet but hand a bufSize that's exactly 1 byte short of
+    // containing the full descriptor payload.
+    UCHAR buf[256];
+    memset(buf, 0, sizeof(buf));
+    ULONG descOffset = build_sdp_packet(buf, sizeof(buf), 0,
+                                        OLD_DESC, OLD_DESC_LEN, 0);
+    if (descOffset == 0) { FAIL("test_scan_desc_overflows_buffer_returns_false", "build failed"); return; }
+    // required size = descOffset + OLD_DESC_LEN; trim by 1
+    ULONG needed = descOffset + OLD_DESC_LEN;
+    ULONG off = 0, len = 0;
+    ASSERT_FALSE("test_scan_desc_overflows_buffer_returns_false",
+                 ScanForSdpHidDescriptor(buf, needed - 1, &off, &len));
+}
+
+static void test_scan_multiple_attributes_finds_first_valid(void)
+{
+    // Two SDP attributes concatenated: first is NOT the HIDDescriptorList
+    // (different attribute ID); second is the correct one. Scanner must skip
+    // the first and return the second.
+    UCHAR buf[256];
+    memset(buf, 0, sizeof(buf));
+
+    // First "attribute" — wrong attribute ID (0x0200 instead of 0x0206)
+    // Uses same SEQUENCE structure but different attr bytes → scanner will
+    // skip at the buf[i+2] != 0x06 check.
+    UCHAR *p = buf;
+    *p++ = 0x09; *p++ = 0x02; *p++ = 0x00; // wrong attr id
+    *p++ = 0x35; *p++ = 0x08;
+    *p++ = 0x35; *p++ = 0x06;
+    *p++ = 0x08; *p++ = 0x22;
+    *p++ = 0x25; *p++ = 0x04;
+    *p++ = 0xDE; *p++ = 0xAD; *p++ = 0xBE; *p++ = 0xEF; // fake desc
+
+    ULONG preamble2 = (ULONG)(p - buf);
+
+    // Now build the real attribute
+    ULONG descOffset = build_sdp_packet(p, sizeof(buf) - preamble2, 0,
+                                        OLD_DESC, OLD_DESC_LEN, 0);
+    if (descOffset == 0) {
+        FAIL("test_scan_multiple_attributes_finds_first_valid", "build failed");
+        return;
+    }
+    descOffset += preamble2; // adjust for the prefix we wrote directly
+
+    ULONG totalLen = preamble2 + 3 + 2 + 2 + 2 + 2 + OLD_DESC_LEN + 0;
+    // compute actual used length from build_sdp_packet result
+    // (easier: use the full buf, let the scanner stop at first match)
+    ULONG off = 0, len = 0;
+    BOOLEAN found = ScanForSdpHidDescriptor(buf, sizeof(buf), &off, &len);
+    (void)totalLen;
+    ASSERT_TRUE("test_scan_multiple_attributes_finds_first_valid [found]", found);
+    ASSERT_EQ_UL("test_scan_multiple_attributes_finds_first_valid [offset]", descOffset, off);
+    ASSERT_EQ_UL("test_scan_multiple_attributes_finds_first_valid [len]", OLD_DESC_LEN, len);
+}
+
+// ===========================================================================
+// PatchSdpHidDescriptor tests
+// ===========================================================================
+
+// Helper: build a full SDP buffer, return descOffset; caller may patch it.
+static ULONG make_patch_buffer(UCHAR *buf, ULONG bufSize,
+                                const UCHAR *oldDesc, ULONG oldDescLen,
+                                ULONG tailLen)
+{
+    return build_sdp_packet(buf, bufSize, 0, oldDesc, oldDescLen, tailLen);
+}
+
+static void test_patch_too_small_offset_returns_false(void)
+{
+    UCHAR buf[256] = {0};
+    ULONG newUsed = 0;
+    // descOffset < 6 is invalid framing
+    ASSERT_FALSE("test_patch_too_small_offset_returns_false",
+                 PatchSdpHidDescriptor(buf, sizeof(buf), 5, 10, &newUsed));
+}
+
+static void test_patch_replacement_same_size(void)
+{
+    // Build a buffer where oldDesc has exactly the same byte count as g_HidDescriptor.
+    // Patch should succeed, no memmove needed, tail unchanged.
+    // Pass the exact used byte count as bufSize (not allocation size) so the
+    // function's tailBytes calculation is accurate.
+    ULONG newDescLen = g_HidDescriptorSize; // 113
+    UCHAR *oldDesc = (UCHAR *)malloc(newDescLen);
+    if (!oldDesc) { FAIL("test_patch_replacement_same_size", "alloc failed"); return; }
+    memset(oldDesc, 0xFF, newDescLen);
+
+    ULONG tailLen = 8;
+    ULONG alloc = 512;
+    UCHAR *buf = (UCHAR *)calloc(1, alloc);
+    if (!buf) { free(oldDesc); FAIL("test_patch_replacement_same_size", "alloc failed"); return; }
+
+    ULONG descOffset = make_patch_buffer(buf, alloc, oldDesc, newDescLen, tailLen);
+    if (descOffset == 0) {
+        free(buf); free(oldDesc);
+        FAIL("test_patch_replacement_same_size", "build failed"); return;
+    }
+
+    // usedSize = exact bytes written by build_sdp_packet
+    ULONG usedSize = descOffset + newDescLen + tailLen;
+
+    // Record tail bytes before patch
+    UCHAR tailBefore[8];
+    memcpy(tailBefore, buf + descOffset + newDescLen, tailLen);
+
+    ULONG newUsed = 0;
+    // Pass usedSize as bufSize so tailBytes = tailLen exactly
+    BOOLEAN ok = PatchSdpHidDescriptor(buf, usedSize, descOffset, newDescLen, &newUsed);
+    ASSERT_TRUE("test_patch_replacement_same_size [returns TRUE]", ok);
+
+    // Descriptor payload replaced with g_HidDescriptor
+    ASSERT_MEM_EQ("test_patch_replacement_same_size [descriptor content]",
+                  g_HidDescriptor, buf + descOffset, newDescLen);
+
+    // Tail must be unmodified
+    ASSERT_MEM_EQ("test_patch_replacement_same_size [tail unchanged]",
+                  tailBefore, buf + descOffset + newDescLen, tailLen);
+
+    // newBufUsed = descOffset + newDescLen + tailLen
+    ULONG expectedUsed = descOffset + newDescLen + tailLen;
+    ASSERT_EQ_UL("test_patch_replacement_same_size [newBufUsed]", expectedUsed, newUsed);
+
+    free(buf); free(oldDesc);
+}
+
+static void test_patch_replacement_smaller_memmoves_tail(void)
+{
+    // oldDesc is LARGER than g_HidDescriptor → replacement makes it smaller.
+    // memmove brings tail backward; gap at end is zeroed.
+    ULONG oldDescLen = g_HidDescriptorSize + 20; // 20 bytes bigger
+    UCHAR *oldDesc = (UCHAR *)malloc(oldDescLen);
+    if (!oldDesc) { FAIL("test_patch_replacement_smaller_memmoves_tail", "alloc failed"); return; }
+    memset(oldDesc, 0xCC, oldDescLen);
+
+    ULONG tailLen = 12;
+    ULONG alloc = 512;
+    UCHAR *buf = (UCHAR *)calloc(1, alloc);
+    if (!buf) { free(oldDesc); FAIL("test_patch_replacement_smaller_memmoves_tail", "alloc failed"); return; }
+
+    ULONG descOffset = make_patch_buffer(buf, alloc, oldDesc, oldDescLen, tailLen);
+    if (descOffset == 0) {
+        free(buf); free(oldDesc);
+        FAIL("test_patch_replacement_smaller_memmoves_tail", "build failed"); return;
+    }
+
+    // usedSize = exact bytes written
+    ULONG usedSize = descOffset + oldDescLen + tailLen;
+
+    // Record original tail
+    UCHAR tailBefore[12];
+    memcpy(tailBefore, buf + descOffset + oldDescLen, tailLen);
+
+    ULONG newUsed = 0;
+    // Pass usedSize so tailBytes = tailLen exactly
+    BOOLEAN ok = PatchSdpHidDescriptor(buf, usedSize, descOffset, oldDescLen, &newUsed);
+    ASSERT_TRUE("test_patch_replacement_smaller [returns TRUE]", ok);
+
+    // New descriptor written at descOffset
+    ASSERT_MEM_EQ("test_patch_replacement_smaller [descriptor content]",
+                  g_HidDescriptor, buf + descOffset, g_HidDescriptorSize);
+
+    // Tail moved to descOffset + g_HidDescriptorSize
+    ULONG newTailOffset = descOffset + g_HidDescriptorSize;
+    ASSERT_MEM_EQ("test_patch_replacement_smaller [tail at new position]",
+                  tailBefore, buf + newTailOffset, tailLen);
+
+    // Gap bytes zeroed (gap follows new tail)
+    ULONG gapStart = newTailOffset + tailLen;
+    ULONG gapLen   = oldDescLen - g_HidDescriptorSize;
+    UCHAR *gap = buf + gapStart;
+    int gapZeroed = 1;
+    for (ULONG i = 0; i < gapLen; i++) {
+        if (gap[i] != 0) { gapZeroed = 0; break; }
+    }
+    ASSERT_TRUE("test_patch_replacement_smaller [gap zeroed]", gapZeroed);
+
+    // Length bytes updated
+    ASSERT_EQ_UL("test_patch_replacement_smaller [TEXT_STRING len byte]",
+                 g_HidDescriptorSize, (ULONG)buf[descOffset - 1]);
+
+    free(buf); free(oldDesc);
+}
+
+static void test_patch_replacement_larger_returns_false(void)
+{
+    // Design constraint: PatchSdpHidDescriptor cannot expand in-place.
+    // When g_HidDescriptor (newDescLen) > oldDescLen, the function must
+    // return FALSE regardless of physical buffer allocation because
+    // tailBytes = bufSize - tailOffset, so newBufSize always exceeds bufSize
+    // when newDescLen > oldDescLen.
+    //
+    // This is intentional: the BRB ACL buffer is fixed-size (allocated by BthEnum).
+    // If the old device descriptor was smaller than our replacement, the user must
+    // force re-pair with a larger SDP buffer — we cannot patch in-place.
+    ULONG oldDescLen = g_HidDescriptorSize - 10; // strictly smaller than g_HidDescriptor
+    UCHAR *oldDesc = (UCHAR *)malloc(oldDescLen);
+    if (!oldDesc) { FAIL("test_patch_replacement_larger_returns_false", "alloc failed"); return; }
+    memset(oldDesc, 0xDD, oldDescLen);
+
+    ULONG tailLen = 0; // no tail to simplify the math
+    ULONG tempAlloc = 512;
+    UCHAR *tempBuf = (UCHAR *)calloc(1, tempAlloc);
+    if (!tempBuf) { free(oldDesc); FAIL("test_patch_replacement_larger_returns_false", "alloc failed"); return; }
+    ULONG descOffset = make_patch_buffer(tempBuf, tempAlloc, oldDesc, oldDescLen, tailLen);
+    free(tempBuf);
+    if (descOffset == 0) {
+        free(oldDesc);
+        FAIL("test_patch_replacement_larger_returns_false", "build failed"); return;
+    }
+
+    // Allocate generously; pass usedOld as bufSize (exact old content length)
+    ULONG usedOld = descOffset + oldDescLen + tailLen;
+    UCHAR *buf = (UCHAR *)calloc(1, usedOld);
+    if (!buf) { free(oldDesc); FAIL("test_patch_replacement_larger_returns_false", "alloc failed"); return; }
+    ULONG d2 = make_patch_buffer(buf, usedOld, oldDesc, oldDescLen, tailLen);
+    if (d2 == 0) {
+        free(buf); free(oldDesc);
+        FAIL("test_patch_replacement_larger_returns_false", "build2 failed"); return;
+    }
+
+    // Save original
+    UCHAR *orig = (UCHAR *)malloc(usedOld);
+    if (!orig) { free(buf); free(oldDesc); FAIL("test_patch_replacement_larger_returns_false", "alloc failed"); return; }
+    memcpy(orig, buf, usedOld);
+
+    ULONG newUsed = 0;
+    // Pass usedOld as bufSize. Since g_HidDescriptorSize > oldDescLen,
+    // newBufSize = descOffset + g_HidDescriptorSize + tailBytes
+    //            = descOffset + g_HidDescriptorSize + (usedOld - descOffset - oldDescLen)
+    //            = g_HidDescriptorSize - oldDescLen + usedOld  >  usedOld
+    // → must return FALSE.
+    BOOLEAN ok = PatchSdpHidDescriptor(buf, usedOld, descOffset, oldDescLen, &newUsed);
+    ASSERT_FALSE("test_patch_replacement_larger_returns_false [returns FALSE]", ok);
+    // Buffer must be unmodified
+    ASSERT_MEM_EQ("test_patch_replacement_larger_returns_false [buf unchanged]",
+                  orig, buf, usedOld);
+
+    free(buf); free(orig); free(oldDesc);
+}
+
+static void test_patch_too_large_buffer_unchanged(void)
+{
+    // Buffer is exactly one byte too small to hold the expanded replacement.
+    // PatchSdpHidDescriptor must return FALSE and leave the buffer unmodified.
+    ULONG oldDescLen = 4; // tiny placeholder — much smaller than g_HidDescriptor
+    UCHAR *oldDesc = (UCHAR *)malloc(oldDescLen);
+    if (!oldDesc) { FAIL("test_patch_too_large_buffer_unchanged", "alloc failed"); return; }
+    memset(oldDesc, 0xEE, oldDescLen);
+
+    // g_HidDescriptorSize >> oldDescLen so there will be a buffer-size gap.
+    if (g_HidDescriptorSize <= oldDescLen) {
+        free(oldDesc);
+        FAIL("test_patch_too_large_buffer_unchanged",
+             "SKIP: g_HidDescriptorSize <= oldDescLen, test invalid"); return;
+    }
+
+    ULONG tailLen = 0;
+    // First pass: discover descOffset using a generous temp buffer.
+    ULONG tmpAlloc = 512;
+    UCHAR *tmpBuf = (UCHAR *)calloc(1, tmpAlloc);
+    if (!tmpBuf) { free(oldDesc); FAIL("test_patch_too_large_buffer_unchanged", "alloc failed"); return; }
+    ULONG descOffset = make_patch_buffer(tmpBuf, tmpAlloc, oldDesc, oldDescLen, tailLen);
+    free(tmpBuf);
+    if (descOffset == 0) {
+        free(oldDesc);
+        FAIL("test_patch_too_large_buffer_unchanged", "build failed"); return;
+    }
+
+    // tightSize = exactly the bytes used by the OLD content
+    ULONG tightSize = descOffset + oldDescLen + tailLen;
+    // The expanded size would be: descOffset + g_HidDescriptorSize + tailLen
+    // Since g_HidDescriptorSize > oldDescLen, tightSize < needed → Patch returns FALSE.
+
+    UCHAR *buf = (UCHAR *)calloc(1, tightSize + 16); // +16 for overflow safety in assertions
+    if (!buf) { free(oldDesc); FAIL("test_patch_too_large_buffer_unchanged", "alloc failed"); return; }
+    ULONG d2 = make_patch_buffer(buf, tightSize, oldDesc, oldDescLen, tailLen);
+    if (d2 == 0) {
+        free(buf); free(oldDesc);
+        FAIL("test_patch_too_large_buffer_unchanged", "build2 failed"); return;
+    }
+
+    // Save original buffer
+    UCHAR *orig = (UCHAR *)malloc(tightSize);
+    if (!orig) { free(buf); free(oldDesc); FAIL("test_patch_too_large_buffer_unchanged", "alloc failed"); return; }
+    memcpy(orig, buf, tightSize);
+
+    ULONG newUsed = 0;
+    // Pass tightSize as bufSize — too small for g_HidDescriptor replacement
+    BOOLEAN ok = PatchSdpHidDescriptor(buf, tightSize, descOffset, oldDescLen, &newUsed);
+    ASSERT_FALSE("test_patch_too_large_buffer_unchanged [returns FALSE]", ok);
+    // Buffer must be completely unmodified
+    ASSERT_MEM_EQ("test_patch_too_large_buffer_unchanged [buf unchanged]",
+                  orig, buf, tightSize);
+
+    free(buf); free(orig); free(oldDesc);
+}
+
+static void test_patch_tlv_length_bytes_updated(void)
+{
+    // Verify the SDP TLV length bytes at [descOffset-1], [descOffset-3], [descOffset-5]
+    // are updated correctly after a successful patch.
+    //
+    // Use oldDescLen == g_HidDescriptorSize (same-size replacement) so that
+    // PatchSdpHidDescriptor succeeds — the function only patches in-place when
+    // newDescLen <= oldDescLen (BRB buffer is fixed-size by design).
+    ULONG oldDescLen = g_HidDescriptorSize; // same size — patch will succeed
+    UCHAR *oldDesc = (UCHAR *)malloc(oldDescLen);
+    if (!oldDesc) { FAIL("test_patch_tlv_length_bytes_updated", "alloc failed"); return; }
+    memset(oldDesc, 0xAB, oldDescLen);
+    ULONG tailLen = 4;
+    ULONG tempAlloc = 512;
+    UCHAR *tmpBuf = (UCHAR *)calloc(1, tempAlloc);
+    if (!tmpBuf) { free(oldDesc); FAIL("test_patch_tlv_length_bytes_updated", "alloc failed"); return; }
+    ULONG descOffset = make_patch_buffer(tmpBuf, tempAlloc, oldDesc, oldDescLen, tailLen);
+    free(tmpBuf);
+    if (descOffset == 0) { free(oldDesc); FAIL("test_patch_tlv_length_bytes_updated", "build1 failed"); return; }
+
+    ULONG usedOld = descOffset + oldDescLen + tailLen;
+    UCHAR *buf = (UCHAR *)calloc(1, usedOld);
+    if (!buf) { free(oldDesc); FAIL("test_patch_tlv_length_bytes_updated", "alloc failed"); return; }
+    ULONG d2 = make_patch_buffer(buf, usedOld, oldDesc, oldDescLen, tailLen);
+    if (d2 == 0) {
+        free(buf); free(oldDesc);
+        FAIL("test_patch_tlv_length_bytes_updated", "build2 failed"); return;
+    }
+
+    ULONG newUsed = 0;
+    BOOLEAN ok = PatchSdpHidDescriptor(buf, usedOld, descOffset, oldDescLen, &newUsed);
+    if (!ok) { free(buf); free(oldDesc); FAIL("test_patch_tlv_length_bytes_updated", "patch failed"); return; }
+
+    ULONG newDescLen    = g_HidDescriptorSize;
+    UCHAR expectedText  = (UCHAR)newDescLen;
+    ULONG innerPayload  = 2 + 2 + newDescLen;
+    UCHAR expectedInner = (UCHAR)(innerPayload & 0xFF);
+    ULONG outerPayload  = 2 + innerPayload;
+    UCHAR expectedOuter = (UCHAR)(outerPayload & 0xFF);
+
+    ASSERT_EQ_UL("test_patch_tlv_length_bytes_updated [TEXT_STRING len]",
+                 expectedText,  (ULONG)buf[descOffset - 1]);
+    ASSERT_EQ_UL("test_patch_tlv_length_bytes_updated [inner SEQUENCE len]",
+                 expectedInner, (ULONG)buf[descOffset - 3]);
+    ASSERT_EQ_UL("test_patch_tlv_length_bytes_updated [outer SEQUENCE len]",
+                 expectedOuter, (ULONG)buf[descOffset - 5]);
+
+    free(buf);
+}
+
+// ===========================================================================
+// ClampInt8 tests
+// ===========================================================================
+
+static void test_clamp_within_range(void)
+{
+    ASSERT_EQ_UL("test_clamp_within_range_zero",    0,    (ULONG)(unsigned char)ClampInt8(0));
+    ASSERT_EQ_UL("test_clamp_within_range_pos",     50,   (ULONG)(unsigned char)ClampInt8(50));
+}
+
+static void test_clamp_max_positive(void)
+{
+    ASSERT_EQ_UL("test_clamp_max_positive",  127, (ULONG)(unsigned char)ClampInt8(200));
+}
+
+static void test_clamp_min_negative(void)
+{
+    // -127 cast to unsigned char is 129 on two's complement
+    INT8 result = ClampInt8(-200);
+    ASSERT_TRUE("test_clamp_min_negative", result == -127);
+}
+
+static void test_clamp_boundary(void)
+{
+    ASSERT_EQ_UL("test_clamp_boundary_127",  127, (ULONG)(unsigned char)ClampInt8(127));
+    INT8 r = ClampInt8(-127);
+    ASSERT_TRUE("test_clamp_boundary_neg127", r == -127);
+}
+
+// ===========================================================================
+// TouchX / TouchY tests
+// (Signed 12-bit values packed across two bytes via Linux formula)
+// ===========================================================================
+
+static void test_touch_x_zero(void)
+{
+    UCHAR t[3] = { 0x00, 0x00, 0x00 };
+    INT32 x = TouchX(t);
+    ASSERT_EQ_UL("test_touch_x_zero", 0, (ULONG)(unsigned int)x);
+}
+
+static void test_touch_x_positive(void)
+{
+    // Encode +128 into the two-byte 12-bit little-endian field.
+    // Formula: result = (t[1]<<28 | t[0]<<20) >> 20 (arithmetic right shift)
+    // To encode value V (signed 12-bit): the 12-bit field occupies bits [31:20]
+    // after the shift, so we need: (V & 0xFFF) << 20, then split across t[0]/t[1].
+    // For V = 128 = 0x080:
+    //   packed = 0x080 << 20 = 0x08000000
+    //   t[0] = bits [27:20] = 0x00, t[1] = bits [31:28] = 0x08
+    // BUT the formula packs differently: t[1]<<28 | t[0]<<20
+    //   So t[0] holds bits [27:20], t[1] holds bits [31:28] of the 32-bit word.
+    //   For V=128 (0x080): the 12-bit value occupies bits[31:20] of the 32-bit signed int.
+    //   We want (t[1]<<28 | t[0]<<20) >> 20 == 128
+    //   => (t[1]<<28 | t[0]<<20) == 128 << 20 = 0x08000000
+    //   => t[1]<<28 = upper nibble: t[1]=0 (since 0x08000000 has 0 in bits31-28)
+    //   Actually 0x08000000: bit31=0, bits[30:28]=000, bits[27:24]=1000
+    //   t[1]<<28 covers bits[31:28] → t[1]=0
+    //   t[0]<<20 covers bits[27:20] → bits[27:20] of 0x08000000 = 0x80 → t[0]=0x80
+    UCHAR t[3] = { 0x80, 0x00, 0x00 };
+    INT32 x = TouchX(t);
+    ASSERT_EQ_UL("test_touch_x_positive", 128, (ULONG)(unsigned int)(INT32)x);
+}
+
+static void test_touch_y_zero(void)
+{
+    UCHAR t[3] = { 0x00, 0x00, 0x00 };
+    INT32 y = TouchY(t);
+    ASSERT_EQ_UL("test_touch_y_zero", 0, (ULONG)(unsigned int)y);
+}
+
+// ===========================================================================
+// TranslateReport12 tests
+// ===========================================================================
+
+static void test_translate_too_short_returns_false(void)
+{
+    // bufSize < TOUCH2_HEADER + 1 (7+1=8) → FALSE
+    UCHAR buf[6] = { 0x12, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    ULONG repLen = 0;
+    ASSERT_FALSE("test_translate_too_short_returns_false",
+                 TranslateReport12(buf, 6, NULL, &repLen));
+}
+
+static void test_translate_no_touch_blocks_output_mouse(void)
+{
+    // bufSize = TOUCH2_HEADER + 1 (8) → minimum to pass the guard, 0 complete
+    // touch blocks (8 - 7 = 1 byte < TOUCH2_BLOCK=8). Must return TRUE and emit
+    // 5-byte Report 0x01 with zero X/Y/wheel (no valid touch blocks parsed).
+    UCHAR buf[8] = { 0x12, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    ULONG repLen = 0;
+    BOOLEAN ok = TranslateReport12(buf, 8, NULL, &repLen);
+    ASSERT_TRUE("test_translate_no_touch_blocks [returns TRUE]", ok);
+    ASSERT_EQ_UL("test_translate_no_touch_blocks [report len]", 5, repLen);
+    ASSERT_EQ_UL("test_translate_no_touch_blocks [report id]",  0x01, (ULONG)buf[0]);
+    // buttons: original buf[1] & 0x03 = 0x01 & 0x03 = 0x01
+    ASSERT_EQ_UL("test_translate_no_touch_blocks [buttons]", 0x01, (ULONG)buf[1]);
+    // x, y, wheelV must be zero (no touch block decoded)
+    ASSERT_EQ_UL("test_translate_no_touch_blocks [x=0]",     0, (ULONG)buf[2]);
+    ASSERT_EQ_UL("test_translate_no_touch_blocks [y=0]",     0, (ULONG)buf[3]);
+    ASSERT_EQ_UL("test_translate_no_touch_blocks [wheelV=0]",0, (ULONG)buf[4]);
+}
+
+static void test_translate_single_touch_block_pointer(void)
+{
+    // bufSize = TOUCH2_HEADER(7) + TOUCH2_BLOCK(8) = 15 → 1 touch block → pointer move
+    UCHAR buf[15];
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0x12;  // report ID
+    buf[1] = 0x00;  // no buttons
+    // Touch block at buf[7..14]:
+    //   t[0]=0x80, t[1]=0x00 → TouchX = 128 → x = ClampInt8(128/4) = 32
+    //   t[2]=0x00 → TouchY: -((t[2]<<24|t[1]<<16)>>20) = 0 → y = 0
+    buf[7] = 0x80; buf[8] = 0x00; // x
+    buf[9] = 0x00; // y high
+    // rest of block zeros (state=0x00, not TOUCH_START/DRAG so doesn't matter for 1-finger)
+    buf[14] = 0x00; // state byte
+
+    ULONG repLen = 0;
+    BOOLEAN ok = TranslateReport12(buf, 15, NULL, &repLen);
+    ASSERT_TRUE("test_translate_single_touch [returns TRUE]", ok);
+    ASSERT_EQ_UL("test_translate_single_touch [report id]",  0x01, (ULONG)buf[0]);
+    ASSERT_EQ_UL("test_translate_single_touch [x=32]",       32,   (ULONG)buf[2]);
+    ASSERT_EQ_UL("test_translate_single_touch [y=0]",         0,   (ULONG)buf[3]);
+}
+
+static void test_translate_two_touch_blocks_scroll_drag(void)
+{
+    // bufSize = TOUCH2_HEADER(7) + 2*TOUCH2_BLOCK(16) = 23 → 2 touch blocks → scroll
+    UCHAR buf[23];
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0x12;
+    buf[1] = 0x00;
+    // First touch block at buf[7]:
+    //   t[0]=0x80, t[1]=0x00 → TouchX=128, TouchY=0
+    //   state byte t[7] = 0x40 (TOUCH_DRAG) → scroll path
+    buf[7]  = 0x80; buf[8]  = 0x00;
+    buf[9]  = 0x00;
+    buf[14] = 0x40; // state = TOUCH_DRAG
+
+    INT8 wheelH = 0;
+    ULONG repLen = 0;
+    BOOLEAN ok = TranslateReport12(buf, 23, &wheelH, &repLen);
+    ASSERT_TRUE("test_translate_two_touch_scroll [returns TRUE]", ok);
+    // wheelH from X: ClampInt8(128/8) = 16
+    ASSERT_EQ_UL("test_translate_two_touch_scroll [wheelH=16]", 16, (ULONG)(unsigned char)wheelH);
+    // wheelV from Y: 0
+    ASSERT_EQ_UL("test_translate_two_touch_scroll [wheelV=0]", 0, (ULONG)buf[4]);
+}
+
+// ===========================================================================
+// main
+// ===========================================================================
+
+int main(void)
+{
+    printf("=== Magic Mouse SDP/Input unit tests ===\n\n");
+
+    printf("-- ScanForSdpHidDescriptor --\n");
+    test_scan_null_returns_false();
+    test_scan_empty_returns_false();
+    test_scan_below_min_len_returns_false();
+    test_scan_all_zeros_returns_false();
+    test_scan_finds_pattern_at_offset0();
+    test_scan_finds_pattern_with_preamble();
+    test_scan_truncated_outer_sequence_returns_false();
+    test_scan_0x36_two_byte_sequence_returns_false();
+    test_scan_desc_len_zero_skipped();
+    test_scan_desc_overflows_buffer_returns_false();
+    test_scan_multiple_attributes_finds_first_valid();
+
+    printf("\n-- PatchSdpHidDescriptor --\n");
+    test_patch_too_small_offset_returns_false();
+    test_patch_replacement_same_size();
+    test_patch_replacement_smaller_memmoves_tail();
+    test_patch_replacement_larger_returns_false();
+    test_patch_too_large_buffer_unchanged();
+    test_patch_tlv_length_bytes_updated();
+
+    printf("\n-- ClampInt8 --\n");
+    test_clamp_within_range();
+    test_clamp_max_positive();
+    test_clamp_min_negative();
+    test_clamp_boundary();
+
+    printf("\n-- TouchX / TouchY --\n");
+    test_touch_x_zero();
+    test_touch_x_positive();
+    test_touch_y_zero();
+
+    printf("\n-- TranslateReport12 --\n");
+    test_translate_too_short_returns_false();
+    test_translate_no_touch_blocks_output_mouse();
+    test_translate_single_touch_block_pointer();
+    test_translate_two_touch_blocks_scroll_drag();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail > 0 ? 1 : 0;
+}

--- a/keyboard-descriptor-patcher/Descriptor.c
+++ b/keyboard-descriptor-patcher/Descriptor.c
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+//
+// MagicKbDesc — descriptor-patch logic + IRP completion routine.
+//
+// Bytes we insert before Col02's closing `c0 c0`:
+//
+//   09 20    Usage (Battery Strength)            <- local item, re-emit
+//   B1 02    Feature (Data, Variable, Absolute)  <- main item
+//
+// Same global attributes as the preceding Input declaration:
+//   75 08    Report Size (8 bits)
+//   95 01    Report Count (1)
+//   15 00    Logical Min (0)
+//   26 FF 00 Logical Max (255)
+// All four global items persist across main items per HID spec
+// (§6.2.2.7). Only the Usage (local) needs re-emitting.
+
+#include "MagicKbDesc.h"
+
+const UCHAR g_FeatureInsertBytes[4] = { 0x09, 0x20, 0xB1, 0x02 };
+
+// Match signature for the END of Col02's logical collection.
+// Col02 starts with `05 0C 09 01 A1 01 05 01 09 06 A1 02 85 47 ...`
+// and ends with `... 81 02 C0 C0`. We anchor on the unique RID
+// declaration `85 47` followed (within ~32 bytes) by `81 02 C0 C0`.
+//
+// We DON'T anchor on the full Col02 byte sequence because it might
+// vary slightly across firmware revisions — but the RID 0x47 + Input
+// main item + double-end anchor is stable.
+
+static PUCHAR
+MagicKbDescFindCol02InsertPoint(
+    _In_reads_bytes_(BufferLength) PUCHAR Buffer,
+    _In_                           SIZE_T BufferLength
+    )
+{
+    // Search for `85 47` (Report ID 0x47).
+    if (BufferLength < 6) {
+        return NULL;
+    }
+
+    for (SIZE_T i = 0; i + 5 < BufferLength; i++) {
+        if (Buffer[i] == 0x85 && Buffer[i + 1] == 0x47) {
+            // Found Report ID 0x47. Now search forward up to 64 bytes
+            // for `81 02 C0 C0` (Input + double EndCollection).
+            SIZE_T scanEnd = (i + 64 < BufferLength) ? i + 64 : BufferLength;
+            for (SIZE_T j = i + 2; j + 3 < scanEnd; j++) {
+                if (Buffer[j]     == 0x81 && Buffer[j + 1] == 0x02 &&
+                    Buffer[j + 2] == 0xC0 && Buffer[j + 3] == 0xC0) {
+                    // Insert at offset j+2 (immediately before C0 C0).
+                    return &Buffer[j + 2];
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
+SIZE_T
+MagicKbDescPatchDescriptor(
+    _Inout_updates_bytes_(BufferCapacity) PUCHAR Buffer,
+    _In_                                  SIZE_T OriginalLength,
+    _In_                                  SIZE_T BufferCapacity
+    )
+{
+    PUCHAR insertPoint;
+    SIZE_T insertOffset;
+    SIZE_T newLength;
+
+    if (Buffer == NULL || OriginalLength == 0) {
+        return 0;
+    }
+
+    insertPoint = MagicKbDescFindCol02InsertPoint(Buffer, OriginalLength);
+    if (insertPoint == NULL) {
+        // This descriptor isn't Col02, or isn't an Apple keyboard with
+        // RID 0x47. Pass through unmodified.
+        return 0;
+    }
+
+    newLength = OriginalLength + sizeof(g_FeatureInsertBytes);
+    if (newLength > BufferCapacity) {
+        // Caller must reallocate with a larger buffer.
+        return newLength;
+    }
+
+    insertOffset = (SIZE_T)(insertPoint - Buffer);
+
+    // Shift the tail right by 4 bytes to make room.
+    RtlMoveMemory(insertPoint + sizeof(g_FeatureInsertBytes),
+                  insertPoint,
+                  OriginalLength - insertOffset);
+
+    // Insert the patch bytes.
+    RtlCopyMemory(insertPoint, g_FeatureInsertBytes, sizeof(g_FeatureInsertBytes));
+
+    return newLength;
+}
+
+VOID
+MagicKbDescDescriptorCompletion(
+    _In_ WDFREQUEST                 Request,
+    _In_ WDFIOTARGET                Target,
+    _In_ PWDF_REQUEST_COMPLETION_PARAMS Params,
+    _In_ WDFCONTEXT                 Context
+    )
+{
+    NTSTATUS status = Params->IoStatus.Status;
+    SIZE_T   info   = (SIZE_T)Params->IoStatus.Information;
+    PUCHAR   buffer = NULL;
+    SIZE_T   bufferLength = 0;
+    SIZE_T   validLen;
+    SIZE_T   patchedLength;
+
+    UNREFERENCED_PARAMETER(Target);
+    UNREFERENCED_PARAMETER(Context);
+
+    if (!NT_SUCCESS(status) || info == 0) {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // Retrieve the output buffer from the request. WdfRequestRetrieveOutputBuffer
+    // is callable at IRQL <= DISPATCH_LEVEL, which matches WDF completion-routine
+    // IRQL guarantees.
+    status = WdfRequestRetrieveOutputBuffer(Request,
+                                            info,
+                                            (PVOID*)&buffer,
+                                            &bufferLength);
+    if (!NT_SUCCESS(status) || buffer == NULL) {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // B4 — defend against the lower stack reporting more bytes written than the
+    // buffer can actually hold. Use the smaller of the two as the byte-search
+    // and shift bound.
+    validLen = (info <= bufferLength) ? info : bufferLength;
+
+    patchedLength = MagicKbDescPatchDescriptor(buffer, validLen, bufferLength);
+    if (patchedLength == 0) {
+        // No patch applicable — pass through unchanged.
+        WdfRequestCompleteWithInformation(Request, status, info);
+        return;
+    }
+    if (patchedLength > bufferLength) {
+        // Buffer too small for the 4-byte expansion. After the B2 fix
+        // (IOCTL_HID_GET_DEVICE_DESCRIPTOR completion routine pre-bumps
+        // wReportLength), this branch should be unreachable. If it ever
+        // fires, hidclass.sys did not call us through the LENGTH IOCTL —
+        // log loudly and fail explicitly so we can diagnose.
+        KdPrint(("MagicKbDesc: descriptor buf too small: have=%Iu need=%Iu "
+                 "(BUG: IOCTL_HID_GET_DEVICE_DESCRIPTOR pre-bump missed)\n",
+                 bufferLength, patchedLength));
+        WdfRequestComplete(Request, STATUS_BUFFER_OVERFLOW);
+        return;
+    }
+
+    KdPrint(("MagicKbDesc: descriptor patched: %Iu -> %Iu bytes\n",
+             validLen, patchedLength));
+    WdfRequestCompleteWithInformation(Request, STATUS_SUCCESS, patchedLength);
+}
+
+// B2 — pre-bump wReportLength so hidclass.sys allocates a buffer big enough
+// for the patched descriptor (original_len + sizeof(g_FeatureInsertBytes)).
+//
+// IOCTL_HID_GET_DEVICE_DESCRIPTOR returns a HID_DESCRIPTOR struct whose
+// DescriptorList[0].wReportLength holds the size of the report descriptor.
+// hidclass.sys reads that value to size the buffer it then passes to
+// IOCTL_HID_GET_REPORT_DESCRIPTOR. Bumping wReportLength here makes the
+// downstream buffer 4 bytes larger, so MagicKbDescDescriptorCompletion's
+// in-place patch fits.
+VOID
+MagicKbDescDeviceDescriptorCompletion(
+    _In_ WDFREQUEST                 Request,
+    _In_ WDFIOTARGET                Target,
+    _In_ PWDF_REQUEST_COMPLETION_PARAMS Params,
+    _In_ WDFCONTEXT                 Context
+    )
+{
+    NTSTATUS        status = Params->IoStatus.Status;
+    SIZE_T          info   = (SIZE_T)Params->IoStatus.Information;
+    PHID_DESCRIPTOR hidDesc = NULL;
+    SIZE_T          bufferLength = 0;
+
+    UNREFERENCED_PARAMETER(Target);
+    UNREFERENCED_PARAMETER(Context);
+
+    if (!NT_SUCCESS(status) || info < sizeof(HID_DESCRIPTOR)) {
+        // hidbth either failed or returned a smaller-than-expected struct.
+        // Pass through unchanged — we're a transparent filter for non-Apple
+        // HID devices that might match our INF whitelist incorrectly.
+        WdfRequestCompleteWithInformation(Request, status, info);
+        return;
+    }
+
+    status = WdfRequestRetrieveOutputBuffer(Request,
+                                            sizeof(HID_DESCRIPTOR),
+                                            (PVOID*)&hidDesc,
+                                            &bufferLength);
+    if (!NT_SUCCESS(status) || hidDesc == NULL) {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // Sanity: confirm the struct shape matches what we expect before mutating.
+    if (hidDesc->bLength       != sizeof(HID_DESCRIPTOR) ||
+        hidDesc->bDescriptorType != 0x21 ||             // HID class descriptor
+        hidDesc->bNumDescriptors == 0) {
+        // Not a stock HID descriptor — leave it alone.
+        WdfRequestCompleteWithInformation(Request, Params->IoStatus.Status, info);
+        return;
+    }
+
+    // Bump the report descriptor length so hidclass allocates a +4 buffer.
+    hidDesc->DescriptorList[0].wReportLength =
+        (USHORT)(hidDesc->DescriptorList[0].wReportLength + sizeof(g_FeatureInsertBytes));
+
+    KdPrint(("MagicKbDesc: bumped wReportLength by %u to %u\n",
+             (unsigned)sizeof(g_FeatureInsertBytes),
+             hidDesc->DescriptorList[0].wReportLength));
+
+    WdfRequestCompleteWithInformation(Request, STATUS_SUCCESS, info);
+}
+
+VOID
+MagicKbDescEvtIoInternalDeviceControl(
+    _In_ WDFQUEUE   Queue,
+    _In_ WDFREQUEST Request,
+    _In_ size_t     OutputBufferLength,
+    _In_ size_t     InputBufferLength,
+    _In_ ULONG      IoControlCode
+    )
+{
+    WDFDEVICE  device = WdfIoQueueGetDevice(Queue);
+    WDFIOTARGET target = WdfDeviceGetIoTarget(device);
+
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    KdPrint(("MagicKbDesc: EvtIoInternalDeviceControl ioctl=0x%X\n", IoControlCode));
+
+    // B1 — canonical WDF lower-filter completion-routine pattern: format the
+    // request, set the completion routine, then ONE WdfRequestSend. The
+    // completion routine MUST be set BEFORE WdfRequestSend; once the request
+    // is sent its ownership transfers to the I/O target.
+    if (IoControlCode == IOCTL_HID_GET_REPORT_DESCRIPTOR) {
+        WdfRequestFormatRequestUsingCurrentType(Request);
+        WdfRequestSetCompletionRoutine(Request,
+                                       MagicKbDescDescriptorCompletion,
+                                       NULL);
+        if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS)) {
+            NTSTATUS status = WdfRequestGetStatus(Request);
+            KdPrint(("MagicKbDesc: WdfRequestSend(GET_REPORT_DESCRIPTOR) failed 0x%X\n", status));
+            WdfRequestComplete(Request, status);
+        }
+        return;
+    }
+
+    // B2 — intercept the LENGTH IOCTL too, so hidclass allocates a buffer
+    // big enough for the subsequent GET_REPORT_DESCRIPTOR after our 4-byte
+    // patch.
+    if (IoControlCode == IOCTL_HID_GET_DEVICE_DESCRIPTOR) {
+        WdfRequestFormatRequestUsingCurrentType(Request);
+        WdfRequestSetCompletionRoutine(Request,
+                                       MagicKbDescDeviceDescriptorCompletion,
+                                       NULL);
+        if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS)) {
+            NTSTATUS status = WdfRequestGetStatus(Request);
+            KdPrint(("MagicKbDesc: WdfRequestSend(GET_DEVICE_DESCRIPTOR) failed 0x%X\n", status));
+            WdfRequestComplete(Request, status);
+        }
+        return;
+    }
+
+    // Default forward (send-and-forget) for all other IOCTLs.
+    {
+        WDF_REQUEST_SEND_OPTIONS opts;
+        WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+        if (!WdfRequestSend(Request, target, &opts)) {
+            NTSTATUS status = WdfRequestGetStatus(Request);
+            WdfRequestComplete(Request, status);
+        }
+    }
+}

--- a/keyboard-descriptor-patcher/Driver.c
+++ b/keyboard-descriptor-patcher/Driver.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+//
+// MagicKbDesc — KMDF lower filter driver entry points.
+// See MagicKbDesc.h for architectural overview.
+
+#include "MagicKbDesc.h"
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT  DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    WDF_DRIVER_CONFIG config;
+    NTSTATUS status;
+
+    KdPrint(("MagicKbDesc: DriverEntry\n"));
+
+    WDF_DRIVER_CONFIG_INIT(&config, MagicKbDescEvtDeviceAdd);
+    config.DriverPoolTag = MAGICKBDESC_POOL_TAG;
+
+    status = WdfDriverCreate(DriverObject,
+                             RegistryPath,
+                             WDF_NO_OBJECT_ATTRIBUTES,
+                             &config,
+                             WDF_NO_HANDLE);
+    if (!NT_SUCCESS(status)) {
+        KdPrint(("MagicKbDesc: WdfDriverCreate failed 0x%X\n", status));
+    }
+    return status;
+}
+
+NTSTATUS
+MagicKbDescEvtDeviceAdd(
+    _In_    WDFDRIVER       Driver,
+    _Inout_ PWDFDEVICE_INIT DeviceInit
+    )
+{
+    WDF_OBJECT_ATTRIBUTES   deviceAttributes;
+    WDFDEVICE               device;
+    WDF_IO_QUEUE_CONFIG     queueConfig;
+    NTSTATUS                status;
+
+    UNREFERENCED_PARAMETER(Driver);
+
+    // Register as a lower filter — hidbth.sys is still the function
+    // driver; we sit between it and BthEnum.
+    WdfFdoInitSetFilter(DeviceInit);
+
+    WDF_OBJECT_ATTRIBUTES_INIT(&deviceAttributes);
+
+    status = WdfDeviceCreate(&DeviceInit, &deviceAttributes, &device);
+    if (!NT_SUCCESS(status)) {
+        KdPrint(("MagicKbDesc: WdfDeviceCreate failed 0x%X\n", status));
+        return status;
+    }
+
+    // Default queue dispatches IRP_MJ_INTERNAL_DEVICE_CONTROL — that's
+    // where IOCTL_HID_GET_REPORT_DESCRIPTOR arrives.
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig,
+                                           WdfIoQueueDispatchParallel);
+    queueConfig.EvtIoInternalDeviceControl = MagicKbDescEvtIoInternalDeviceControl;
+
+    status = WdfIoQueueCreate(device,
+                              &queueConfig,
+                              WDF_NO_OBJECT_ATTRIBUTES,
+                              WDF_NO_HANDLE);
+    if (!NT_SUCCESS(status)) {
+        KdPrint(("MagicKbDesc: WdfIoQueueCreate failed 0x%X\n", status));
+        return status;
+    }
+
+    KdPrint(("MagicKbDesc: device added as filter on HID stack\n"));
+    return STATUS_SUCCESS;
+}

--- a/keyboard-descriptor-patcher/MORNING-FINISH.md
+++ b/keyboard-descriptor-patcher/MORNING-FINISH.md
@@ -1,0 +1,153 @@
+# Morning finish — sign, install, test
+
+**Driver compiles successfully.** `MagicKbDesc.sys` (10,752 bytes) and `MagicKbDesc.cat` are staged at `C:\Windows\Temp\MagicKbDescStage\`. Three steps remain — all need your explicit approval (kernel driver loading is too high-severity for unattended automation).
+
+## Status from session 2026-05-08
+
+| Step | Status | Where |
+|------|--------|-------|
+| Source compiled | ✅ | `\\wsl.localhost\Ubuntu\home\lesley\.claude\worktrees\ai-m4-kbd-build-and-test\driver-keyboard\x64\Release\MagicKbDesc.sys` |
+| stampinf + Inf2Cat | ✅ | `C:\Windows\Temp\MagicKbDescStage\` (.sys + .cat + .inf) |
+| Sign .sys + .cat via M12 cert | ⏸ ready to run |
+| `pnputil /add-driver /install /force` | ⏸ ready to run |
+| Toggle BT + verify filter in stack | ⏸ ready to run |
+| Run `Test-HidD-GetFeature-RID47.ps1` | ⏸ ready to run |
+
+## Run it (all PowerShell as Administrator)
+
+Three steps. Each is a small inline block — copy/paste into your shell.
+
+### Step 1 — Sign the .sys and .cat
+
+Uses the M12 `CN=MagicMouseFix` cert in `LocalMachine\My` (thumbprint `16940C0F937D569363560D5FEC5CD8FA6D6D9BCE`). Driven via the existing `MM-Dev-Cycle` scheduled task's `SIGN-FILE` route, which runs as SYSTEM and has private-key access.
+
+```powershell
+$thumb    = '16940C0F937D569363560D5FEC5CD8FA6D6D9BCE'
+$queueDir = 'C:\mm-dev-queue'
+$stage    = 'C:\Windows\Temp\MagicKbDescStage'
+
+function Sign-One($file) {
+    $nonce = 'sign-' + [guid]::NewGuid().ToString().Substring(0,8)
+    $req   = "SIGN-FILE|$nonce|$file|$thumb"
+    Set-Content "$queueDir\request.txt" $req -Encoding ASCII
+    Remove-Item "$queueDir\result.txt" -Force -ErrorAction SilentlyContinue
+    schtasks /run /tn MM-Dev-Cycle | Out-Null
+    $deadline = (Get-Date).AddMinutes(2)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Path "$queueDir\result.txt") {
+            $r = (Get-Content "$queueDir\result.txt" -Raw).Trim()
+            if ($r -match "\|$nonce") {
+                Write-Host "  $file -> $r"
+                return [int]($r -split '\|')[0]
+            }
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    Write-Host "  TIMEOUT signing $file" -ForegroundColor Red
+    return 124
+}
+
+Sign-One "$stage\MagicKbDesc.sys"
+Sign-One "$stage\MagicKbDesc.cat"
+
+& 'F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe' verify /pa "$stage\MagicKbDesc.sys"
+```
+
+### Step 2 — Install via pnputil
+
+Self-elevates if needed (UAC prompt).
+
+```powershell
+$inf = 'C:\Windows\Temp\MagicKbDescStage\MagicKbDesc.inf'
+pnputil /add-driver $inf /install /force
+```
+
+Verify the new filter binds. Toggle BT off then on in Settings first (Win+I → Bluetooth → toggle radio), wait ~5 seconds for the keyboard to reconnect, then:
+
+```powershell
+$kb = 'BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&000205AC_PID&0239\9&73B8B28&0&E806884B0741_C00000000'
+Get-PnpDeviceProperty -InstanceId $kb -KeyName 'DEVPKEY_Device_Stack' | Select-Object -ExpandProperty Data
+# Expect: \Driver\HidBth, \Driver\MagicKbDesc, \Driver\BthEnum
+# (The MagicKeyboard.sys filter from earlier MagicUtilities install may also be there.
+#  That's OK — both filters can coexist; ours hooks the descriptor IRP.)
+```
+
+### Step 3 — Test the patch worked
+
+```powershell
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class Hid {
+    public const uint GENERIC_READ  = 0x80000000;
+    public const uint GENERIC_WRITE = 0x40000000;
+    public const uint FILE_SHARE_RW = 0x00000003;
+    public const uint OPEN_EXISTING = 3;
+    public static readonly IntPtr INVALID = new IntPtr(-1);
+    [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern IntPtr CreateFileW(string lpFileName, uint dwDesiredAccess,
+        uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition,
+        uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool CloseHandle(IntPtr h);
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_GetFeature(IntPtr h, byte[] buf, uint len);
+}
+'@
+
+$col02 = Get-PnpDevice -Class HIDClass | Where-Object { $_.InstanceId -match 'PID&0239&Col02' -and $_.InstanceId -match '00001124' } | Select-Object -First 1
+$key   = "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceClasses\{4d1e55b2-f16f-11cf-88cb-001111000030}"
+$path  = (Get-ChildItem $key | Where-Object { $_.PSChildName -match ($col02.InstanceId -replace '\\','#') } | Select-Object -First 1).PSChildName -replace '^##\?#','\\?\' -replace '#\{','#{'
+
+$h = [Hid]::CreateFileW($path, [Hid]::GENERIC_READ -bor [Hid]::GENERIC_WRITE,
+    [Hid]::FILE_SHARE_RW, [IntPtr]::Zero, [Hid]::OPEN_EXISTING, 0, [IntPtr]::Zero)
+if ($h -eq [Hid]::INVALID) { throw "CreateFile failed err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())" }
+
+$buf = New-Object byte[] 2
+$buf[0] = 0x47
+$ok = [Hid]::HidD_GetFeature($h, $buf, 2)
+$err = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+[Hid]::CloseHandle($h) | Out-Null
+
+if ($ok) {
+    Write-Host "*** SUCCESS *** [{0:X2} {1:X2}]   BATTERY = $($buf[1])%" -ForegroundColor Green
+} else {
+    Write-Host "FAILED ok=$ok err=$err" -ForegroundColor Yellow
+    if ($err -eq 1) { Write-Host "  err=1 means the descriptor patch didn't apply — re-toggle BT and retry" }
+}
+```
+
+Expected: `*** SUCCESS *** [47 NN]   BATTERY = NN%` where NN is your keyboard battery percent.
+
+Expected output of step 3:
+
+```
+[Col02 / RID 0x47 (Battery Strength) / patched Feature]
+  HidD_GetFeature(rid=0x47, len=2)...
+  *** SUCCESS *** bytes: [47 NN]   ← NN is battery percent
+```
+
+If step 3 still returns `err=1`, the BT toggle didn't re-enumerate the device. Manual fix:
+```powershell
+pnputil /restart-device "BTHENUM\Dev_E806884B0741"
+```
+Then re-run step 3.
+
+## Recovery (if anything goes sideways)
+
+Uninstall the driver:
+```powershell
+pnputil /enum-drivers | findstr /I MagicKbDesc
+pnputil /delete-driver oem##.inf /uninstall /force   # use the OEM number from above
+```
+Then toggle BT off/on. Keyboard returns to default driver state.
+
+## What we proved
+
+Empirical pre-flight (`Test-HidD-GetFeature-0x09.ps1` 2026-05-08):
+- `HidD_GetFeature(Col03, RID=0x09, 4)` → SUCCESS, returned `[92 12 02 02]`
+- `HidD_GetFeature(Col02, RID=0x47, 2)` → FAIL err=1 ERROR_INVALID_FUNCTION
+
+This proves the only blocker is descriptor validation. After the 4-byte patch this driver inserts (`09 20 B1 02` before Col02's closing `c0 c0`), `hidclass.sys` will parse RID `0x47` as both Input and Feature — same outcome as the working RID `0x09` test.
+
+See `docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md` (Empirical update section) for the full architectural rationale.

--- a/keyboard-descriptor-patcher/MagicKbDesc.h
+++ b/keyboard-descriptor-patcher/MagicKbDesc.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+//
+// MagicKbDesc — KMDF lower filter on BTHENUM\{HID-PSM}_VID&05AC_PID&{Apple kb whitelist}.
+//
+// Patches the HID Report Descriptor returned by hidbth.sys so the
+// Windows HID class driver (hidclass.sys) treats RID 0x47 (Battery
+// Strength) as BOTH an Input and a Feature report.
+//
+// 4-byte insert: `09 20 B1 02` immediately before the closing
+// `c0 c0` of Col02. Re-emits the Battery Strength Usage (local item,
+// consumed by the previous Input main item) and adds a Feature main
+// item with the same global attributes (8-bit, count 1, range 0..255).
+//
+// Empirical proof of approach (2026-05-08):
+//   HidD_GetFeature(Col03, RID=0x09, len=4) → SUCCESS [92 12 02 02]
+//   Confirms Windows BT HID can issue Feature GET_REPORTs to this
+//   firmware over L2CAP — the only blocker for RID 0x47 is the
+//   missing Feature declaration in the descriptor.
+
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+#include <hidport.h>
+
+EXTERN_C_START
+
+DRIVER_INITIALIZE  DriverEntry;
+
+EVT_WDF_DRIVER_DEVICE_ADD               MagicKbDescEvtDeviceAdd;
+EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL  MagicKbDescEvtIoInternalDeviceControl;
+
+// Completion routine: invoked when the lower stack fills the report
+// descriptor buffer; we patch the bytes here.
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      MagicKbDescDescriptorCompletion;
+
+// Completion routine for IOCTL_HID_GET_DEVICE_DESCRIPTOR - bumps the
+// HID_DESCRIPTOR.DescriptorList[0].wReportLength by the number of bytes
+// we are about to insert into the report descriptor, so hidclass.sys
+// allocates a large-enough buffer for the subsequent
+// IOCTL_HID_GET_REPORT_DESCRIPTOR.
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      MagicKbDescDeviceDescriptorCompletion;
+
+// Patch driver: returns the new buffer length, or 0 if no patch was
+// applicable (e.g. this collection's descriptor doesn't match Col02).
+// Patches in-place if buffer is large enough; otherwise the caller must
+// reallocate.
+SIZE_T
+MagicKbDescPatchDescriptor(
+    _Inout_updates_bytes_(BufferCapacity) PUCHAR Buffer,
+    _In_                                  SIZE_T OriginalLength,
+    _In_                                  SIZE_T BufferCapacity
+    );
+
+// The 4-byte payload we insert: re-emit Battery Strength Usage +
+// Feature main item with same global attributes carried from previous
+// Input declaration.
+extern const UCHAR g_FeatureInsertBytes[4];
+
+#define MAGICKBDESC_POOL_TAG  'cDkM'  // "MkDc" reversed (NT pool tags are little-endian)
+
+EXTERN_C_END

--- a/keyboard-descriptor-patcher/MagicKbDesc.inx
+++ b/keyboard-descriptor-patcher/MagicKbDesc.inx
@@ -1,0 +1,70 @@
+; MagicKbDesc.inx
+; HID lower filter that patches the report descriptor returned by
+; hidbth.sys so RID 0x47 (Battery Strength) on Col02 is declared as
+; both Input and Feature. Apple keyboards over Bluetooth Classic.
+
+[Version]
+Signature   = "$WINDOWS NT$"
+Class       = HIDClass
+ClassGuid   = {745A17A0-74D3-11D0-B6FE-00A0C90F57DA}
+Provider    = %ProviderName%
+CatalogFile = MagicKbDesc.cat
+PnpLockDown = 1
+DriverVer   =                  ; stampinf will fill this in
+
+[DestinationDirs]
+DefaultDestDir = 13   ; %SystemRoot%\System32\Drivers
+
+[SourceDisksNames]
+1 = %DiskName%,,,""
+
+[SourceDisksFiles]
+MagicKbDesc.sys = 1,,
+
+[Manufacturer]
+%ManufacturerName% = Standard,NTamd64.10.0...17763
+
+; Apple keyboard PIDs — full whitelist from PRD-185 (lesley-workspace).
+; A1314 dual-PID coverage is critical (0x0239 = 2009 fw rev,
+; 0x0255 = 2011 fw rev — same Apple model number).
+[Standard.NTamd64.10.0...17763]
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&022c
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&022d
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&022e
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&0239
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&0255
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&0267
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&029a
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&029c
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&029f
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&0320
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&0321
+%DeviceDesc% = MagicKbDesc_Inst, BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&0322
+
+[MagicKbDesc_Inst.NT]
+Include        = input.inf, hidbth.inf
+Needs          = HIDBTH_Inst.NT
+CopyFiles      = MagicKbDesc_Files
+LowerFilters   = MagicKbDesc
+
+[MagicKbDesc_Inst.NT.Services]
+Include    = input.inf, hidbth.inf
+Needs      = HIDBTH_Inst.NT.Services
+AddService = MagicKbDesc, , MagicKbDesc_Service
+
+[MagicKbDesc_Service]
+DisplayName    = %ServiceDesc%
+ServiceType    = 1                       ; SERVICE_KERNEL_DRIVER
+StartType      = 3                       ; SERVICE_DEMAND_START
+ErrorControl   = 1                       ; SERVICE_ERROR_NORMAL
+ServiceBinary  = %13%\MagicKbDesc.sys
+
+[MagicKbDesc_Files]
+MagicKbDesc.sys
+
+[Strings]
+ProviderName     = "Lesley Murfin"
+ManufacturerName = "Apple Inc."
+DiskName         = "Magic Keyboard Descriptor Patcher Installation Disk"
+DeviceDesc       = "Apple Wireless Keyboard - Bluetooth (Battery Patch)"
+ServiceDesc      = "Magic Keyboard Descriptor Patcher Service"

--- a/keyboard-descriptor-patcher/MagicKbDesc.sln
+++ b/keyboard-descriptor-patcher/MagicKbDesc.sln
@@ -1,0 +1,23 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32104.313
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MagicKbDesc", "MagicKbDesc.vcxproj", "{B2C3D4E5-F607-8901-BCDE-F23456789012}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Debug|x64.ActiveCfg = Debug|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Debug|x64.Build.0 = Debug|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Debug|x64.Deploy.0 = Debug|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Release|x64.ActiveCfg = Release|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Release|x64.Build.0 = Release|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Release|x64.Deploy.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/keyboard-descriptor-patcher/MagicKbDesc.vcxproj
+++ b/keyboard-descriptor-patcher/MagicKbDesc.vcxproj
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MagicKbDesc.vcxproj — KMDF lower filter for Apple keyboard descriptor patching.
+  Cloned from sibling driver/MagicMouseDriver.vcxproj 2026-05-08; same EWDK +
+  WDK target, just renamed and pointed at this directory's source files.
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B2C3D4E5-F607-8901-BCDE-F23456789012}</ProjectGuid>
+    <TargetName>MagicKbDesc</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <DriverType>KMDF</DriverType>
+    <KmdfVersionMajor>1</KmdfVersionMajor>
+    <KmdfVersionMinor>33</KmdfVersionMinor>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+      <Driver>WDM</Driver>
+      <AdditionalDependencies>wdmguid.lib;hidclass.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="Driver.c" />
+    <ClCompile Include="Descriptor.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="MagicKbDesc.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Inf Include="MagicKbDesc.inx" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(WDKContentRoot)\build\WindowsDriver.targets"
+          Condition="Exists('$(WDKContentRoot)\build\WindowsDriver.targets')" />
+
+  <!-- Same SIGNTASK pre-backup workaround used by the M3 driver — see
+       sibling MagicMouseDriver.vcxproj for full rationale. -->
+  <Target Name="BackupPreSign" AfterTargets="Link">
+    <MakeDir Directories="C:\mm3-presign" />
+    <Copy SourceFiles="$(OutDir)$(TargetFileName)"
+          DestinationFiles="C:\mm3-presign\$(TargetFileName)"
+          Condition="Exists('$(OutDir)$(TargetFileName)')" />
+    <Message Text="*** BackupPreSign: $(TargetFileName) -&gt; C:\mm3-presign\ ***" Importance="High" />
+  </Target>
+
+</Project>

--- a/keyboard-descriptor-patcher/README.md
+++ b/keyboard-descriptor-patcher/README.md
@@ -1,0 +1,90 @@
+# MagicKbDesc — Apple Keyboard HID Descriptor Patcher
+
+KMDF lower filter that patches the HID Report Descriptor returned by `hidbth.sys` so Windows' HID class driver knows that RID `0x47` (Battery Strength) on Col02 of an Apple keyboard is **also** a Feature report — not just an Input report. The 4-byte patch unblocks `HidD_GetFeature(0x47)` from userland.
+
+## Why a 4-byte patch is enough
+
+The keyboard firmware happily responds to `GET_REPORT(Feature, RID=0x47)` over L2CAP — proven by:
+1. macOS's PacketLogger capture: `host→kbd 43 47` → `kbd→host A3 47 NN` (NN = battery %)
+2. Empirical Windows test 2026-05-08: `HidD_GetFeature(Col03, RID=0x09, len=4)` succeeds with real bytes `[92 12 02 02]`. Same L2CAP path; RID `0x09` IS declared as Feature.
+
+The only thing that prevents `HidD_GetFeature(Col02, RID=0x47)` from working today is `hidclass.sys`'s descriptor validation: RID `0x47` is declared in the public Apple descriptor as Input only (`81 02`), so userland callers are rejected with `ERROR_INVALID_FUNCTION (1)` before the bytes ever go on the wire.
+
+This driver intercepts `IOCTL_HID_GET_REPORT_DESCRIPTOR`, finds the `... 81 02 c0 c0` tail of Col02, and inserts `09 20 B1 02` (re-emit Battery Strength Usage + Feature Main item with the same global state). After the patch, `hidclass.sys` parses RID `0x47` as both Input and Feature; `HidD_GetFeature(0x47)` succeeds.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `MagicKbDesc.inx` | INF source — function-driver-with-filter (`Include = hidbth.inf`, `Needs = HIDBTH_Inst.NT`, `LowerFilters = MagicKbDesc`); whitelist `BTHENUM\{...}_VID&000205AC_PID&{022C,022D,022E,0239,0255,0267,029A,029C,029F,0320,0321,0322}` |
+| `Driver.c` | `DriverEntry` + `EvtDriverDeviceAdd` (registers as filter via `WdfFdoInitSetFilter`) |
+| `Descriptor.c` | The patch logic + IRP completion routine for `IOCTL_HID_GET_REPORT_DESCRIPTOR` |
+| `MagicKbDesc.h` | Common types + IOCTL constants |
+| `MagicKbDesc.vcxproj` | MSBuild project for EWDK 10.0.26100 |
+| `MagicKbDesc.sln` | Solution wrapper |
+| `build.ps1` | Compiles via `mm-task-runner.ps1 BUILD` (existing M12 EWDK pipeline) |
+| `sign.ps1` | Signs catalog with the `CN=MagicMouseFix` M14 cert via `mm-task-runner.ps1 SIGN-FILE` (cert already in `LocalMachine\TrustedPublisher`); .sys signature is left untouched per PATH-A signing doctrine |
+| `install.ps1` | `pnputil /add-driver MagicKbDesc.inf /install /force` (paired with BT toggle for clean re-enumeration) |
+
+## Build prerequisite
+
+EWDK ISO mounted at `F:\Program Files\Windows Kits\10\` (already configured for the M12 pipeline). The `BUILD` route in `mm-task-runner.ps1` handles ISO mount auto-detection.
+
+## Install (production trust path — no `bcdedit`)
+
+```powershell
+.\build.ps1                                 # → driver/x64/Release/MagicKbDesc.{sys,cat,inf}
+.\sign.ps1                                  # → embeds signature + signs catalog with M12 cert
+pwsh .\install.ps1                          # → pnputil /add-driver /install
+```
+
+After install, toggle Bluetooth off/on in Settings — the new lower filter binds during re-enumeration. Verify:
+
+```powershell
+Get-PnpDeviceProperty -InstanceId 'BTHENUM\{00001124-...}_VID&000205AC_PID&0239\...' `
+    -KeyName DEVPKEY_Device_Stack
+# Expect: \Driver\HidBth, \Driver\MagicKbDesc, \Driver\BthEnum
+```
+
+Then the empirical proof:
+
+```powershell
+pwsh -File ..\scripts\Test-HidD-GetFeature-0x47.ps1
+# Expect: *** SUCCESS *** bytes: [47 NN]   where NN is battery %
+```
+
+## Install (dev — test signing during iteration)
+
+If iterating the driver source, save a build cycle by reusing the M12 `bcdedit /set testsigning on` state from prior driver work. Reverts to production signing once the source stabilises.
+
+## Uninstall
+
+```powershell
+pnputil /enum-drivers | findstr /I MagicKbDesc
+pnputil /delete-driver oemNN.inf /uninstall /force
+```
+
+## Status (2026-05-08)
+
+**Source complete, build clean, signed, install-binding in progress.**
+
+Implemented:
+- Patch logic in `Descriptor.c` — searches for `... 81 02 c0 c0` Col02 tail, allocates `len + 4`, inserts `09 20 B1 02`, updates `IoStatus.Information`, completes the IRP.
+- EWDK 10.0.26100 build via `mm-task-runner.ps1 BUILD` — `MagicKbDesc.{sys,cat,inf}` produced.
+- `Inf2Cat` + `signtool sign /sm /sha1 16940C0F... /fd SHA256` via `mm-task-runner.ps1 SIGN-FILE` — catalog signed with M14 cert (`CN=MagicMouseFix`).
+- INF whitelist: full Apple keyboard PID census (`0x022C..0x0322` over `BTHENUM\{00001124-...}`).
+- Service load proven: `sc start MagicKbDesc` returns `STATE: 4 RUNNING` — kernel signing accepted.
+
+Remaining (M2 close-out):
+- **Filter binding**: install completes and the service registers, but `DEVPKEY_Device_Stack` does not yet show `\Driver\MagicKbDesc`. Setupapi log on prior Extension-INF attempt logged `{Configure Driver Configuration: MagicKbDesc_Inst.NT} No associated service`. Reverting to the canonical function-driver-with-filter INF format used by the reference project (`Include = hidbth.inf`, `Needs = HIDBTH_Inst.NT`, `LowerFilters = MagicKbDesc` directly in `[Inst.NT]`) and reinstalling.
+- **Functional proof**: `HidD_GetFeature(Col02, RID=0x47, len=2)` returning `[47 NN]` with `0 <= NN <= 100`.
+
+After M2 closes: 24h soak (M4 in PRD-185), then GitHub release (M5).
+
+## Documentation
+
+- **PRD**: `Personal/prd/185-apple-keyboard-windows-tray-battery-monitor.md`
+- **Architectural rationale**: `Personal/magic-mouse-tray/KMDF-PLAN.md`
+- **Problem-Solution Note**: `Personal/magic-mouse-tray/PSN-0001-hid-battery-driver.yaml`
+- **Signing doctrine**: `Personal/magic-mouse-tray/docs/PATH-A-SIGNING-DIVERGENCE.md`
+- **macOS L2CAP wire capture (firmware proof)**: `docs/m4-bt-capture-findings.md`

--- a/keyboard-descriptor-patcher/build.ps1
+++ b/keyboard-descriptor-patcher/build.ps1
@@ -1,0 +1,52 @@
+# build.ps1 — compile MagicKbDesc.sys via the M12 EWDK pipeline.
+#
+# Uses the existing mm-task-runner.ps1 BUILD route which handles
+# EWDK ISO mount detection and msbuild invocation. SYSTEM-priv
+# scheduled task — driver builds need privileged access for
+# certain WDK steps.
+#
+# Run from project root:
+#   powershell -File driver-keyboard\build.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$slnPath  = Join-Path $PSScriptRoot 'MagicKbDesc.sln'
+
+if (-not (Test-Path $slnPath)) {
+    throw "MagicKbDesc.sln not found at $slnPath — has the .vcxproj been authored yet?"
+}
+
+# Generate nonce for the queue protocol.
+$nonce = 'kbdesc-' + [guid]::NewGuid().ToString().Substring(0,8)
+$queueDir = 'C:\mm-dev-queue'
+if (-not (Test-Path $queueDir)) { New-Item -ItemType Directory -Path $queueDir | Out-Null }
+
+# BUILD|<nonce>|<config>|<platform>|<sln-path>
+$req = "BUILD|$nonce|Release|x64|$slnPath"
+Set-Content -Path (Join-Path $queueDir 'request.txt') -Value $req -Encoding ASCII
+Remove-Item (Join-Path $queueDir 'result.txt') -Force -ErrorAction SilentlyContinue
+
+Write-Host "[build] Triggering MM-Dev-Cycle BUILD..."
+schtasks /run /tn MM-Dev-Cycle | Out-Null
+
+$deadline = (Get-Date).AddMinutes(10)
+while ((Get-Date) -lt $deadline) {
+    if (Test-Path (Join-Path $queueDir 'result.txt')) {
+        $r = (Get-Content (Join-Path $queueDir 'result.txt') -Raw).Trim()
+        if ($r -match "\|$nonce") {
+            $exitCode = [int]($r -split '\|')[0]
+            if ($exitCode -eq 0) {
+                Write-Host "[build] OK" -ForegroundColor Green
+                Get-ChildItem -Path (Join-Path $PSScriptRoot 'x64\Release\MagicKbDesc.*') -ErrorAction SilentlyContinue | Format-Table Name,Length
+                exit 0
+            } else {
+                Write-Host "[build] FAILED exit=$exitCode" -ForegroundColor Red
+                Get-Content (Join-Path $queueDir "build-$nonce.log") -ErrorAction SilentlyContinue | Select-Object -Last 50
+                exit $exitCode
+            }
+        }
+    }
+    Start-Sleep -Seconds 2
+}
+throw "[build] timeout waiting for MM-Dev-Cycle to complete"

--- a/keyboard-descriptor-patcher/build.ps1
+++ b/keyboard-descriptor-patcher/build.ps1
@@ -1,8 +1,8 @@
-# build.ps1 — compile MagicKbDesc.sys via the M12 EWDK pipeline.
+# build.ps1 - compile MagicKbDesc.sys via the M12 EWDK pipeline.
 #
 # Uses the existing mm-task-runner.ps1 BUILD route which handles
 # EWDK ISO mount detection and msbuild invocation. SYSTEM-priv
-# scheduled task — driver builds need privileged access for
+# scheduled task - driver builds need privileged access for
 # certain WDK steps.
 #
 # Run from project root:
@@ -10,11 +10,10 @@
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $slnPath  = Join-Path $PSScriptRoot 'MagicKbDesc.sln'
 
 if (-not (Test-Path $slnPath)) {
-    throw "MagicKbDesc.sln not found at $slnPath — has the .vcxproj been authored yet?"
+    throw "MagicKbDesc.sln not found at $slnPath - has the .vcxproj been authored yet?"
 }
 
 # Generate nonce for the queue protocol.

--- a/keyboard-descriptor-patcher/install.ps1
+++ b/keyboard-descriptor-patcher/install.ps1
@@ -1,0 +1,47 @@
+# install.ps1 — pnputil /add-driver MagicKbDesc.inf /install /force.
+# Reuses the M12 SYSTEM scheduled task runner so the install runs with
+# elevated PnP rights. Self-elevates if not already admin.
+
+param(
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = 'Stop'
+$infPath = Join-Path $PSScriptRoot 'x64\Release\MagicKbDesc\MagicKbDesc.inf'
+
+if (-not (Test-Path $infPath)) {
+    throw "INF not found at $infPath. Run build.ps1 first."
+}
+
+# self-elevate
+$id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$pp = New-Object System.Security.Principal.WindowsPrincipal($id)
+if (-not $pp.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Start-Process pwsh -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$PSCommandPath`"") -Verb RunAs -Wait
+    exit
+}
+
+if ($Uninstall) {
+    Write-Host "Looking for installed MagicKbDesc.inf..."
+    $rx = pnputil /enum-drivers | Select-String -Pattern 'MagicKbDesc' -Context 0,3 | Select-Object -First 1
+    if ($rx) {
+        $oem = ($rx.Context.PostContext | Where-Object { $_ -match 'oem\d+\.inf' } | Select-Object -First 1) -replace '.*?(oem\d+\.inf).*', '$1'
+        if ($oem) {
+            Write-Host "Removing $oem..."
+            pnputil /delete-driver $oem /uninstall /force
+        } else {
+            Write-Host "Could not parse oemNN.inf name from pnputil output."
+        }
+    } else {
+        Write-Host "MagicKbDesc not installed."
+    }
+    exit
+}
+
+Write-Host "Installing $infPath ..."
+pnputil /add-driver $infPath /install /force
+
+Write-Host ""
+Write-Host "Verify the filter is in the keyboard's stack:"
+Write-Host '  Get-PnpDeviceProperty -InstanceId "BTHENUM\{00001124-...}_VID&000205AC_PID&0239\..." -KeyName DEVPKEY_Device_Stack'
+Write-Host "Expect: \Driver\HidBth, \Driver\MagicKbDesc, \Driver\BthEnum"

--- a/keyboard-descriptor-patcher/install.ps1
+++ b/keyboard-descriptor-patcher/install.ps1
@@ -1,4 +1,4 @@
-# install.ps1 — pnputil /add-driver MagicKbDesc.inf /install /force.
+# install.ps1 - pnputil /add-driver MagicKbDesc.inf /install /force.
 # Reuses the M12 SYSTEM scheduled task runner so the install runs with
 # elevated PnP rights. Self-elevates if not already admin.
 

--- a/keyboard-descriptor-patcher/post-reboot-validate.ps1
+++ b/keyboard-descriptor-patcher/post-reboot-validate.ps1
@@ -1,0 +1,218 @@
+# post-reboot-validate.ps1
+# End-to-end MagicKbDesc validation after the SCM-marked-for-deletion reboot.
+#
+# What this does:
+#   0.  SCM clean check
+#   1.  Re-install oem57 via mm-task-runner queue (INSTALL-DRIVER)
+#   2.  Verify service registration is fresh
+#   3.  Force-load MagicKbDesc.sys via SC-START-DRIVER; check kernel module list
+#   4.  Pause for USER to toggle BT off/on in Settings
+#   5.  Check DEVPKEY_Device_Stack for MagicKbDesc
+#   6.  Run test.ps1 — empirical battery byte
+#
+# Run from anywhere on Windows:
+#   pwsh.exe -File post-reboot-validate.ps1
+# OR (works from \\wsl.localhost\... too):
+#   powershell.exe -ExecutionPolicy Bypass -File "<this script>"
+
+param(
+    [string]$StagingDir = 'C:\mm-dev-queue\kbd-stage-kbd-stage-1778263483',
+    [string]$DeviceInstanceId = 'BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&000205AC_PID&0239\9&73B8B28&0&E806884B0741_C00000000',
+    [string]$QueueDir = 'C:\mm-dev-queue',
+    [int]$PollMaxSeconds = 120
+)
+
+$ErrorActionPreference = 'Stop'
+$Host.UI.RawUI.ForegroundColor = 'White'
+
+function Write-Step {
+    param([string]$Title)
+    Write-Host ""
+    Write-Host "================================================================" -ForegroundColor Cyan
+    Write-Host "  $Title" -ForegroundColor Cyan
+    Write-Host "================================================================" -ForegroundColor Cyan
+}
+
+function Invoke-RunnerPhase {
+    param(
+        [string]$Phase,
+        [string[]]$Args = @(),
+        [int]$TimeoutSec = 60
+    )
+    $nonce = "kbd-postrb-$([guid]::NewGuid().ToString().Substring(0,8))"
+    $req = ($Phase, $nonce) + $Args -join '|'
+    $reqPath = Join-Path $QueueDir 'request.txt'
+    $resPath = Join-Path $QueueDir 'result.txt'
+
+    $req | Set-Content -Path $reqPath -Encoding ASCII
+    Remove-Item $resPath -ErrorAction SilentlyContinue
+    Write-Host "[runner] $Phase | $nonce" -ForegroundColor DarkGray
+    schtasks /run /tn MM-Dev-Cycle | Out-Null
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Path $resPath) {
+            $r = (Get-Content $resPath -Raw -ErrorAction SilentlyContinue).Trim()
+            if ($r -match "\|$nonce") {
+                $rc = [int]($r -split '\|')[0]
+                Write-Host "[runner] result rc=$rc" -ForegroundColor DarkGray
+                return [pscustomobject]@{ Rc = $rc; Nonce = $nonce; Result = $r }
+            }
+        }
+        Start-Sleep -Seconds 2
+    }
+    throw "[runner] TIMEOUT waiting for $Phase ($nonce) after ${TimeoutSec}s"
+}
+
+# --------------------------------------------------------------------------
+# Step 0 — SCM clean check
+# --------------------------------------------------------------------------
+Write-Step "Step 0 — SCM clean check"
+$scOut = sc.exe query MagicKbDesc 2>&1 | Out-String
+if ($scOut -match 'does not exist as an installed service' -or
+    $scOut -match 'The specified service does not exist') {
+    Write-Host "OK — SCM is clean (service not registered)." -ForegroundColor Green
+} elseif ($scOut -match 'marked for deletion') {
+    Write-Host "FAIL — SCM still says marked-for-deletion. Reboot didn't clear it." -ForegroundColor Red
+    Write-Host $scOut
+    throw "SCM not clean — cannot proceed."
+} else {
+    Write-Host "WARNING — service still exists after reboot. Will attempt to use it." -ForegroundColor Yellow
+    Write-Host ($scOut -split "`n" | Select-Object -First 5 | Out-String)
+}
+
+# --------------------------------------------------------------------------
+# Step 1 — Re-install the INF cleanly
+# --------------------------------------------------------------------------
+Write-Step "Step 1 — Re-install oem57 (INSTALL-DRIVER)"
+$infPath = Join-Path $StagingDir 'MagicKbDesc.inf'
+if (-not (Test-Path $infPath)) {
+    throw "INF not found at $infPath — has the staging dir been cleaned up? Re-run STAGE-CAT first."
+}
+
+$r1 = Invoke-RunnerPhase -Phase 'INSTALL-DRIVER' -Args @($infPath) -TimeoutSec $PollMaxSeconds
+$installLog = Join-Path $QueueDir "install-$($r1.Nonce).log"
+if (Test-Path $installLog) {
+    $logContent = Get-Content $installLog -Raw
+    Write-Host $logContent
+    if ($logContent -match 'Added driver packages:\s*1') {
+        Write-Host "OK — fresh service registration created." -ForegroundColor Green
+    } elseif ($logContent -match 'Added driver packages:\s*0') {
+        Write-Host "WARNING — pnputil reports Added=0 (treats package as already present)." -ForegroundColor Yellow
+        Write-Host "  Attempting full uninstall + reinstall..." -ForegroundColor Yellow
+        Invoke-RunnerPhase -Phase 'UNINSTALL-DRIVER' -Args @('oem57.inf') -TimeoutSec 60 | Out-Null
+        Start-Sleep -Seconds 3
+        $r1b = Invoke-RunnerPhase -Phase 'INSTALL-DRIVER' -Args @($infPath) -TimeoutSec $PollMaxSeconds
+        $log2 = Join-Path $QueueDir "install-$($r1b.Nonce).log"
+        Get-Content $log2 -Raw | Write-Host
+    }
+}
+
+# --------------------------------------------------------------------------
+# Step 2 — Verify service registration
+# --------------------------------------------------------------------------
+Write-Step "Step 2 — Verify service registration"
+$qcOut = sc.exe qc MagicKbDesc 2>&1 | Out-String
+Write-Host ($qcOut -split "`n" | Select-String 'BINARY|START_TYPE|TYPE' | Out-String)
+
+$sysInDrivers = Test-Path 'C:\Windows\System32\drivers\MagicKbDesc.sys'
+Write-Host "C:\Windows\System32\drivers\MagicKbDesc.sys exists? $sysInDrivers"
+
+$svcReg = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\MagicKbDesc' -ErrorAction SilentlyContinue
+if ($svcReg) {
+    Write-Host "ImagePath: $($svcReg.ImagePath)" -ForegroundColor White
+    Write-Host "Type: $($svcReg.Type)  Start: $($svcReg.Start)  ErrorControl: $($svcReg.ErrorControl)"
+    if ($svcReg.ImagePath -match 'magickbdesc\.inf_amd64_19830858ec72e2ad' -or
+        $svcReg.ImagePath -match '\\drivers\\MagicKbDesc\.sys') {
+        Write-Host "OK — ImagePath points at a valid location." -ForegroundColor Green
+    } else {
+        Write-Host "FAIL — ImagePath looks stale: $($svcReg.ImagePath)" -ForegroundColor Red
+        throw "Service ImagePath is broken."
+    }
+} else {
+    throw "Service registration missing — INSTALL-DRIVER didn't write it."
+}
+
+# --------------------------------------------------------------------------
+# Step 3 — Force-load + verify kernel module loaded
+# --------------------------------------------------------------------------
+Write-Step "Step 3 — Force-load MagicKbDesc"
+$r3 = Invoke-RunnerPhase -Phase 'SC-START-DRIVER' -Args @('MagicKbDesc') -TimeoutSec 30
+$startLog = Join-Path $QueueDir "scstart-$($r3.Nonce).log"
+if (Test-Path $startLog) {
+    Write-Host (Get-Content $startLog -Raw)
+}
+
+Start-Sleep -Seconds 2
+$dq = driverquery /v /fo csv 2>&1 | Select-String 'MagicKbDesc'
+if ($dq) {
+    Write-Host "OK — MagicKbDesc IS loaded in the kernel:" -ForegroundColor Green
+    Write-Host $dq
+} else {
+    Write-Host "FAIL — MagicKbDesc NOT loaded in kernel (driverquery shows nothing)." -ForegroundColor Red
+    Write-Host "Check Microsoft-Windows-CodeIntegrity/Operational log for the load error."
+    Get-WinEvent -LogName 'Microsoft-Windows-CodeIntegrity/Operational' -MaxEvents 10 -ErrorAction SilentlyContinue |
+        Where-Object { $_.Message -match 'MagicKbDesc' } |
+        Format-List TimeCreated, Id, Message
+    throw "Kernel-load failed — investigate before continuing."
+}
+
+# --------------------------------------------------------------------------
+# Step 4 — USER toggles Bluetooth
+# --------------------------------------------------------------------------
+Write-Step "Step 4 — USER ACTION REQUIRED"
+Write-Host ""
+Write-Host "  Open Settings → Bluetooth & devices → toggle Bluetooth OFF, wait 5s, ON." -ForegroundColor Yellow
+Write-Host "  Wait for the keyboard to reconnect (it will appear in the device list)." -ForegroundColor Yellow
+Write-Host ""
+Read-Host "Press Enter when the keyboard has reconnected"
+
+# --------------------------------------------------------------------------
+# Step 5 — Check device stack
+# --------------------------------------------------------------------------
+Write-Step "Step 5 — Verify MagicKbDesc is in the device stack"
+$stack = Get-PnpDeviceProperty -InstanceId $DeviceInstanceId -KeyName 'DEVPKEY_Device_Stack' -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty Data
+Write-Host "Stack:"
+$stack | ForEach-Object { Write-Host "  $_" }
+
+if ($stack -match 'MagicKbDesc') {
+    Write-Host "PASS — filter is bound." -ForegroundColor Green
+} else {
+    Write-Host "FAIL — MagicKbDesc not in stack." -ForegroundColor Red
+    Write-Host "B3 architectural premise falsified — lower filter on BTHENUM PDO doesn't see the descriptor IOCTL." -ForegroundColor Red
+    Write-Host "Capturing setupapi log for diagnosis..."
+    $diagFile = Join-Path $QueueDir "diag-postrb-$(Get-Date -Format yyyyMMdd-HHmmss).log"
+    "=== last 100 setupapi entries mentioning BTHENUM/0239/MagicKbDesc ===" | Set-Content $diagFile
+    Get-Content 'C:\Windows\inf\setupapi.dev.log' |
+        Select-String 'BTHENUM.*0239|MagicKbDesc' |
+        Select-Object -Last 100 |
+        ForEach-Object { $_.Line } |
+        Add-Content $diagFile
+    "" | Add-Content $diagFile
+    "=== last 30 System events mentioning MagicKbDesc/HidBth ===" | Add-Content $diagFile
+    Get-WinEvent -LogName System -MaxEvents 200 -ErrorAction SilentlyContinue |
+        Where-Object { $_.Message -match 'MagicKbDesc|HidBth' } |
+        Select-Object -First 30 |
+        Format-List TimeCreated, Id, LevelDisplayName, Message |
+        Out-String |
+        Add-Content $diagFile
+    Write-Host "Diagnosis written to $diagFile" -ForegroundColor Yellow
+    exit 1
+}
+
+# --------------------------------------------------------------------------
+# Step 6 — Empirical battery byte
+# --------------------------------------------------------------------------
+Write-Step "Step 6 — Empirical battery read"
+$testScript = Join-Path $PSScriptRoot 'test.ps1'
+if (-not (Test-Path $testScript)) {
+    Write-Host "test.ps1 not found at $testScript — running inline check instead." -ForegroundColor Yellow
+    & "$PSScriptRoot\check-stack-and-test.ps1" 2>&1
+} else {
+    & pwsh.exe -NoProfile -File $testScript 2>&1
+}
+
+Write-Step "DONE"
+Write-Host "If you see *** SUCCESS *** [47 NN] BATTERY = NN% above, M2 closes." -ForegroundColor Green
+Write-Host "Send the user a copy of this terminal output for the PR test-plan checkboxes."

--- a/keyboard-descriptor-patcher/post-reboot-validate.ps1
+++ b/keyboard-descriptor-patcher/post-reboot-validate.ps1
@@ -8,7 +8,7 @@
 #   3.  Force-load MagicKbDesc.sys via SC-START-DRIVER; check kernel module list
 #   4.  Pause for USER to toggle BT off/on in Settings
 #   5.  Check DEVPKEY_Device_Stack for MagicKbDesc
-#   6.  Run test.ps1 — empirical battery byte
+#   6.  Run test.ps1 - empirical battery byte
 #
 # Run from anywhere on Windows:
 #   pwsh.exe -File post-reboot-validate.ps1
@@ -36,11 +36,11 @@ function Write-Step {
 function Invoke-RunnerPhase {
     param(
         [string]$Phase,
-        [string[]]$Args = @(),
+        [string[]]$PhaseArgs = @(),
         [int]$TimeoutSec = 60
     )
     $nonce = "kbd-postrb-$([guid]::NewGuid().ToString().Substring(0,8))"
-    $req = ($Phase, $nonce) + $Args -join '|'
+    $req = ($Phase, $nonce) + $PhaseArgs -join '|'
     $reqPath = Join-Path $QueueDir 'request.txt'
     $resPath = Join-Path $QueueDir 'result.txt'
 
@@ -65,53 +65,53 @@ function Invoke-RunnerPhase {
 }
 
 # --------------------------------------------------------------------------
-# Step 0 — SCM clean check
+# Step 0 - SCM clean check
 # --------------------------------------------------------------------------
-Write-Step "Step 0 — SCM clean check"
+Write-Step "Step 0 - SCM clean check"
 $scOut = sc.exe query MagicKbDesc 2>&1 | Out-String
 if ($scOut -match 'does not exist as an installed service' -or
     $scOut -match 'The specified service does not exist') {
-    Write-Host "OK — SCM is clean (service not registered)." -ForegroundColor Green
+    Write-Host "OK - SCM is clean (service not registered)." -ForegroundColor Green
 } elseif ($scOut -match 'marked for deletion') {
-    Write-Host "FAIL — SCM still says marked-for-deletion. Reboot didn't clear it." -ForegroundColor Red
+    Write-Host "FAIL - SCM still says marked-for-deletion. Reboot didn't clear it." -ForegroundColor Red
     Write-Host $scOut
-    throw "SCM not clean — cannot proceed."
+    throw "SCM not clean - cannot proceed."
 } else {
-    Write-Host "WARNING — service still exists after reboot. Will attempt to use it." -ForegroundColor Yellow
+    Write-Host "WARNING - service still exists after reboot. Will attempt to use it." -ForegroundColor Yellow
     Write-Host ($scOut -split "`n" | Select-Object -First 5 | Out-String)
 }
 
 # --------------------------------------------------------------------------
-# Step 1 — Re-install the INF cleanly
+# Step 1 - Re-install the INF cleanly
 # --------------------------------------------------------------------------
-Write-Step "Step 1 — Re-install oem57 (INSTALL-DRIVER)"
+Write-Step "Step 1 - Re-install oem57 (INSTALL-DRIVER)"
 $infPath = Join-Path $StagingDir 'MagicKbDesc.inf'
 if (-not (Test-Path $infPath)) {
-    throw "INF not found at $infPath — has the staging dir been cleaned up? Re-run STAGE-CAT first."
+    throw "INF not found at $infPath - has the staging dir been cleaned up? Re-run STAGE-CAT first."
 }
 
-$r1 = Invoke-RunnerPhase -Phase 'INSTALL-DRIVER' -Args @($infPath) -TimeoutSec $PollMaxSeconds
+$r1 = Invoke-RunnerPhase -Phase 'INSTALL-DRIVER' -PhaseArgs @($infPath) -TimeoutSec $PollMaxSeconds
 $installLog = Join-Path $QueueDir "install-$($r1.Nonce).log"
 if (Test-Path $installLog) {
     $logContent = Get-Content $installLog -Raw
     Write-Host $logContent
     if ($logContent -match 'Added driver packages:\s*1') {
-        Write-Host "OK — fresh service registration created." -ForegroundColor Green
+        Write-Host "OK - fresh service registration created." -ForegroundColor Green
     } elseif ($logContent -match 'Added driver packages:\s*0') {
-        Write-Host "WARNING — pnputil reports Added=0 (treats package as already present)." -ForegroundColor Yellow
+        Write-Host "WARNING - pnputil reports Added=0 (treats package as already present)." -ForegroundColor Yellow
         Write-Host "  Attempting full uninstall + reinstall..." -ForegroundColor Yellow
-        Invoke-RunnerPhase -Phase 'UNINSTALL-DRIVER' -Args @('oem57.inf') -TimeoutSec 60 | Out-Null
+        Invoke-RunnerPhase -Phase 'UNINSTALL-DRIVER' -PhaseArgs @('oem57.inf') -TimeoutSec 60 | Out-Null
         Start-Sleep -Seconds 3
-        $r1b = Invoke-RunnerPhase -Phase 'INSTALL-DRIVER' -Args @($infPath) -TimeoutSec $PollMaxSeconds
+        $r1b = Invoke-RunnerPhase -Phase 'INSTALL-DRIVER' -PhaseArgs @($infPath) -TimeoutSec $PollMaxSeconds
         $log2 = Join-Path $QueueDir "install-$($r1b.Nonce).log"
         Get-Content $log2 -Raw | Write-Host
     }
 }
 
 # --------------------------------------------------------------------------
-# Step 2 — Verify service registration
+# Step 2 - Verify service registration
 # --------------------------------------------------------------------------
-Write-Step "Step 2 — Verify service registration"
+Write-Step "Step 2 - Verify service registration"
 $qcOut = sc.exe qc MagicKbDesc 2>&1 | Out-String
 Write-Host ($qcOut -split "`n" | Select-String 'BINARY|START_TYPE|TYPE' | Out-String)
 
@@ -124,20 +124,20 @@ if ($svcReg) {
     Write-Host "Type: $($svcReg.Type)  Start: $($svcReg.Start)  ErrorControl: $($svcReg.ErrorControl)"
     if ($svcReg.ImagePath -match 'magickbdesc\.inf_amd64_19830858ec72e2ad' -or
         $svcReg.ImagePath -match '\\drivers\\MagicKbDesc\.sys') {
-        Write-Host "OK — ImagePath points at a valid location." -ForegroundColor Green
+        Write-Host "OK - ImagePath points at a valid location." -ForegroundColor Green
     } else {
-        Write-Host "FAIL — ImagePath looks stale: $($svcReg.ImagePath)" -ForegroundColor Red
+        Write-Host "FAIL - ImagePath looks stale: $($svcReg.ImagePath)" -ForegroundColor Red
         throw "Service ImagePath is broken."
     }
 } else {
-    throw "Service registration missing — INSTALL-DRIVER didn't write it."
+    throw "Service registration missing - INSTALL-DRIVER didn't write it."
 }
 
 # --------------------------------------------------------------------------
-# Step 3 — Force-load + verify kernel module loaded
+# Step 3 - Force-load + verify kernel module loaded
 # --------------------------------------------------------------------------
-Write-Step "Step 3 — Force-load MagicKbDesc"
-$r3 = Invoke-RunnerPhase -Phase 'SC-START-DRIVER' -Args @('MagicKbDesc') -TimeoutSec 30
+Write-Step "Step 3 - Force-load MagicKbDesc"
+$r3 = Invoke-RunnerPhase -Phase 'SC-START-DRIVER' -PhaseArgs @('MagicKbDesc') -TimeoutSec 30
 $startLog = Join-Path $QueueDir "scstart-$($r3.Nonce).log"
 if (Test-Path $startLog) {
     Write-Host (Get-Content $startLog -Raw)
@@ -146,41 +146,41 @@ if (Test-Path $startLog) {
 Start-Sleep -Seconds 2
 $dq = driverquery /v /fo csv 2>&1 | Select-String 'MagicKbDesc'
 if ($dq) {
-    Write-Host "OK — MagicKbDesc IS loaded in the kernel:" -ForegroundColor Green
+    Write-Host "OK - MagicKbDesc IS loaded in the kernel:" -ForegroundColor Green
     Write-Host $dq
 } else {
-    Write-Host "FAIL — MagicKbDesc NOT loaded in kernel (driverquery shows nothing)." -ForegroundColor Red
+    Write-Host "FAIL - MagicKbDesc NOT loaded in kernel (driverquery shows nothing)." -ForegroundColor Red
     Write-Host "Check Microsoft-Windows-CodeIntegrity/Operational log for the load error."
     Get-WinEvent -LogName 'Microsoft-Windows-CodeIntegrity/Operational' -MaxEvents 10 -ErrorAction SilentlyContinue |
         Where-Object { $_.Message -match 'MagicKbDesc' } |
         Format-List TimeCreated, Id, Message
-    throw "Kernel-load failed — investigate before continuing."
+    throw "Kernel-load failed - investigate before continuing."
 }
 
 # --------------------------------------------------------------------------
-# Step 4 — USER toggles Bluetooth
+# Step 4 - USER toggles Bluetooth
 # --------------------------------------------------------------------------
-Write-Step "Step 4 — USER ACTION REQUIRED"
+Write-Step "Step 4 - USER ACTION REQUIRED"
 Write-Host ""
-Write-Host "  Open Settings → Bluetooth & devices → toggle Bluetooth OFF, wait 5s, ON." -ForegroundColor Yellow
+Write-Host "  Open Settings -> Bluetooth & devices -> toggle Bluetooth OFF, wait 5s, ON." -ForegroundColor Yellow
 Write-Host "  Wait for the keyboard to reconnect (it will appear in the device list)." -ForegroundColor Yellow
 Write-Host ""
 Read-Host "Press Enter when the keyboard has reconnected"
 
 # --------------------------------------------------------------------------
-# Step 5 — Check device stack
+# Step 5 - Check device stack
 # --------------------------------------------------------------------------
-Write-Step "Step 5 — Verify MagicKbDesc is in the device stack"
+Write-Step "Step 5 - Verify MagicKbDesc is in the device stack"
 $stack = Get-PnpDeviceProperty -InstanceId $DeviceInstanceId -KeyName 'DEVPKEY_Device_Stack' -ErrorAction SilentlyContinue |
     Select-Object -ExpandProperty Data
 Write-Host "Stack:"
 $stack | ForEach-Object { Write-Host "  $_" }
 
 if ($stack -match 'MagicKbDesc') {
-    Write-Host "PASS — filter is bound." -ForegroundColor Green
+    Write-Host "PASS - filter is bound." -ForegroundColor Green
 } else {
-    Write-Host "FAIL — MagicKbDesc not in stack." -ForegroundColor Red
-    Write-Host "B3 architectural premise falsified — lower filter on BTHENUM PDO doesn't see the descriptor IOCTL." -ForegroundColor Red
+    Write-Host "FAIL - MagicKbDesc not in stack." -ForegroundColor Red
+    Write-Host "B3 architectural premise falsified - lower filter on BTHENUM PDO doesn't see the descriptor IOCTL." -ForegroundColor Red
     Write-Host "Capturing setupapi log for diagnosis..."
     $diagFile = Join-Path $QueueDir "diag-postrb-$(Get-Date -Format yyyyMMdd-HHmmss).log"
     "=== last 100 setupapi entries mentioning BTHENUM/0239/MagicKbDesc ===" | Set-Content $diagFile
@@ -202,12 +202,12 @@ if ($stack -match 'MagicKbDesc') {
 }
 
 # --------------------------------------------------------------------------
-# Step 6 — Empirical battery byte
+# Step 6 - Empirical battery byte
 # --------------------------------------------------------------------------
-Write-Step "Step 6 — Empirical battery read"
+Write-Step "Step 6 - Empirical battery read"
 $testScript = Join-Path $PSScriptRoot 'test.ps1'
 if (-not (Test-Path $testScript)) {
-    Write-Host "test.ps1 not found at $testScript — running inline check instead." -ForegroundColor Yellow
+    Write-Host "test.ps1 not found at $testScript - running inline check instead." -ForegroundColor Yellow
     & "$PSScriptRoot\check-stack-and-test.ps1" 2>&1
 } else {
     & pwsh.exe -NoProfile -File $testScript 2>&1

--- a/keyboard-descriptor-patcher/pre-reboot-checkpoint.ps1
+++ b/keyboard-descriptor-patcher/pre-reboot-checkpoint.ps1
@@ -1,0 +1,91 @@
+# pre-reboot-checkpoint.ps1
+# Runs immediately before reboot. Captures current MagicKbDesc state and
+# verifies the staging dir + driver-store entries are still there so the
+# post-reboot validate script doesn't have to rebuild from scratch.
+#
+# Run:
+#   powershell.exe -ExecutionPolicy Bypass -File pre-reboot-checkpoint.ps1
+
+param(
+    [string]$StagingDir = 'C:\mm-dev-queue\kbd-stage-kbd-stage-1778263483',
+    [string]$DeviceInstanceId = 'BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&000205AC_PID&0239\9&73B8B28&0&E806884B0741_C00000000'
+)
+
+$ErrorActionPreference = 'Continue'
+$pass = $true
+
+function Check {
+    param([string]$Name, [bool]$Ok, [string]$Detail = '')
+    $tag = if ($Ok) { 'OK  ' } else { 'FAIL' }
+    $color = if ($Ok) { 'Green' } else { 'Red' }
+    Write-Host "[$tag] $Name" -ForegroundColor $color
+    if ($Detail) { Write-Host "       $Detail" -ForegroundColor DarkGray }
+    if (-not $Ok) { $script:pass = $false }
+}
+
+Write-Host "=================================================================" -ForegroundColor Cyan
+Write-Host "  Pre-Reboot Checkpoint — MagicKbDesc state" -ForegroundColor Cyan
+Write-Host "=================================================================" -ForegroundColor Cyan
+
+# Staging dir
+$stageInf = Join-Path $StagingDir 'MagicKbDesc.inf'
+$stageSys = Join-Path $StagingDir 'MagicKbDesc.sys'
+$stageCat = Join-Path $StagingDir 'magickbdesc.cat'
+Check -Name "Staging INF present" -Ok (Test-Path $stageInf) -Detail $stageInf
+Check -Name "Staging SYS present" -Ok (Test-Path $stageSys) -Detail $stageSys
+Check -Name "Staging CAT present" -Ok (Test-Path $stageCat) -Detail $stageCat
+
+if (Test-Path $stageSys) {
+    $stageMd5 = (Get-FileHash -Algorithm MD5 $stageSys).Hash.ToLower()
+    Check -Name "Staging SYS MD5 = e11d8b97660d6b9324e82225c37201c0" `
+          -Ok ($stageMd5 -eq 'e11d8b97660d6b9324e82225c37201c0') `
+          -Detail "actual: $stageMd5"
+}
+
+# Driver store
+$dsRoot = 'C:\Windows\System32\DriverStore\FileRepository'
+$dsHash = Get-ChildItem $dsRoot -Filter 'magickbdesc.inf_amd64_*' -Directory -ErrorAction SilentlyContinue
+Check -Name "Driver store has magickbdesc package" -Ok ($dsHash.Count -gt 0) `
+      -Detail "Found: $($dsHash.Name -join ', ')"
+
+# pnputil enum
+$enum = pnputil /enum-drivers 2>&1 | Out-String
+$hasOem57 = $enum -match 'oem57\.inf' -and $enum -match 'magickbdesc'
+Check -Name "pnputil enum-drivers shows magickbdesc as oem57.inf" -Ok $hasOem57
+
+# Service state
+$scOut = sc.exe query MagicKbDesc 2>&1 | Out-String
+if ($scOut -match 'marked for deletion') {
+    Check -Name "Service state" -Ok $false -Detail "marked for deletion (REBOOT REQUIRED)"
+} elseif ($scOut -match 'does not exist') {
+    Check -Name "Service state" -Ok $true -Detail "not registered (clean — INSTALL-DRIVER will create)"
+} else {
+    Check -Name "Service state" -Ok $true -Detail ($scOut -split "`n" | Select-String 'STATE' | ForEach-Object { $_.Line.Trim() })
+}
+
+# Device LowerFilters reg
+$drv = (Get-ItemProperty ('HKLM:\SYSTEM\CurrentControlSet\Enum\' + $DeviceInstanceId) -ErrorAction SilentlyContinue).Driver
+if ($drv) {
+    $lf = (Get-ItemProperty ('HKLM:\SYSTEM\CurrentControlSet\Control\Class\' + $drv) -ErrorAction SilentlyContinue).LowerFilters
+    Check -Name "Device LowerFilters includes MagicKbDesc" -Ok ($lf -contains 'MagicKbDesc') `
+          -Detail "Driver class instance: $drv  LowerFilters: $($lf -join ',')"
+} else {
+    Check -Name "Device class instance lookup" -Ok $false -Detail "no Driver value at $DeviceInstanceId"
+}
+
+# Branch state
+$gitState = & git -C '\\wsl.localhost\Ubuntu\home\lesley\.claude\worktrees\ai-m4-kbd-inf-fix-final' log --oneline -1 2>&1 | Out-String
+Check -Name "Worktree branch HEAD" -Ok ($gitState -match 'fix\(kbd-driver\): peer-review B1\+B2\+B4') `
+      -Detail $gitState.Trim()
+
+Write-Host ""
+Write-Host "=================================================================" -ForegroundColor Cyan
+if ($pass) {
+    Write-Host "  ALL CHECKS PASSED — safe to reboot now." -ForegroundColor Green
+    Write-Host "  After reboot run:" -ForegroundColor White
+    Write-Host "    powershell.exe -ExecutionPolicy Bypass -File post-reboot-validate.ps1" -ForegroundColor Yellow
+} else {
+    Write-Host "  ONE OR MORE CHECKS FAILED — fix before reboot." -ForegroundColor Red
+}
+Write-Host "=================================================================" -ForegroundColor Cyan
+exit $(if ($pass) { 0 } else { 1 })

--- a/keyboard-descriptor-patcher/pre-reboot-checkpoint.ps1
+++ b/keyboard-descriptor-patcher/pre-reboot-checkpoint.ps1
@@ -23,8 +23,19 @@ function Check {
     if (-not $Ok) { $script:pass = $false }
 }
 
+# MD5 is used here as a non-cryptographic identity check: it catches a stale or
+# replaced staging file, and is not relied on as a security control. The baseline
+# below was recorded in MD5 when this MagicKbDesc.sys was built, so the comparison
+# has to stay MD5 to remain meaningful.
+function Get-StagedSysFingerprint {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingBrokenHashAlgorithms', '',
+        Justification = 'Non-cryptographic build-identity check against a recorded MD5 baseline.')]
+    param([Parameter(Mandatory=$true)][string]$Path)
+    return (Get-FileHash -Algorithm MD5 -Path $Path).Hash.ToLower()
+}
+
 Write-Host "=================================================================" -ForegroundColor Cyan
-Write-Host "  Pre-Reboot Checkpoint — MagicKbDesc state" -ForegroundColor Cyan
+Write-Host "  Pre-Reboot Checkpoint - MagicKbDesc state" -ForegroundColor Cyan
 Write-Host "=================================================================" -ForegroundColor Cyan
 
 # Staging dir
@@ -36,7 +47,7 @@ Check -Name "Staging SYS present" -Ok (Test-Path $stageSys) -Detail $stageSys
 Check -Name "Staging CAT present" -Ok (Test-Path $stageCat) -Detail $stageCat
 
 if (Test-Path $stageSys) {
-    $stageMd5 = (Get-FileHash -Algorithm MD5 $stageSys).Hash.ToLower()
+    $stageMd5 = Get-StagedSysFingerprint -Path $stageSys
     Check -Name "Staging SYS MD5 = e11d8b97660d6b9324e82225c37201c0" `
           -Ok ($stageMd5 -eq 'e11d8b97660d6b9324e82225c37201c0') `
           -Detail "actual: $stageMd5"
@@ -58,7 +69,7 @@ $scOut = sc.exe query MagicKbDesc 2>&1 | Out-String
 if ($scOut -match 'marked for deletion') {
     Check -Name "Service state" -Ok $false -Detail "marked for deletion (REBOOT REQUIRED)"
 } elseif ($scOut -match 'does not exist') {
-    Check -Name "Service state" -Ok $true -Detail "not registered (clean — INSTALL-DRIVER will create)"
+    Check -Name "Service state" -Ok $true -Detail "not registered (clean - INSTALL-DRIVER will create)"
 } else {
     Check -Name "Service state" -Ok $true -Detail ($scOut -split "`n" | Select-String 'STATE' | ForEach-Object { $_.Line.Trim() })
 }
@@ -81,11 +92,11 @@ Check -Name "Worktree branch HEAD" -Ok ($gitState -match 'fix\(kbd-driver\): pee
 Write-Host ""
 Write-Host "=================================================================" -ForegroundColor Cyan
 if ($pass) {
-    Write-Host "  ALL CHECKS PASSED — safe to reboot now." -ForegroundColor Green
+    Write-Host "  ALL CHECKS PASSED - safe to reboot now." -ForegroundColor Green
     Write-Host "  After reboot run:" -ForegroundColor White
     Write-Host "    powershell.exe -ExecutionPolicy Bypass -File post-reboot-validate.ps1" -ForegroundColor Yellow
 } else {
-    Write-Host "  ONE OR MORE CHECKS FAILED — fix before reboot." -ForegroundColor Red
+    Write-Host "  ONE OR MORE CHECKS FAILED - fix before reboot." -ForegroundColor Red
 }
 Write-Host "=================================================================" -ForegroundColor Cyan
 exit $(if ($pass) { 0 } else { 1 })

--- a/keyboard-descriptor-patcher/sign.ps1
+++ b/keyboard-descriptor-patcher/sign.ps1
@@ -1,0 +1,34 @@
+# sign.ps1 — sign MagicKbDesc.sys + .cat with the M12 CN=MagicMouseFix cert.
+# Reuses the M12 trust path (cert already in TrustedPublisher).
+
+$ErrorActionPreference = 'Stop'
+
+$sysPath = Join-Path $PSScriptRoot 'x64\Release\MagicKbDesc\MagicKbDesc.sys'
+$catPath = Join-Path $PSScriptRoot 'x64\Release\MagicKbDesc\MagicKbDesc.cat'
+
+foreach ($f in @($sysPath, $catPath)) {
+    if (-not (Test-Path $f)) {
+        throw "Build artifact missing: $f. Run build.ps1 first."
+    }
+}
+
+# Reuse M12 thumbprint (CN=MagicMouseFix) — see sign-and-install.ps1.
+$thumb = 'B902C2864315E2DE359450024768CE7D01715C38'
+$timestampUrl = 'http://timestamp.digicert.com'
+$signtool = 'F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe'
+
+if (-not (Test-Path $signtool)) {
+    throw "signtool.exe not found at $signtool. EWDK ISO mounted at F:\?"
+}
+
+foreach ($f in @($sysPath, $catPath)) {
+    Write-Host "Signing $f ..."
+    & $signtool sign /sm /sha1 $thumb /fd sha256 /tr $timestampUrl /td sha256 /v $f
+    if ($LASTEXITCODE -ne 0) {
+        throw "signtool failed on $f (exit=$LASTEXITCODE)"
+    }
+}
+
+Write-Host ""
+Write-Host "Signed. Verify with:"
+Write-Host "  & '$signtool' verify /pa $sysPath"

--- a/keyboard-descriptor-patcher/sign.ps1
+++ b/keyboard-descriptor-patcher/sign.ps1
@@ -1,4 +1,4 @@
-# sign.ps1 — sign MagicKbDesc.sys + .cat with the M12 CN=MagicMouseFix cert.
+# sign.ps1 - sign MagicKbDesc.sys + .cat with the M12 CN=MagicMouseFix cert.
 # Reuses the M12 trust path (cert already in TrustedPublisher).
 
 $ErrorActionPreference = 'Stop'
@@ -12,7 +12,7 @@ foreach ($f in @($sysPath, $catPath)) {
     }
 }
 
-# Reuse M12 thumbprint (CN=MagicMouseFix) — see sign-and-install.ps1.
+# Reuse M12 thumbprint (CN=MagicMouseFix) - see sign-and-install.ps1.
 $thumb = 'B902C2864315E2DE359450024768CE7D01715C38'
 $timestampUrl = 'http://timestamp.digicert.com'
 $signtool = 'F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe'

--- a/v2-kmdf-driver/.clang-format
+++ b/v2-kmdf-driver/.clang-format
@@ -1,0 +1,12 @@
+# .clang-format — M12 WDF-style preset
+# Place in driver/ (or repo root) so clang-format picks it up automatically.
+# Enforced by scripts/check-style.sh check #8.
+---
+BasedOnStyle: Microsoft
+IndentWidth: 4
+ColumnLimit: 100
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+DerivePointerAlignment: false
+PointerAlignment: Right
+SortIncludes: false

--- a/v2-kmdf-driver/.gitattributes
+++ b/v2-kmdf-driver/.gitattributes
@@ -1,0 +1,17 @@
+# Driver source files MUST use CRLF on Windows (signing depends on byte-exact content)
+# See: upstream MagicMouse2DriversWin10x64 issue #1 (hash mismatch from LF conversion)
+*.inf  text eol=crlf
+*.cat  binary
+*.sys  binary
+*.tmf  text eol=crlf
+*.h    text eol=crlf
+*.c    text eol=crlf
+*.rc   text eol=crlf
+
+# Build/sign artifacts -- never modify
+build/** binary
+*.cer  binary
+*.pfx  binary
+
+# Documentation -- let git auto-detect (Markdown is platform-agnostic)
+*.md   text

--- a/v2-kmdf-driver/Driver.c
+++ b/v2-kmdf-driver/Driver.c
@@ -1,0 +1,568 @@
+// SPDX-License-Identifier: MIT
+#include "Driver.h"
+#include "InputHandler.h"   // SdpRewrite_Process
+#include "GestureEngine.h"  // TranslateMouse2ToHid, MM2_HEADER_LEN
+
+// --------------------------------------------------------------------------
+// DriverEntry
+// --------------------------------------------------------------------------
+
+NTSTATUS
+DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
+{
+    WDF_DRIVER_CONFIG config;
+    WDF_DRIVER_CONFIG_INIT(&config, EvtDeviceAdd);
+    return WdfDriverCreate(DriverObject, RegistryPath, WDF_NO_OBJECT_ATTRIBUTES,
+                           &config, WDF_NO_HANDLE);
+}
+
+// --------------------------------------------------------------------------
+// EvtDeviceAdd — bind as lower filter, read config, start diagnostic timer
+// --------------------------------------------------------------------------
+
+NTSTATUS
+EvtDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT DeviceInit)
+{
+    UNREFERENCED_PARAMETER(Driver);
+
+    WdfFdoInitSetFilter(DeviceInit);
+
+    WDF_OBJECT_ATTRIBUTES devAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&devAttr, DEVICE_CONTEXT);
+
+    WDFDEVICE device;
+    NTSTATUS status = WdfDeviceCreate(&DeviceInit, &devAttr, &device);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+
+    WDF_OBJECT_ATTRIBUTES lockAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&lockAttr);
+    lockAttr.ParentObject = device;
+    status = WdfSpinLockCreate(&lockAttr, &ctx->Lock);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    // Read EnableInjection from Parameters registry subkey.
+    // Default TRUE — missing key/value means "enabled".
+    ctx->EnableInjection = TRUE;
+    {
+        WDFKEY paramsKey = NULL;
+        NTSTATUS ks = WdfDriverOpenParametersRegistryKey(
+            Driver, KEY_READ, WDF_NO_OBJECT_ATTRIBUTES, &paramsKey);
+        if (NT_SUCCESS(ks) && paramsKey != NULL)
+        {
+            ULONG val = 1;
+            UNICODE_STRING valName;
+            RtlInitUnicodeString(&valName, L"EnableInjection");
+            NTSTATUS vs = WdfRegistryQueryULong(paramsKey, &valName, &val);
+            if (NT_SUCCESS(vs))
+            {
+                ctx->EnableInjection = (val != 0);
+            }
+            WdfRegistryClose(paramsKey);
+        }
+    }
+
+    DbgPrint("M13: AddDevice — EnableInjection=%d\n", ctx->EnableInjection);
+
+    // Populate ProductId from hardware ID so OnSdpQueryComplete can gate
+    // Descriptor C injection to v3 (PID 0x0323) only.
+    // v1 (PIDs 0x030D / 0x0310) has a native HID descriptor with RID=0x47
+    // for battery; overwriting it with Descriptor C would break v1 battery.
+    //
+    // Hardware ID format (BT stack):
+    //   BTHENUM\{...}_VID&XXXXXXXX_PID&NNNN_REV&XXXX
+    // We scan for the substring "PID&" and parse the following 4 hex digits.
+    //
+    // IoGetDeviceProperty on the PDO works at PASSIVE_LEVEL (EvtDeviceAdd runs
+    // at PASSIVE_LEVEL), requires no extra allocation handles, and is the
+    // standard WDM approach for lower filter drivers that don't own the PDO.
+    ctx->ProductId = 0;  // safe default: unknown → injection allowed
+    {
+        PDEVICE_OBJECT pdo = WdfDeviceWdmGetPhysicalDevice(device);
+        if (pdo != NULL)
+        {
+            // Hardware ID is a REG_MULTI_SZ; allocate a 512-byte stack buffer.
+            // Typical BT hardware ID strings are well under 256 wide characters.
+            WCHAR hwIdBuf[256] = { 0 };
+            ULONG retLen = 0;
+            NTSTATUS pidStatus = IoGetDeviceProperty(
+                pdo,
+                DevicePropertyHardwareID,
+                sizeof(hwIdBuf) - sizeof(WCHAR),  // leave room for terminator
+                hwIdBuf,
+                &retLen);
+
+            if (NT_SUCCESS(pidStatus) && retLen >= sizeof(WCHAR))
+            {
+                // Scan the MULTI_SZ block (may contain multiple NUL-separated
+                // strings; we search the entire block for "PID&").
+                ULONG wcharCount = retLen / sizeof(WCHAR);
+                for (ULONG i = 0; i + 8 <= wcharCount; i++)
+                {
+                    if (hwIdBuf[i]   == L'P' &&
+                        hwIdBuf[i+1] == L'I' &&
+                        hwIdBuf[i+2] == L'D' &&
+                        hwIdBuf[i+3] == L'&')
+                    {
+                        // Parse up to 4 hex digits immediately following "PID&".
+                        USHORT pid = 0;
+                        for (ULONG j = i + 4; j < wcharCount && j < i + 8; j++)
+                        {
+                            WCHAR  c      = hwIdBuf[j];
+                            USHORT nibble = 0;
+                            if      (c >= L'0' && c <= L'9') nibble = (USHORT)(c - L'0');
+                            else if (c >= L'A' && c <= L'F') nibble = (USHORT)(c - L'A' + 10);
+                            else if (c >= L'a' && c <= L'f') nibble = (USHORT)(c - L'a' + 10);
+                            else break;
+                            pid = (USHORT)((pid << 4) | nibble);
+                        }
+                        ctx->ProductId = pid;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                DbgPrint("M13: AddDevice — IoGetDeviceProperty(HardwareID) status=0x%08X; ProductId stays 0\n",
+                         (ULONG)pidStatus);
+            }
+        }
+        DbgPrint("M13: AddDevice — ProductId=0x%04X\n", ctx->ProductId);
+    }
+
+    // Diagnostic 1 Hz timer (parent = device, fires M13_DiagTimerFunc)
+    WDF_TIMER_CONFIG timerCfg;
+    WDF_TIMER_CONFIG_INIT_PERIODIC(&timerCfg, M13_DiagTimerFunc, 1000);
+    WDF_OBJECT_ATTRIBUTES timerAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&timerAttr);
+    timerAttr.ParentObject = device;
+    status = WdfTimerCreate(&timerCfg, &timerAttr, &ctx->DiagTimer);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    // Work item for PASSIVE_LEVEL registry writes (parent = device)
+    WDF_WORKITEM_CONFIG wiCfg;
+    WDF_WORKITEM_CONFIG_INIT(&wiCfg, M13_DiagWorkItemFunc);
+    WDF_OBJECT_ATTRIBUTES wiAttr;
+    WDF_OBJECT_ATTRIBUTES_INIT(&wiAttr);
+    wiAttr.ParentObject = device;
+    status = WdfWorkItemCreate(&wiCfg, &wiAttr, &ctx->DiagWorkItem);
+    if (!NT_SUCCESS(status)) { return status; }
+
+    WdfTimerStart(ctx->DiagTimer, WDF_REL_TIMEOUT_IN_MS(1000));
+
+    // Default I/O queue — parallel dispatch.
+    // EvtIoDeviceControl: intercept IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE (0x410210)
+    //   sent as IRP_MJ_DEVICE_CONTROL by applewirelessmouse.sys/HidBth.sys.
+    // EvtIoInternalDeviceControl: same intercept via IRP_MJ_INTERNAL_DEVICE_CONTROL
+    //   (covers both dispatch types; only one fires per request).
+    // EvtIoDefault: passthrough for all other IRP types (READ, WRITE, etc.)
+    //   so we don't break the device stack for non-SDP traffic.
+    WDF_IO_QUEUE_CONFIG qCfg;
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&qCfg, WdfIoQueueDispatchParallel);
+    qCfg.EvtIoDeviceControl         = EvtIoDeviceControl;
+    qCfg.EvtIoInternalDeviceControl = EvtIoInternalDeviceControl;
+    qCfg.EvtIoRead                  = EvtIoRead;   // M14: intercept READ completions for RID=0x12 scroll translation
+    qCfg.EvtIoDefault               = EvtIoDefault;
+    WDFQUEUE queue;
+    return WdfIoQueueCreate(device, &qCfg, WDF_NO_OBJECT_ATTRIBUTES, &queue);
+}
+
+// --------------------------------------------------------------------------
+// EvtIoInternalDeviceControl
+//
+// Intercepts IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE (0x410210) and forwards
+// it with a completion routine to rewrite the SDP output buffer.
+// All other IOCTLs pass through send-and-forget.
+// --------------------------------------------------------------------------
+
+VOID
+EvtIoInternalDeviceControl(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request,
+                            _In_ size_t OutputBufferLength, _In_ size_t InputBufferLength,
+                            _In_ ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE    device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    WDFIOTARGET  target = WdfDeviceGetIoTarget(device);
+
+    if (IoControlCode == IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        WdfSpinLockAcquire(ctx->Lock);
+        ctx->IoctlInterceptCount++;
+        WdfSpinLockRelease(ctx->Lock);
+
+        // Forward with our completion routine so we can rewrite the output buffer.
+        WdfRequestFormatRequestUsingCurrentType(Request);
+        WdfRequestSetCompletionRoutine(Request, OnSdpQueryComplete, ctx);
+        if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+        {
+            WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+        }
+        return;
+    }
+
+    // Passthrough — send-and-forget.
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WDF_REQUEST_SEND_OPTIONS opts;
+    WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+    if (!WdfRequestSend(Request, target, &opts))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+// --------------------------------------------------------------------------
+// EvtIoDeviceControl — IRP_MJ_DEVICE_CONTROL intercept
+//
+// IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE is sent by applewirelessmouse.sys
+// via IRP_MJ_DEVICE_CONTROL. Same logic as EvtIoInternalDeviceControl.
+// --------------------------------------------------------------------------
+
+VOID
+EvtIoDeviceControl(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request,
+                   _In_ size_t OutputBufferLength, _In_ size_t InputBufferLength,
+                   _In_ ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE    device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    WDFIOTARGET  target = WdfDeviceGetIoTarget(device);
+
+    if (IoControlCode == IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE &&
+        ctx != NULL && ctx->EnableInjection)
+    {
+        WdfSpinLockAcquire(ctx->Lock);
+        ctx->IoctlInterceptCount++;
+        WdfSpinLockRelease(ctx->Lock);
+
+        WdfRequestFormatRequestUsingCurrentType(Request);
+        WdfRequestSetCompletionRoutine(Request, OnSdpQueryComplete, ctx);
+        if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+        {
+            WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+        }
+        return;
+    }
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WDF_REQUEST_SEND_OPTIONS opts;
+    WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+    if (!WdfRequestSend(Request, target, &opts))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+// --------------------------------------------------------------------------
+// EvtIoDefault — passthrough for all non-IOCTL I/O requests
+//
+// WDF filter drivers with a default queue must explicitly forward any IRP
+// types not otherwise handled (READ, WRITE, etc.) or WDF completes them
+// with STATUS_INVALID_DEVICE_REQUEST, breaking the device.
+// --------------------------------------------------------------------------
+
+VOID
+EvtIoDefault(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request)
+{
+    WDFDEVICE   device = WdfIoQueueGetDevice(Queue);
+    WDFIOTARGET target = WdfDeviceGetIoTarget(device);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WDF_REQUEST_SEND_OPTIONS opts;
+    WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+    if (!WdfRequestSend(Request, target, &opts))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+// --------------------------------------------------------------------------
+// EvtIoRead — M14: intercept IRP_MJ_READ completions
+//
+// Forwards the READ request with OnReadComplete so we can inspect the
+// returned buffer. HidBth fills the buffer with a HID input report on
+// completion; byte[0] is the Report ID.
+// --------------------------------------------------------------------------
+
+VOID
+EvtIoRead(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request, _In_ size_t Length)
+{
+    UNREFERENCED_PARAMETER(Length);
+
+    WDFDEVICE   device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    WDFIOTARGET target = WdfDeviceGetIoTarget(device);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, OnReadComplete, ctx);
+    if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+// --------------------------------------------------------------------------
+// OnReadComplete — M14c: RID 0x12 → RID 0x02 scroll translation completion routine
+//
+// Replaces OnHidReadComplete. Handles IRP_MJ_READ completions:
+//   - Increments HidReadCount (total IRP_MJ_READ completions seen)
+//   - For v3 (PID 0x0323) devices: if buf[0] == 0x12 (MOUSE2_REPORT_ID),
+//     calls TranslateMouse2ToHid() to synthesize a RID 0x02 scroll report
+//   - SEH guard: IOCTL_HID_READ_REPORT may use METHOD_NEITHER buffers;
+//     accessing buf without __try/__except is a Page Fault BSOD vector
+//   - WdfRequestSetInformation: updates returned byte count after translation
+//     (missing = heap corruption in caller)
+// --------------------------------------------------------------------------
+
+VOID
+OnReadComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+               _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    PUCHAR buf    = NULL;
+    SIZE_T bufLen = 0;
+    NTSTATUS rs = WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufLen);
+    if (!NT_SUCCESS(rs) || buf == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // Update diagnostic counters
+    SIZE_T bytesRead = Params->IoStatus.Information;
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->HidReadCount++;
+    if (bytesRead > 0 && bytesRead < bufLen && ((PUCHAR)buf)[0] == 0x12)
+        ctx->Rid12Count++;
+    WdfSpinLockRelease(ctx->Lock);
+
+    // __try/__except required: IOCTL_HID_READ_REPORT may use METHOD_NEITHER buffers.
+    // Accessing buf without SEH is a Page Fault BSOD vector.
+    __try
+    {
+        if (bytesRead >= MM2_HEADER_LEN && ((PUCHAR)buf)[0] == 0x12
+            && ctx->ProductId == MM_PID_V3)
+        {
+            UCHAR  translated[5];
+            ULONG  translatedLen = sizeof(translated);
+            NTSTATUS ts = TranslateMouse2ToHid(
+                (PUCHAR)buf, bytesRead, translated, &translatedLen, ctx);
+            if (NT_SUCCESS(ts) && translatedLen > 0)
+            {
+                RtlCopyMemory(buf, translated, translatedLen);
+                // CRITICAL: update returned byte count (missing = heap corruption)
+                WdfRequestSetInformation(Request, translatedLen);
+            }
+        }
+    }
+    __except(EXCEPTION_EXECUTE_HANDLER)
+    {
+        DbgPrint("M14: OnReadComplete — buffer access exception, passing through\n");
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+// --------------------------------------------------------------------------
+// OnSdpQueryComplete — completion routine for IOCTL 0x410210
+//
+// Retrieves the SDP attribute response buffer, calls SdpRewrite_Process to
+// find and replace the HIDDescriptorList (attribute 0x0206), then completes
+// the request. If rewrite is not applicable (attribute not found, or buffer
+// parse fails), completes with the original unmodified buffer and status.
+// --------------------------------------------------------------------------
+
+VOID
+OnSdpQueryComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+                   _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // METHOD_BUFFERED: output buffer is Irp->AssociatedIrp.SystemBuffer.
+    PVOID  buf         = NULL;
+    size_t bufAllocLen = 0;
+    NTSTATUS rs = WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufAllocLen);
+    if (!NT_SUCCESS(rs) || buf == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // IoStatus.Information = bytes actually written by lower driver.
+    size_t sdpLen = Params->IoStatus.Information;
+    if (sdpLen == 0 || sdpLen > bufAllocLen)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // Snapshot first 64 bytes + buffer size for offline diagnosis.
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->LastSdpBufSize = (ULONG)sdpLen;
+    ULONG snapLen = (sdpLen < 64) ? (ULONG)sdpLen : 64;
+    RtlCopyMemory(ctx->LastSdpBytes, buf, snapLen);
+    if (snapLen < 64) RtlZeroMemory(ctx->LastSdpBytes + snapLen, 64 - snapLen);
+    WdfSpinLockRelease(ctx->Lock);
+
+    // v1 pass-through guard: only inject Descriptor C for v3 (PID 0x0323).
+    // v1 (PIDs 0x030D / 0x0310) has a native HID descriptor with RID=0x47 for
+    // battery; overwriting it with Descriptor C would break v1 battery permanently.
+    // ProductId == 0 means we could not read the PID — allow injection (safe
+    // fallback: preserves behaviour for unknown devices, same as before this guard).
+    if (ctx->ProductId != 0 && ctx->ProductId != MM_PID_V3)
+    {
+        DbgPrint("M13: OnSdpQueryComplete — PID=0x%04X is not v3 (0x%04X), pass-through (no injection)\n",
+                 ctx->ProductId, (USHORT)MM_PID_V3);
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // Attempt descriptor rewrite.
+    ULONG    newLen      = (ULONG)sdpLen;
+    NTSTATUS patchStatus = SdpRewrite_Process((PUCHAR)buf, (ULONG)sdpLen, &newLen);
+
+    // Update diagnostic counters.
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->LastPatchStatus = (ULONG)patchStatus;
+    if (patchStatus == STATUS_SUCCESS)
+    {
+        ctx->SdpScanHits++;
+        ctx->SdpPatchSuccess++;
+    }
+    else if (patchStatus == STATUS_MORE_PROCESSING_REQUIRED)
+    {
+        // Pattern found but patch validation failed.
+        ctx->SdpScanHits++;
+    }
+    // STATUS_NOT_FOUND: no HIDDescriptorList in this buffer — normal, no counter.
+    WdfSpinLockRelease(ctx->Lock);
+
+    // If patch shrunk the buffer, update IoStatus.Information for the caller.
+    if (patchStatus == STATUS_SUCCESS && newLen != (ULONG)sdpLen)
+    {
+        WdfRequestSetInformation(Request, (ULONG_PTR)newLen);
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+// --------------------------------------------------------------------------
+// Diagnostic timer + work item — 1 Hz flush to registry
+//
+// Registry path: HKLM\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag
+//
+// Keys written (read with Get-ItemProperty in PowerShell to verify driver):
+//   IoctlInterceptCount  REG_DWORD  — 0x410210 IOCTLs seen
+//   SdpScanHits          REG_DWORD  — attribute 0x0206 found
+//   SdpPatchSuccess      REG_DWORD  — descriptor replaced successfully
+//   LastSdpBufSize       REG_DWORD  — size of last SDP buffer
+//   LastPatchStatusHex   REG_DWORD  — NTSTATUS of last patch attempt
+//   LastSdpBytes         REG_BINARY — first 64 bytes of last SDP buffer
+//   HidReadCount         REG_DWORD  — M14: total IRP_MJ_READ completions
+//   Rid12Count           REG_DWORD  — M14c: completions where buf[0]==0x12 (MOUSE2)
+//   Rid27Count           REG_DWORD  — legacy: completions where buf[0]==0x27
+//   Rid27LoggedCount     REG_DWORD  — legacy: RID=0x27 reports sent to DbgPrint
+// --------------------------------------------------------------------------
+
+VOID M13_DiagTimerFunc(_In_ WDFTIMER Timer)
+{
+    WDFDEVICE device = (WDFDEVICE)WdfTimerGetParentObject(Timer);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    if (ctx != NULL && ctx->DiagWorkItem != NULL)
+        WdfWorkItemEnqueue(ctx->DiagWorkItem);
+}
+
+VOID M13_DiagWorkItemFunc(_In_ WDFWORKITEM WorkItem)
+{
+    WDFDEVICE device = (WDFDEVICE)WdfWorkItemGetParentObject(WorkItem);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    if (ctx == NULL) return;
+
+    // Snapshot under lock, then write registry at PASSIVE_LEVEL unlocked.
+    ULONG ictlCount, scanHits, patchOk, lastSize, lastStatus;
+    ULONG hidReads, rid12Count, rid27Count, rid27Logged, rid27SlotsFilled;
+    UCHAR lastBytes[64];
+    UCHAR rid27Snapshot[RID27_RING_SLOTS * RID27_BYTES_PER_SLOT];
+    WdfSpinLockAcquire(ctx->Lock);
+    ictlCount     = ctx->IoctlInterceptCount;
+    scanHits      = ctx->SdpScanHits;
+    patchOk       = ctx->SdpPatchSuccess;
+    lastSize      = ctx->LastSdpBufSize;
+    lastStatus    = ctx->LastPatchStatus;
+    hidReads      = ctx->HidReadCount;
+    rid12Count    = ctx->Rid12Count;
+    rid27Count    = ctx->Rid27Count;
+    rid27Logged   = ctx->Rid27LoggedCount;
+    rid27SlotsFilled = (rid27Count < RID27_RING_SLOTS) ? rid27Count : RID27_RING_SLOTS;
+    RtlCopyMemory(lastBytes, ctx->LastSdpBytes, 64);
+    RtlCopyMemory(rid27Snapshot, ctx->Rid27Ring,
+                  RID27_RING_SLOTS * RID27_BYTES_PER_SLOT);
+    WdfSpinLockRelease(ctx->Lock);
+
+    UNICODE_STRING keyPath;
+    RtlInitUnicodeString(&keyPath,
+        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Services\\MagicMouseDriver\\Diag");
+    OBJECT_ATTRIBUTES attr;
+    InitializeObjectAttributes(&attr, &keyPath,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+    HANDLE key   = NULL;
+    ULONG  disp  = 0;
+    if (!NT_SUCCESS(ZwCreateKey(&key, KEY_WRITE, &attr, 0, NULL,
+                                REG_OPTION_NON_VOLATILE, &disp))) return;
+
+    UNICODE_STRING n;
+
+#define SET_DWORD(Name, Val) \
+    RtlInitUnicodeString(&n, Name); \
+    ZwSetValueKey(key, &n, 0, REG_DWORD, &(Val), sizeof(ULONG))
+
+    SET_DWORD(L"IoctlInterceptCount", ictlCount);
+    SET_DWORD(L"SdpScanHits",         scanHits);
+    SET_DWORD(L"SdpPatchSuccess",     patchOk);
+    SET_DWORD(L"LastSdpBufSize",      lastSize);
+    SET_DWORD(L"LastPatchStatusHex",  lastStatus);
+    SET_DWORD(L"HidReadCount",        hidReads);
+    SET_DWORD(L"Rid12Count",          rid12Count);
+    SET_DWORD(L"Rid27Count",          rid27Count);
+    SET_DWORD(L"Rid27LoggedCount",    rid27Logged);
+    SET_DWORD(L"Rid27SlotsFilled",    rid27SlotsFilled);
+
+#undef SET_DWORD
+
+    RtlInitUnicodeString(&n, L"LastSdpBytes");
+    ZwSetValueKey(key, &n, 0, REG_BINARY, lastBytes, 64);
+
+    // Flush RID=0x27 ring buffer so PowerShell can read raw bytes directly
+    // from registry (no DebugView required).
+    // Each slot is RID27_BYTES_PER_SLOT bytes; only rid27SlotsFilled slots valid.
+    RtlInitUnicodeString(&n, L"Rid27RingBuf");
+    ZwSetValueKey(key, &n, 0, REG_BINARY, rid27Snapshot,
+                  RID27_RING_SLOTS * RID27_BYTES_PER_SLOT);
+
+    ZwClose(key);
+}

--- a/v2-kmdf-driver/Driver.h
+++ b/v2-kmdf-driver/Driver.h
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+//
+// M14 — RID=0x27 raw byte capture layer (on top of M13 SDP injection).
+//
+// Stack position (lower filter between BTHENUM and HidBth):
+//   HidClass → HidBth → [M13 (this)] → BTHENUM
+//
+// Mechanism (confirmed 2026-04-30 by Ghidra RE of applewirelessmouse.sys
+// SHA-256 08F33D7E... FUN_14000A440):
+//
+//   Apple's driver intercepts IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE (0x410210)
+//   in a completion routine and rewrites SDP attribute 0x0206 (HIDDescriptorList)
+//   with its own 116-byte descriptor. M13 replicates this mechanism but injects
+//   Descriptor C — RID=0x02 scroll mouse + RID=0x90 vendor battery — giving
+//   both scroll AND battery readout on Magic Mouse 2024 (PID 0x0323).
+//
+// Why M12 failed:
+//   M12 intercepted IOCTL_INTERNAL_BTH_SUBMIT_BRB (0x410003). BRB submits carry
+//   L2CAP connection/transfer traffic but NOT the SDP attribute response that
+//   carries the HID descriptor. The SDP layer is above that. Wrong IOCTL.
+
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+// 'M13D' little-endian — pool tag for all M13 allocations
+#define M13_POOL_TAG 'D31M'
+
+// Known Apple Magic Mouse Bluetooth Product IDs.
+// Used by ProductId PID guard in OnSdpQueryComplete (PR-SS-1).
+#define MM_PID_V3   0x0323u   // Magic Mouse 2024 (USB-C) — Descriptor C target
+#define MM_PID_V1A  0x030Du   // Magic Mouse 2 (Lightning, batch A)
+#define MM_PID_V1B  0x0310u   // Magic Mouse 2 (Lightning, batch B)
+
+// IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE
+// CTL_CODE(FILE_DEVICE_BLUETOOTH=0x41, Function=0x84, METHOD_BUFFERED=0, FILE_ANY_ACCESS=0)
+// Confirmed via RE: FUN_14000A440 checks Irp+0xB8+0x18 (IoControlCode) against this value.
+#define IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE 0x00410210UL
+
+// --------------------------------------------------------------------------
+// Device context — per-device state
+// --------------------------------------------------------------------------
+
+typedef struct _DEVICE_CONTEXT
+{
+    WDFSPINLOCK Lock;   // protects all mutable fields below
+
+    // Configuration: read from Services\MagicMouseDriver\Parameters at AddDevice.
+    // Default TRUE (inject) if Parameters key or value is absent.
+    BOOLEAN EnableInjection;
+
+    // BT Product ID — populated at AddDevice via IoGetDeviceProperty on PDO.
+    // 0x0323 = Magic Mouse 2024 (v3) — receives Descriptor C injection.
+    // 0x030D / 0x0310 = Magic Mouse 2 (v1) — pass through native descriptor.
+    // 0 = unknown (PID could not be read) — injection allowed (safe fallback,
+    //     preserves prior behaviour for any device not positively identified as v1).
+    USHORT  ProductId;
+
+    // Diagnostic counters (inspectable via Services\MagicMouseDriver\Diag).
+    ULONG   IoctlInterceptCount;   // 0x410210 IOCTLs intercepted
+    ULONG   SdpScanHits;           // attribute 0x0206 pattern found in buffer
+    ULONG   SdpPatchSuccess;       // descriptor replacement succeeded
+    ULONG   LastSdpBufSize;        // size of most recent SDP output buffer
+    ULONG   LastPatchStatus;       // NTSTATUS of most recent PatchSdpHidDescriptor
+    UCHAR   LastSdpBytes[64];      // first 64 raw bytes of most recent SDP buffer
+
+    // M14: HID READ intercept counters + ring buffer (flushed to registry by DiagWorkItem)
+    ULONG   HidReadCount;          // total IRP_MJ_READ completions seen
+    ULONG   Rid27Count;            // completions where buf[0] == 0x27
+    ULONG   Rid27LoggedCount;      // how many RID=0x27 reports were DbgPrinted
+
+    // Ring buffer: last 8 RID=0x27 raw reports (48 bytes each).
+    // Work item flushes as Rid27RingBuf REG_BINARY (8×48=384 bytes).
+    // PowerShell reads without needing DebugView.
+#define RID27_RING_SLOTS 8
+#define RID27_BYTES_PER_SLOT 48
+    UCHAR   Rid27Ring[RID27_RING_SLOTS][RID27_BYTES_PER_SLOT];
+    ULONG   Rid27RingNext;         // next write slot (0..7, wraps mod 8)
+
+    // M14: scroll accumulators — persistent across RID 0x12 reports (GestureEngine.c)
+    INT ScrollAccumY;   // accumulated Y delta, reset by SCROLL_THRESHOLD
+    INT ScrollAccumX;   // accumulated X delta (horizontal scroll)
+    ULONG Rid12Count;   // RID 0x12 reports seen (replaces legacy Rid27Count naming)
+
+    WDFTIMER    DiagTimer;         // 1 Hz periodic
+    WDFWORKITEM DiagWorkItem;      // PASSIVE_LEVEL flush to registry
+
+} DEVICE_CONTEXT, *PDEVICE_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext)
+
+// --------------------------------------------------------------------------
+// Function declarations
+// --------------------------------------------------------------------------
+
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_DEVICE_ADD               EvtDeviceAdd;
+EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL EvtIoInternalDeviceControl;
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL      EvtIoDeviceControl;
+EVT_WDF_IO_QUEUE_IO_DEFAULT             EvtIoDefault;
+EVT_WDF_IO_QUEUE_IO_READ                EvtIoRead;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnSdpQueryComplete;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnReadComplete;
+EVT_WDF_TIMER                           M13_DiagTimerFunc;
+EVT_WDF_WORKITEM                        M13_DiagWorkItemFunc;

--- a/v2-kmdf-driver/GestureEngine.c
+++ b/v2-kmdf-driver/GestureEngine.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+// GestureEngine.c — M14: port of Linux hid-magicmouse.c MOUSE2_REPORT_ID handler.
+// Translates RID 0x12 multi-touch surface data into RID 0x02 Wheel events.
+//
+// Source: Linux drivers/hid/hid-magicmouse.c (GPL-2.0+)
+//   magicmouse_raw_event()     lines 461-490  — MOUSE2_REPORT_ID dispatch
+//   magicmouse_emit_touch()    lines 214-360  — per-finger parsing + scroll synthesis
+//   magicmouse_emit_buttons()  lines 177-213  — button state extraction
+//
+// Windows adaptation:
+//   - le16_to_cpu / u16 → USHORT (x64/ARM64 is natively LE, no swap needed)
+//   - input_report_rel(REL_WHEEL) → accumulated in ctx->ScrollAccumY, emitted when
+//     |accum| >= SCROLL_THRESHOLD (threshold same as Linux DEFAULT_SCROLL_ACCELERATION)
+//   - No HID input subsystem — outputs a standard RID 0x02 5-byte mouse report
+//   - Scroll accumulators stored in DEVICE_CONTEXT (per-device, persistent across reports)
+#include "GestureEngine.h"
+
+// RID 0x12 (MOUSE2_REPORT_ID) layout constants (from Linux, confirmed empirically)
+// MM2_HEADER_LEN is defined in GestureEngine.h (shared with Driver.c)
+#define MM2_TOUCH_BYTES  8    // bytes per touch point
+
+// Button state lives in bits [0..2] of byte[1] in the MOUSE2 header
+#define MM2_BTN_MASK     0x07
+
+// RID 0x02 output report layout (standard HID mouse, 5 bytes)
+// [0] = 0x02 (RID), [1] = buttons, [2] = X_lo, [3] = X_hi, [4] = Wheel (signed 8-bit)
+
+// Extract a signed 12-bit coordinate from a 16-bit LE field at buf[offset].
+// Linux pattern (DO NOT use on Windows — le16_to_cpu and u16 don't exist in WDM):
+//   int x = (int)(le16_to_cpu(*(u16*)(data+offset)) & 0x0FFF);
+// Windows equivalent (natively LE on x64/ARM64, no byte swap needed):
+static __forceinline INT
+Mm2Read12(PUCHAR buf, ULONG offset)
+{
+    USHORT raw = *(USHORT*)(buf + offset);   // direct LE read
+    INT val = (INT)(raw & 0x0FFF);           // keep lower 12 bits
+    if (val & 0x0800) val |= (INT)(~0x0FFF); // sign extend from bit 11
+    return val;
+}
+
+// ProcessTouchPoints — accumulate scroll from multi-finger Y delta.
+// Ported from magicmouse_emit_touch() lines 214-360.
+// Returns TRUE if a scroll event should be emitted (accumulated delta >= threshold).
+static BOOLEAN
+ProcessTouchPoints(
+    _In_    PUCHAR          buf,
+    _In_    SIZE_T          inLen,
+    _Inout_ PDEVICE_CONTEXT ctx,
+    _Out_   INT*            outWheelDelta,
+    _Out_   INT*            outHWheelDelta,
+    _Out_   UCHAR*          outButtons)
+{
+    *outWheelDelta  = 0;
+    *outHWheelDelta = 0;
+    *outButtons     = 0;
+
+    if (inLen < MM2_HEADER_LEN) return FALSE;
+
+    // Button state from header byte[1] (magicmouse_emit_buttons equivalent)
+    *outButtons = buf[1] & MM2_BTN_MASK;
+
+    // Touch count from report size: N = (inLen - MM2_HEADER_LEN) / MM2_TOUCH_BYTES
+    ULONG nTouches = (ULONG)((inLen - MM2_HEADER_LEN) / MM2_TOUCH_BYTES);
+    if (nTouches == 0) return FALSE;
+
+    // Accumulate Y and X deltas from all touch points (2-finger scroll tracking).
+    // Linux magicmouse_emit_touch: extracts dx/dy per finger and sums.
+    // Simplified: sum Y changes across all N fingers and divide by N for net gesture.
+    INT sumY = 0;
+    INT sumX = 0;
+    ULONG activeTouches = 0;
+
+    for (ULONG i = 0; i < nTouches; i++)
+    {
+        ULONG touchOffset = MM2_HEADER_LEN + i * MM2_TOUCH_BYTES;
+        if (touchOffset + 4 > inLen) break;  // bounds check
+
+        // 12-bit signed X at touchOffset+0, Y at touchOffset+2
+        INT x = Mm2Read12(buf, touchOffset + 0);
+        INT y = Mm2Read12(buf, touchOffset + 2);
+
+        // Only count fingers that appear to be in contact (rough heuristic:
+        // non-zero position; Linux uses explicit contact state bits but
+        // the simplified approach works for 2-finger scroll detection)
+        if (x != 0 || y != 0)
+        {
+            sumX += x;
+            sumY += y;
+            activeTouches++;
+        }
+    }
+
+    if (activeTouches < 2) return FALSE;  // require at least 2 fingers for scroll
+
+    // Net delta per finger
+    INT netY = sumY / (INT)activeTouches;
+    INT netX = sumX / (INT)activeTouches;
+
+    // Accumulate deltas (persist across reports in device context)
+    ctx->ScrollAccumY += netY;
+    ctx->ScrollAccumX += netX;
+
+    BOOLEAN emit = FALSE;
+
+    // Emit wheel tick when accumulated Y exceeds threshold
+    if (ctx->ScrollAccumY >= SCROLL_THRESHOLD)
+    {
+        *outWheelDelta = 1;
+        ctx->ScrollAccumY -= SCROLL_THRESHOLD;
+        emit = TRUE;
+    }
+    else if (ctx->ScrollAccumY <= -SCROLL_THRESHOLD)
+    {
+        *outWheelDelta = -1;
+        ctx->ScrollAccumY += SCROLL_THRESHOLD;
+        emit = TRUE;
+    }
+
+    // Horizontal wheel (for future use — not yet wired to HWheel output)
+    if (ctx->ScrollAccumX >= SCROLL_THRESHOLD)
+    {
+        *outHWheelDelta = 1;
+        ctx->ScrollAccumX -= SCROLL_THRESHOLD;
+        emit = TRUE;
+    }
+    else if (ctx->ScrollAccumX <= -SCROLL_THRESHOLD)
+    {
+        *outHWheelDelta = -1;
+        ctx->ScrollAccumX += SCROLL_THRESHOLD;
+        emit = TRUE;
+    }
+
+    return emit;
+}
+
+NTSTATUS
+TranslateMouse2ToHid(
+    _In_reads_bytes_(inLen)     PUCHAR in,
+    _In_                        SIZE_T inLen,
+    _Out_writes_bytes_all_(5)   PUCHAR out,
+    _Inout_                     PULONG outLen,
+    _Inout_                     PDEVICE_CONTEXT ctx)
+{
+    *outLen = 0;
+
+    // Minimum size: RID byte + 14-byte MOUSE2 header
+    if (inLen < MM2_HEADER_LEN || in[0] != 0x12) return STATUS_NO_MORE_ENTRIES;
+    if (ctx == NULL) return STATUS_INVALID_PARAMETER;
+
+    INT wheelDelta  = 0;
+    INT hwheelDelta = 0;
+    UCHAR buttons   = 0;
+
+    if (!ProcessTouchPoints(in, inLen, ctx, &wheelDelta, &hwheelDelta, &buttons))
+    {
+        return STATUS_NO_MORE_ENTRIES;  // no scroll this report — pass through
+    }
+
+    // Build RID 0x02 output: [RID][buttons][X_lo][X_hi][Wheel]
+    // X movement from touch surface is handled separately (not synthesized here).
+    out[0] = 0x02;                          // RID
+    out[1] = buttons;                       // button state from header
+    out[2] = 0;                             // X_lo (no cursor movement from scroll)
+    out[3] = 0;                             // X_hi
+    out[4] = (UCHAR)(CHAR)wheelDelta;       // Wheel: signed 8-bit, 1=up/-1=down
+
+    *outLen = 5;
+    return STATUS_SUCCESS;
+}

--- a/v2-kmdf-driver/GestureEngine.h
+++ b/v2-kmdf-driver/GestureEngine.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// GestureEngine.h — M14: RID 0x12 (MOUSE2_REPORT_ID) to RID 0x02 scroll translation.
+// Port of Linux drivers/hid/hid-magicmouse.c magicmouse_emit_touch() +
+// magicmouse_raw_event() MOUSE2 case.
+#pragma once
+#include "Driver.h"
+
+// MM2_HEADER_LEN: minimum valid RID 0x12 (MOUSE2_REPORT_ID) buffer length.
+// Format: 1-byte RID + 13-byte header = 14 bytes with 0 touch points.
+#define MM2_HEADER_LEN 14
+
+// SCROLL_THRESHOLD: accumulated Y (or X) delta required to emit one WM_MOUSEWHEEL tick.
+// Linux default is 256 (in 1/1000 mm units). Start conservative; tune empirically.
+#define SCROLL_THRESHOLD 256
+
+// TranslateMouse2ToHid
+//
+// Translates a RID 0x12 (MOUSE2_REPORT_ID) buffer from v3 multi-touch surface into
+// a standard RID 0x02 mouse report (5 bytes: RID, buttons, X_lo, X_hi, Wheel).
+//
+// in:       RID 0x12 buffer (from IOCTL_HID_READ_REPORT completion)
+// inLen:    buffer length (must be >= 14 for header, 14+8*N for N touch points)
+// out:      caller-supplied 5-byte buffer for RID 0x02 output
+// outLen:   in = sizeof(out) = 5; out = 5 on success, 0 if no scroll this report
+// ctx:      device context (scroll accumulators stored here)
+//
+// Returns STATUS_SUCCESS if translation produced output (outLen=5).
+//         STATUS_NO_MORE_ENTRIES if the report should pass through unchanged (outLen=0).
+NTSTATUS TranslateMouse2ToHid(
+    _In_reads_bytes_(inLen)     PUCHAR in,
+    _In_                        SIZE_T inLen,
+    _Out_writes_bytes_all_(5)   PUCHAR out,
+    _Inout_                     PULONG outLen,
+    _Inout_                     PDEVICE_CONTEXT ctx
+);

--- a/v2-kmdf-driver/HidDescriptor.c
+++ b/v2-kmdf-driver/HidDescriptor.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+//
+// HID report descriptor injected into SDP attribute 0x0206 (HIDDescriptorList).
+//
+// Source: extracted byte-for-byte from Apple's applewirelessmouse.sys
+//   SHA-256 08F33D7E...  offset 0xA850, 116 bytes.
+//   Verified 2026-04-30 by Ghidra RE of FUN_14000A440.
+//
+// Layout (RID=0x02 report — 5 bytes of data after Report ID):
+//   byte[0]  Report ID 0x02
+//   byte[1]  2 buttons (bits 0-1) + 5-bit pad + 1-bit vendor pad (Page FF02)
+//   byte[2]  X delta  INT8 relative
+//   byte[3]  Y delta  INT8 relative
+//   byte[4]  AC Pan   INT8 relative  (Consumer 0x0238, horizontal scroll)
+//   byte[5]  Wheel    INT8 relative  (GD 0x38, vertical scroll)
+//
+// Additional reports (inside same Application collection):
+//   RID=0x47  Feature, 1 byte — Battery Strength 0-100 (GDC page 0x06)
+//   RID=0x27  Input,  46 bytes — Touch/gesture data (GDC page 0x06)
+//
+// Size: Apple's descriptor is 116 bytes. Padded to 135 bytes with reserved
+// zero short items (HID spec §6.2.2.4: size specifier 0 = 0 bytes, tag 0 =
+// reserved, safely ignored by all HID parsers). This matches the native
+// Magic Mouse 2024 SDP HIDDescriptorList descriptor size exactly, so
+// PatchSdpHidDescriptor operates as an in-place swap (delta=0) — no SDP
+// sequence length fields need updating.
+//
+// Why 135 bytes (native size):
+//   The SDP output buffer contains a Windows BTH_SDP_STREAM_RESPONSE header
+//   (8 bytes: requiredSize + responseSize as two LE ULONGs) before the raw
+//   SDP data. PatchSdpHidDescriptor's top-level length fix checks buf[0] for
+//   0x35/0x36, but buf[0] is the first byte of the Windows header (0x09),
+//   not the SDP sequence header (which is at buf[8]). With delta=0 (same
+//   size swap) this fix is never needed — no SDP length fields change.
+
+#include "HidDescriptor.h"
+
+const UCHAR g_HidDescriptor[] = {
+    // ---- Apple's original 116-byte descriptor (from applewirelessmouse.sys 0xA850) ----
+
+    // TLC: Generic Desktop Mouse (0x01/0x02), Report ID 0x02
+    0x05, 0x01,             // Usage Page (Generic Desktop)
+    0x09, 0x02,             // Usage (Mouse)
+    0xA1, 0x01,             // Collection (Application)
+    0x85, 0x02,             //   Report ID (2)
+
+    // 2 buttons — 2 × 1-bit fields
+    0x05, 0x09,             //   Usage Page (Button)
+    0x19, 0x01,             //   Usage Minimum (Button 1)
+    0x29, 0x02,             //   Usage Maximum (Button 2)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0x01,             //   Logical Maximum (1)
+    0x95, 0x02,             //   Report Count (2)
+    0x75, 0x01,             //   Report Size (1)
+    0x81, 0x02,             //   Input (Data, Variable, Absolute)   — 2 bits
+
+    // 5-bit generic padding
+    0x95, 0x01,             //   Report Count (1)
+    0x75, 0x05,             //   Report Size (5)
+    0x81, 0x03,             //   Input (Constant)                   — 5 bits
+
+    // 1-bit vendor padding (page FF02 usage 0x20) — total button byte = 8 bits
+    0x06, 0x02, 0xFF,       //   Usage Page (Vendor 0xFF02)
+    0x09, 0x20,             //   Usage (0x20)
+    0x95, 0x01,             //   Report Count (1)
+    0x75, 0x01,             //   Report Size (1)
+    0x81, 0x03,             //   Input (Constant)                   — 1 bit
+
+    // Pointer: X, Y (INT8 relative)
+    0x05, 0x01,             //   Usage Page (Generic Desktop)
+    0x09, 0x01,             //   Usage (Pointer)
+    0xA1, 0x00,             //   Collection (Physical)
+    0x15, 0x81,             //     Logical Minimum (-127)
+    0x25, 0x7F,             //     Logical Maximum (127)
+    0x09, 0x30,             //     Usage (X)
+    0x09, 0x31,             //     Usage (Y)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x02,             //     Report Count (2)
+    0x81, 0x06,             //     Input (Data, Variable, Relative) — 2 bytes
+
+    // AC Pan (Consumer 0x0238) — horizontal scroll, INT8 relative
+    0x05, 0x0C,             //     Usage Page (Consumer Devices)
+    0x0A, 0x38, 0x02,       //     Usage (AC Pan 0x0238)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x01,             //     Report Count (1)
+    0x81, 0x06,             //     Input (Data, Variable, Relative) — 1 byte
+
+    // Vertical Wheel (GD 0x38) — INT8 relative
+    0x05, 0x01,             //     Usage Page (Generic Desktop)
+    0x09, 0x38,             //     Usage (Wheel)
+    0x75, 0x08,             //     Report Size (8)
+    0x95, 0x01,             //     Report Count (1)
+    0x81, 0x06,             //     Input (Data, Variable, Relative) — 1 byte
+
+    0xC0,                   //   End Collection (Physical)
+
+    // Battery Strength — Feature report RID=0x47 (GDC page 0x06, Usage 0x20)
+    // Read via HidD_GetFeature; value 0-100 = battery percent.
+    0x05, 0x06,             //   Usage Page (Generic Device Controls)
+    0x09, 0x20,             //   Usage (Battery Strength)
+    0x85, 0x47,             //   Report ID (0x47)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x25, 0x64,             //   Logical Maximum (100)
+    0x75, 0x08,             //   Report Size (8)
+    0x95, 0x01,             //   Report Count (1)
+    0xB1, 0xA2,             //   Feature (Data, Var, Abs, NoPreferredState)
+
+    // Touch/gesture input — RID=0x27, 46 bytes (GDC page 0x06, Usage 0x01)
+    // Raw touch surface data; consumed by higher-level gesture processing.
+    0x05, 0x06,             //   Usage Page (Generic Device Controls)
+    0x09, 0x01,             //   Usage (0x01)
+    0x85, 0x27,             //   Report ID (0x27)
+    0x15, 0x01,             //   Logical Minimum (1)
+    0x25, 0x41,             //   Logical Maximum (65)
+    0x75, 0x08,             //   Report Size (8)
+    0x95, 0x2E,             //   Report Count (46)
+    0x81, 0x06,             //   Input (Data, Variable, Relative)   — 46 bytes
+
+    0xC0,                   // End Collection (Application)
+
+    // ---- 19-byte padding to reach 135 bytes (native SDP descriptor size) ----
+    // HID spec §6.2.2.4: size specifier 0 = 0 data bytes, type/tag 0 = reserved.
+    // All compliant HID parsers (HidBth, mouhid, hid.sys) ignore these items.
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00,
+};
+
+const ULONG g_HidDescriptorSize = sizeof(g_HidDescriptor);

--- a/v2-kmdf-driver/HidDescriptor.h
+++ b/v2-kmdf-driver/HidDescriptor.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Driver.h"
+
+// Descriptor C: RID=0x02 scroll mouse TLC + RID=0x90 vendor battery TLC.
+// Injected into SDP attribute 0x0206 (HIDDescriptorList) by M13.
+extern const UCHAR g_HidDescriptor[];
+extern const ULONG g_HidDescriptorSize;

--- a/v2-kmdf-driver/INTAKE.md
+++ b/v2-kmdf-driver/INTAKE.md
@@ -1,0 +1,13 @@
+KMDF sources in this tree were copied from public magic-tray `driver/`
+(HEAD 2a06226) on 2026-09-02.
+
+The existing `README.md` in this directory is the v2 roadmap stub from
+magic-mouse-v3-windows-fix; it was kept. Incoming magic-tray `driver/`
+had no README.md.
+
+Related intake:
+- `keyboard-descriptor-patcher/` ← magic-tray `driver-keyboard/`
+- `driver-test/` ← magic-tray `driver-test/`, plus root `HelloWorld.c`,
+  `BadSample.c`, `tests/`, and `LICENSE-M12`
+- `v2-kmdf-driver/scripts/` ← magic-tray driver-script set (root
+  sign/diagnose/startup-repair scripts and `scripts/` driver helpers)

--- a/v2-kmdf-driver/InputHandler.c
+++ b/v2-kmdf-driver/InputHandler.c
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+//
+// SdpRewrite — SDP attribute 0x0206 (HIDDescriptorList) descriptor injection.
+//
+// Called from OnSdpQueryComplete (Driver.c) after
+// IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE (0x410210) completes. Scans the SDP
+// response buffer for attribute 0x0206 and replaces the embedded HID descriptor
+// with g_HidDescriptor[] (Descriptor C).
+//
+// SDP DataElement wire format (Bluetooth Core Spec Vol 3 Part B §3.3):
+//   Byte 0: type descriptor (upper 5 bits = type, lower 3 bits = size specifier)
+//   Size specifier 5 = 1 additional byte gives element length
+//                  6 = 2 additional bytes (big-endian) give element length
+//
+//   Type 1 (unsigned int): 0x08 = 8-bit, 0x09 = 16-bit (2 BE bytes follow)
+//   Type 4 (sequence):     0x35 = length in next 1 byte, 0x36 = next 2 bytes
+//   Type 2 (string):       0x25 = length in next 1 byte, 0x26 = next 2 bytes
+//
+// Pattern for HIDDescriptorList (attribute 0x0206) with 1-byte sequence headers:
+//   09 02 06    UINT16 attribute ID = 0x0206
+//   35 LL       outer SEQUENCE, 1-byte length (LL = outerPayload)
+//     35 LL     inner SEQUENCE (one {type, descriptor} entry), 1-byte length
+//       08 22   UINT8 value 0x22 = "HID Report Descriptor" type tag
+//       25 NN   TEXT_STRING, 1-byte length (NN = descriptor byte count)
+//         <NN bytes> = HID descriptor
+//
+// The SDP response buffer is the AttributeLists output of the IOCTL — it is
+// itself wrapped in a top-level sequence (either 0x35 or 0x36). Patching
+// updates all four length fields: TEXT_STRING len, inner seq len, outer seq
+// len, AND the top-level AttributeLists sequence length.
+
+#include "InputHandler.h"
+#include "HidDescriptor.h"
+
+// SDP DataElement type descriptor bytes
+#define SDP_TYPE_UINT8   0x08   // unsigned int, 8-bit value
+#define SDP_TYPE_UINT16  0x09   // unsigned int, 16-bit value (2 bytes, big-endian)
+#define SDP_SEQ_1B       0x35   // sequence, 1-byte length follows
+#define SDP_SEQ_2B       0x36   // sequence, 2-byte big-endian length follows
+#define SDP_STR_1B       0x25   // text string, 1-byte length follows
+
+#define HID_DESC_ATTR_HI  0x02  // HIDDescriptorList attribute ID high byte
+#define HID_DESC_ATTR_LO  0x06  // HIDDescriptorList attribute ID low byte
+#define HID_RPT_DESC_TYPE 0x22  // "HID Report Descriptor" type tag value
+
+#define SDP_SCAN_MATCH_LEN 11   // bytes from attr UINT16 header to descriptor body start
+#define SDP_DESC_MAX_LEN  512   // sanity cap on declared descriptor length
+
+// --------------------------------------------------------------------------
+// ScanForSdpHidDescriptor
+//
+// Locates the embedded HID descriptor within an SDP attribute response buffer.
+// Only handles 1-byte-length-prefix sequences (0x35). If the response uses
+// 0x36 (2-byte) length sequences, this returns FALSE. The diagnostic
+// LastSdpBytes key will reveal the actual format so support can be added.
+//
+// On TRUE: *descOffset = byte offset of first descriptor byte,
+//          *descLen    = byte count of the existing descriptor.
+// --------------------------------------------------------------------------
+
+static BOOLEAN
+ScanForSdpHidDescriptor(
+    _In_reads_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG    bufSize,
+    _Out_ PULONG   descOffset,
+    _Out_ PULONG   descLen)
+{
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN) return FALSE;
+    ULONG limit = bufSize - SDP_SCAN_MATCH_LEN;
+
+    for (ULONG i = 0; i <= limit; i++)
+    {
+        // 09 02 06 — UINT16 attribute ID 0x0206 (HIDDescriptorList)
+        if (buf[i]     != SDP_TYPE_UINT16)  continue;
+        if (buf[i + 1] != HID_DESC_ATTR_HI) continue;
+        if (buf[i + 2] != HID_DESC_ATTR_LO) continue;
+
+        // Outer sequence — 1-byte length only
+        if (buf[i + 3] != SDP_SEQ_1B) continue;
+        UCHAR outerLen = buf[i + 4];
+        if (outerLen < 4) continue;
+        if ((ULONG)(i + 5) + outerLen > bufSize) continue;
+
+        // Inner sequence — 1-byte length only
+        if (buf[i + 5] != SDP_SEQ_1B) continue;
+        UCHAR innerLen = buf[i + 6];
+        if (innerLen < 4) continue;
+        if ((ULONG)(i + 7) + innerLen > bufSize) continue;
+
+        // UINT8 0x22 = HID_REPORT_DESCRIPTOR_TYPE
+        if (buf[i + 7] != SDP_TYPE_UINT8)    continue;
+        if (buf[i + 8] != HID_RPT_DESC_TYPE) continue;
+
+        // TEXT_STRING 1-byte length
+        if (buf[i + 9] != SDP_STR_1B) continue;
+        UCHAR nd = buf[i + 10];
+        if (nd == 0 || nd > SDP_DESC_MAX_LEN) continue;
+        if ((ULONG)(i + 11) + nd > bufSize) continue;
+
+        *descOffset = i + 11;
+        *descLen    = (ULONG)nd;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+// --------------------------------------------------------------------------
+// PatchSdpHidDescriptor
+//
+// All-or-nothing: validates all preconditions, then replaces the descriptor
+// body and updates four SDP length fields. Never partially mutates on failure.
+//
+// Fields updated:
+//   buf[descOffset - 1]  TEXT_STRING length byte
+//   buf[descOffset - 5]  inner SEQUENCE length byte
+//   buf[descOffset - 7]  outer SEQUENCE length byte
+//   buf[0..1] or [0..2]  top-level AttributeLists sequence length
+//
+// With Apple's 135-byte descriptor (116 bytes + 19-byte zero padding), delta=0
+// and this function performs an in-place byte swap — no tail shifting, no SDP
+// length field updates needed. STATUS_BUFFER_TOO_SMALL is a safety rail for
+// any future descriptor larger than the native one.
+// --------------------------------------------------------------------------
+
+static NTSTATUS
+PatchSdpHidDescriptor(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG    bufSize,
+    _In_  ULONG    descOffset,
+    _In_  ULONG    descLen,
+    _Out_ PULONG   newBufUsed)
+{
+    // Validate before any mutation.
+    // descOffset = i + 11 (from ScanForSdpHidDescriptor), always >= 11.
+    ASSERT(descOffset >= 11);
+    if (g_HidDescriptorSize == 0) return STATUS_INVALID_PARAMETER;
+
+    ULONG newDescLen   = g_HidDescriptorSize;
+    ULONG innerPayload = 2 + 2 + newDescLen;  // 08 22 + 25 NN + <desc>
+    ULONG outerPayload = 2 + innerPayload;    // 35 LL + inner seq
+
+    if (newDescLen   > 0xFF) return STATUS_INVALID_PARAMETER;
+    if (innerPayload > 0xFF) return STATUS_INVALID_PARAMETER;
+    if (outerPayload > 0xFF) return STATUS_INVALID_PARAMETER;
+
+    ULONG tailOffset = descOffset + descLen;
+    if (tailOffset > bufSize) return STATUS_INVALID_PARAMETER;
+    ULONG tailBytes  = bufSize - tailOffset;
+    ULONG needed     = descOffset + newDescLen + tailBytes;
+    if (needed > bufSize)    return STATUS_BUFFER_TOO_SMALL;
+
+    // Shift tail bytes if sizes differ.
+    if (newDescLen != descLen && tailBytes > 0)
+    {
+        ULONG newTailOffset = descOffset + newDescLen;
+        RtlMoveMemory(buf + newTailOffset, buf + tailOffset, tailBytes);
+    }
+
+    // Zero the gap left by shrinking (keeps buffer clean for diagnostics).
+    if (newDescLen < descLen)
+    {
+        ULONG gapStart = descOffset + newDescLen + tailBytes;
+        ULONG gapLen   = descLen - newDescLen;
+        RtlZeroMemory(buf + gapStart, gapLen);
+    }
+
+    // Place new descriptor.
+    RtlCopyMemory(buf + descOffset, g_HidDescriptor, newDescLen);
+
+    // Fix three innermost SDP length bytes.
+    // Layout relative to descOffset (= match position i + 11):
+    //   [descOffset-1] = buf[i+10] = TEXT_STRING length (0x25 NN)
+    //   [descOffset-5] = buf[i+ 6] = inner SEQUENCE length (0x35 LL)
+    //   [descOffset-7] = buf[i+ 4] = outer SEQUENCE length (0x35 LL)
+    buf[descOffset - 1] = (UCHAR)newDescLen;    // TEXT_STRING len
+    buf[descOffset - 5] = (UCHAR)innerPayload;  // inner SEQUENCE len
+    buf[descOffset - 7] = (UCHAR)outerPayload;  // outer SEQUENCE len
+
+    // Fix the top-level AttributeLists sequence that wraps the entire response.
+    // The SDP ServiceAttributeResponse AttributeLists parameter is itself a
+    // sequence data element starting at buf[0].
+    LONG delta = (LONG)newDescLen - (LONG)descLen;  // negative when shrinking
+    if (bufSize >= 2 && buf[0] == SDP_SEQ_1B)
+    {
+        // 0x35 NN — 1-byte length
+        LONG newTop = (LONG)(UCHAR)buf[1] + delta;
+        if (newTop >= 0 && newTop <= 0xFF)
+            buf[1] = (UCHAR)newTop;
+    }
+    else if (bufSize >= 3 && buf[0] == SDP_SEQ_2B)
+    {
+        // 0x36 HH LL — 2-byte big-endian length
+        USHORT top    = ((USHORT)buf[1] << 8) | (USHORT)buf[2];
+        LONG   newTop = (LONG)top + delta;
+        if (newTop >= 0 && newTop <= 0xFFFF)
+        {
+            buf[1] = (UCHAR)((USHORT)newTop >> 8);
+            buf[2] = (UCHAR)((USHORT)newTop & 0xFF);
+        }
+    }
+
+    *newBufUsed = needed;
+    return STATUS_SUCCESS;
+}
+
+// --------------------------------------------------------------------------
+// SdpRewrite_Process — public entry point
+// --------------------------------------------------------------------------
+
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen)
+{
+    *newLen = bufSize;  // default: no change
+
+    if (buf == NULL || bufSize < SDP_SCAN_MATCH_LEN) return STATUS_INVALID_PARAMETER;
+
+    ULONG descOffset = 0, descLen = 0;
+    if (!ScanForSdpHidDescriptor(buf, bufSize, &descOffset, &descLen))
+    {
+        // Normal for non-HID SDP attribute responses — not an error.
+        return STATUS_NOT_FOUND;
+    }
+
+    DbgPrint("M13: SDP 0x0206 found at buf[%lu], existing desc=%lu B, injecting %lu B\n",
+             descOffset, descLen, g_HidDescriptorSize);
+
+    ULONG    used = 0;
+    NTSTATUS s    = PatchSdpHidDescriptor(buf, bufSize, descOffset, descLen, &used);
+    if (!NT_SUCCESS(s))
+    {
+        DbgPrint("M13: PatchSdpHidDescriptor failed 0x%08X — passthrough unchanged\n", s);
+        return STATUS_MORE_PROCESSING_REQUIRED;  // buffer unmodified; caller passthrough
+    }
+
+    DbgPrint("M13: Patch OK — SDP buffer %lu -> %lu bytes\n", bufSize, used);
+    *newLen = used;
+    return STATUS_SUCCESS;
+}

--- a/v2-kmdf-driver/InputHandler.h
+++ b/v2-kmdf-driver/InputHandler.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// SdpRewrite — SDP attribute 0x0206 (HIDDescriptorList) descriptor injection.
+//
+// Public entry point called from OnSdpQueryComplete (Driver.c) after
+// IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE completes. Scans the SDP response
+// buffer for attribute 0x0206, replaces the embedded HID descriptor with
+// g_HidDescriptor[] (Descriptor C: RID=0x02 scroll + RID=0x90 battery).
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+// SdpRewrite_Process — scan buf[0..bufSize) for SDP attribute 0x0206 and
+// replace the embedded HID descriptor with g_HidDescriptor[].
+//
+// Returns:
+//   STATUS_SUCCESS                 — patch applied; *newLen = new byte count
+//   STATUS_NOT_FOUND               — attribute 0x0206 not present; passthrough
+//   STATUS_MORE_PROCESSING_REQUIRED — pattern found but patch validation failed
+//   STATUS_INVALID_PARAMETER       — buf NULL or bufSize too small to scan
+NTSTATUS
+SdpRewrite_Process(
+    _Inout_updates_bytes_(bufSize) PUCHAR  buf,
+    _In_  ULONG  bufSize,
+    _Out_ PULONG newLen);

--- a/v2-kmdf-driver/MagicMouseDriver.inf
+++ b/v2-kmdf-driver/MagicMouseDriver.inf
@@ -1,0 +1,112 @@
+; MagicMouseDriver.inf  (M13)
+; SPDX-License-Identifier: MIT
+;
+; Installs MagicMouseDriver.sys as a LOWER FILTER on the Apple Magic Mouse 2024
+; BTHENUM HID PDO, sitting between BTHENUM and HidBth.
+;
+; Mechanism (M13): intercepts IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE (0x410210)
+; in a completion routine and rewrites SDP attribute 0x0206 (HIDDescriptorList)
+; with Descriptor C: RID=0x02 scroll mouse + RID=0x90 vendor battery.
+; Confirmed correct by Ghidra RE of Apple's applewirelessmouse.sys (2026-04-30).
+;
+; M12 used IOCTL_INTERNAL_BTH_SUBMIT_BRB (0x410003) — wrong IOCTL. Fixed in M13.
+;
+; Hardware ID: BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+; (Magic Mouse 2024, Bluetooth HID, PID 0x0323)
+;
+; Install (elevated):
+;   pnputil /add-driver MagicMouseDriver.inf /install
+;   (uninstall Apple driver first: pnputil /delete-driver applewirelessmouse.inf /uninstall)
+;
+; Uninstall:
+;   pnputil /delete-driver oem<N>.inf /uninstall /force
+;
+; Verify after re-pair:
+;   Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag"
+;   SdpPatchSuccess > 0 confirms descriptor injection is working.
+
+[Version]
+Signature   = "$WINDOWS NT$"
+Class       = HIDClass
+ClassGUID   = {745A17A0-74D3-11D0-B6FE-00A0C90F57DA}
+Provider    = %ManufacturerName%
+DriverPackageDisplayName = %DeviceDesc%
+DriverPackageType = PlugAndPlay
+DriverVer   = 05/18/2026,2.0.0.0
+CatalogFile = MagicMouseDriver.cat
+PnpLockdown = 1
+
+[DestinationDirs]
+DefaultDestDir = 12
+
+[Manufacturer]
+%ManufacturerName% = MagicMouseDriver, NTamd64
+
+[MagicMouseDriver.NTamd64]
+; Magic Mouse 2024 (v3), VID 0x004C
+%DeviceDesc%    = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+; Magic Mouse (v1) — PID 030D (main) and 0310 (wireless), VID 0x05AC
+%DeviceDescV1%  = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&000105AC_PID&030D
+%DeviceDescV1B% = MagicMouseDriver_Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&000105AC_PID&0310
+
+; ---- Install: delegate function driver to hidbth.inf, copy our filter binary ----
+
+[MagicMouseDriver_Install.NT]
+Include  = hidbth.inf
+Needs    = HIDBTH_Inst.NT
+CopyFiles = MagicMouseDriver_Copy
+
+[MagicMouseDriver_Copy]
+MagicMouseDriver.sys
+
+; ---- HW: add ourselves as lower filter; pull in HID input section from input.inf ----
+
+[MagicMouseDriver_Install.NT.HW]
+AddReg  = MagicMouseDriver_AddReg
+Include = input.inf
+Needs   = HID_Inst.NT.HW
+
+[MagicMouseDriver_AddReg]
+; M13 as sole lower filter on the v3 BTHENUM stack.
+; Intercepts IOCTL 0x410210, rewrites SDP attribute 0x0206 with Descriptor C.
+; Do NOT install alongside applewirelessmouse — whichever is highest in the
+; filter list wins; both trying to inject causes undefined descriptor output.
+HKR,,"LowerFilters",0x00010000,"MagicMouseDriver"
+
+; Default configuration: EnableInjection=1 (can be set to 0 to passthrough for testing)
+HKLM,"SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Parameters","EnableInjection",0x00010001,1
+
+; ---- Services: pull in HidBth's services + add our filter service (no SPSVCINST_ASSOCSERVICE) ----
+
+[MagicMouseDriver_Install.NT.Services]
+; Per applewirelessmouse.inf reference: do NOT specify SPSVCINST_ASSOCSERVICE on
+; filter drivers. The Include/Needs of hidbth.inf provides the function driver
+; service entry (HidBth itself).
+Include    = hidbth.inf
+Needs      = HIDBTH_Inst.NT.Services
+AddService = MagicMouseDriver, , MagicMouseDriver_Service_Inst
+
+[MagicMouseDriver_Service_Inst]
+DisplayName   = %ServiceDesc%
+ServiceType   = 1               ; SERVICE_KERNEL_DRIVER
+StartType     = 3               ; SERVICE_DEMAND_START
+ErrorControl  = 1               ; SERVICE_ERROR_NORMAL
+ServiceBinary = %12%\MagicMouseDriver.sys
+
+; ---- SourceDisks (validator requirement) ----
+
+[SourceDisksNames]
+1 = %DiskName%,,,""
+
+[SourceDisksFiles]
+MagicMouseDriver.sys = 1,,
+
+; ---- Strings ----
+
+[Strings]
+ManufacturerName = "Magic Mouse Driver"
+DeviceDesc       = "Apple Magic Mouse 2024 (M13 SDP filter)"
+DeviceDescV1     = "Apple Magic Mouse (v1)"
+DeviceDescV1B    = "Apple Magic Mouse (v1, wireless)"
+ServiceDesc      = "Magic Mouse Driver M13 (SDP descriptor injection)"
+DiskName         = "Magic Mouse Driver Installation Disk"

--- a/v2-kmdf-driver/MagicMouseDriver.sln
+++ b/v2-kmdf-driver/MagicMouseDriver.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MagicMouseDriver", "MagicMouseDriver.vcxproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/v2-kmdf-driver/MagicMouseDriver.vcxproj
+++ b/v2-kmdf-driver/MagicMouseDriver.vcxproj
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MagicMouseDriver.vcxproj — KMDF Kernel-Mode Driver Project
+  Build with EWDK (Enterprise WDK) standalone environment:
+
+    1. Mount EWDK ISO (no install needed)
+    2. Run: <ISO>\LaunchBuildEnv.cmd
+    3. In the EWDK shell: cd <this directory>
+    4. Build: msbuild MagicMouseDriver.vcxproj /p:Configuration=Debug /p:Platform=x64
+
+  If this .vcxproj does not work with your EWDK version, clone mac-precision-touchpad
+  (https://github.com/roblabla/MacTrackpad) and adapt its project files:
+    - Change TargetName to MagicMouseDriver
+    - Replace source files with Driver.c, HidDescriptor.c, InputHandler.c
+    - Update the INF reference to MagicMouseDriver.inf
+
+  Requires test signing for development:
+    bcdedit /set testsigning on  (run elevated, then reboot once)
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <TargetName>MagicMouseDriver</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <!-- KMDF version — update to match EWDK version (1.33 = Windows 11 22H2) -->
+    <DriverType>KMDF</DriverType>
+    <KmdfVersionMajor>1</KmdfVersionMajor>
+    <KmdfVersionMinor>33</KmdfVersionMinor>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <!-- NOTE: SIGNTASK (WDK inline C# task) calls signtool without /fd sha256.
+         Newer signtool requires /fd sha256 as mandatory and exits non-zero, so
+         SIGNTASK fails and the .sys is deleted. The BackupPreSign target below
+         hooks AfterTargets="Link" to copy the .sys to C:\mm3-presign\ before any
+         signing target runs. mm-dev.ps1 Build phase restores from C:\mm3-presign\
+         if the .sys is missing after msbuild exits. -->
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+      <Driver>WDM</Driver>
+      <AdditionalDependencies>wdmguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="Driver.c" />
+    <ClCompile Include="GestureEngine.c" />
+    <ClCompile Include="HidDescriptor.c" />
+    <ClCompile Include="InputHandler.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Driver.h" />
+    <ClInclude Include="GestureEngine.h" />
+    <ClInclude Include="HidDescriptor.h" />
+    <ClInclude Include="InputHandler.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Inf Include="MagicMouseDriver.inf" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(WDKContentRoot)\build\WindowsDriver.targets"
+          Condition="Exists('$(WDKContentRoot)\build\WindowsDriver.targets')" />
+
+  <!-- Back up the linked .sys right after Link completes, before any WDK signing
+       target deletes it on failure (SIGNTASK /fd sha256 issue on newer signtool).
+       mm-dev.ps1 Build phase restores from C:\mm3-presign\ if .sys is missing. -->
+  <Target Name="BackupPreSign" AfterTargets="Link">
+    <MakeDir Directories="C:\mm3-presign" />
+    <Copy SourceFiles="$(OutDir)$(TargetFileName)"
+          DestinationFiles="C:\mm3-presign\$(TargetFileName)"
+          Condition="Exists('$(OutDir)$(TargetFileName)')" />
+    <Message Text="*** BackupPreSign: $(TargetFileName) → C:\mm3-presign\ ***" Importance="High" />
+  </Target>
+
+</Project>

--- a/v2-kmdf-driver/scripts/build-driver.ps1
+++ b/v2-kmdf-driver/scripts/build-driver.ps1
@@ -1,0 +1,48 @@
+# build-driver.ps1 — Build the KMDF Magic Mouse driver (M13).
+# Standalone: powershell -ExecutionPolicy Bypass -File build-driver.ps1
+# Via queue: BUILD|<nonce>|Release|x64
+#
+# Requires EWDK ISO mounted (task runner mounts it automatically when called via queue).
+# When running standalone, ensure EWDK is mounted first.
+param(
+    [string]$Config   = 'Release',
+    [string]$Platform = 'x64',
+    [string]$SlnPath  = ''
+)
+
+$ErrorActionPreference = 'Continue'
+
+# Ensure queue dir exists for build log
+if (-not (Test-Path 'C:\mm-dev-queue')) {
+    New-Item -ItemType Directory -Force -Path 'C:\mm-dev-queue' | Out-Null
+}
+
+$ewdkSetup = $null
+foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+    $c = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+    if (Test-Path $c) { $ewdkSetup = $c; break }
+}
+
+if (-not $ewdkSetup) {
+    Write-Error "EWDK not found on any mounted drive. Mount the EWDK ISO first."
+    exit 1
+}
+
+if (-not $SlnPath) {
+    # Default to WSL2 path — requires WSL2 to be running
+    $SlnPath = '\\wsl.localhost\Ubuntu\home\lesley\projects\magic-mouse-tray\driver\MagicMouseDriver.sln'
+}
+
+if (-not (Test-Path $SlnPath)) {
+    Write-Error "Solution not found: $SlnPath"
+    exit 2
+}
+
+$buildLog = 'C:\mm-dev-queue\build-standalone.log'
+$cmdLine = '"' + $ewdkSetup + '" && msbuild "' + $SlnPath + '" /m /nr:false /v:minimal /p:Configuration=' + $Config + ' /p:Platform=' + $Platform + ' /p:RunCodeAnalysis=false /p:SignMode=Off'
+Write-Host "Building: $SlnPath ($Config|$Platform)"
+"=== $cmdLine ===" | Set-Content $buildLog -Encoding ASCII
+& cmd.exe /c $cmdLine 2>&1 | Add-Content $buildLog -Encoding ASCII
+$rc = $LASTEXITCODE
+Write-Host "Build exited $rc. Log: $buildLog"
+exit $rc

--- a/v2-kmdf-driver/scripts/build-driver.ps1
+++ b/v2-kmdf-driver/scripts/build-driver.ps1
@@ -1,4 +1,4 @@
-# build-driver.ps1 — Build the KMDF Magic Mouse driver (M13).
+# build-driver.ps1 - Build the KMDF Magic Mouse driver (M13).
 # Standalone: powershell -ExecutionPolicy Bypass -File build-driver.ps1
 # Via queue: BUILD|<nonce>|Release|x64
 #
@@ -29,7 +29,7 @@ if (-not $ewdkSetup) {
 }
 
 if (-not $SlnPath) {
-    # Default to WSL2 path — requires WSL2 to be running
+    # Default to WSL2 path - requires WSL2 to be running
     $SlnPath = '\\wsl.localhost\Ubuntu\home\lesley\projects\magic-mouse-tray\driver\MagicMouseDriver.sln'
 }
 

--- a/v2-kmdf-driver/scripts/check-style.sh
+++ b/v2-kmdf-driver/scripts/check-style.sh
@@ -1,0 +1,667 @@
+#!/usr/bin/env bash
+# scripts/check-style.sh
+# M12 Style-Guide Enforcer — AI-tell detector and commit/PR gate.
+#
+# Usage:
+#   check-style.sh [--files file1 file2 ...]   # scan specific files
+#   check-style.sh [--diff]                    # scan files changed in current git diff (staged + unstaged)
+#   check-style.sh [--staged]                  # scan only staged files
+#   check-style.sh [--branch <branch>]         # scan files changed vs given branch
+#
+# Outputs:
+#   style-results.json     — structured violations (in repo root)
+#   style-report.md        — human-readable for PR comments (in repo root)
+#
+# Exit codes:
+#   0 = pass (no hard-fail violations)
+#   1 = fail (one or more hard-reject violations)
+#
+# Checks:
+#   1. Comment density (>25% => REJECT)
+#   2. TODO/FIXME/HACK/XXX in diff (=> REJECT)
+#   3. Generic identifier names (=> FLAG)
+#   4. Mixed casing styles in same file (=> REJECT)
+#   5. Over-defensive null checks after _In_ params (=> WARN)
+#   6. Helper functions with <3 callers (=> FLAG)
+#   7. Pool tag presence (not 'M12 ' => REJECT)
+#   8. clang-format compliance (=> REJECT)
+#
+# Severity legend:
+#   REJECT  — hard fail; blocks commit/PR; exit 1
+#   FLAG    — soft; surfaced in report but does not block alone
+#   WARN    — advisory; informational only
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || echo "$(dirname "$0")/..")"
+RESULTS_JSON="$REPO_ROOT/style-results.json"
+RESULTS_MD="$REPO_ROOT/style-report.md"
+CLANG_FORMAT_CFG="$REPO_ROOT/driver/.clang-format"
+
+# ---- timestamp (Calgary / Mountain) ----
+if command -v python3 >/dev/null 2>&1; then
+    TIMESTAMP=$(python3 -c "
+import datetime, zoneinfo
+tz = zoneinfo.ZoneInfo('America/Edmonton')
+print(datetime.datetime.now(tz).strftime('%Y-%m-%d %H:%M %Z'))
+" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+else
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+fi
+
+# ---- argument parsing ----
+MODE="diff"
+FILES=()
+BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --files)
+            MODE="files"
+            shift
+            while [[ $# -gt 0 && "$1" != --* ]]; do
+                FILES+=("$1")
+                shift
+            done
+            ;;
+        --diff)
+            MODE="diff"
+            shift
+            ;;
+        --staged)
+            MODE="staged"
+            shift
+            ;;
+        --branch)
+            MODE="branch"
+            BRANCH="${2:-main}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ---- collect target files ----
+collect_files() {
+    local -n _out=$1
+    case "$MODE" in
+        files)
+            _out=("${FILES[@]}")
+            ;;
+        diff)
+            mapfile -t _out < <(git -C "$REPO_ROOT" diff --name-only HEAD 2>/dev/null | grep -E '\.(c|h)$' || true)
+            # also include staged
+            local staged=()
+            mapfile -t staged < <(git -C "$REPO_ROOT" diff --name-only --cached 2>/dev/null | grep -E '\.(c|h)$' || true)
+            for f in "${staged[@]}"; do
+                local found=false
+                for e in "${_out[@]}"; do [[ "$e" == "$f" ]] && found=true && break; done
+                $found || _out+=("$f")
+            done
+            ;;
+        staged)
+            mapfile -t _out < <(git -C "$REPO_ROOT" diff --name-only --cached 2>/dev/null | grep -E '\.(c|h)$' || true)
+            ;;
+        branch)
+            mapfile -t _out < <(git -C "$REPO_ROOT" diff --name-only "${BRANCH}...HEAD" 2>/dev/null | grep -E '\.(c|h)$' || true)
+            ;;
+    esac
+
+    # resolve to absolute paths; skip non-existent
+    local resolved=()
+    for f in "${_out[@]}"; do
+        local abs_f
+        if [[ "$f" = /* ]]; then
+            abs_f="$f"
+        else
+            abs_f="$REPO_ROOT/$f"
+        fi
+        [[ -f "$abs_f" ]] && resolved+=("$abs_f")
+    done
+    _out=("${resolved[@]}")
+}
+
+declare -a TARGET_FILES=()
+collect_files TARGET_FILES
+
+# ---- violation tracking ----
+# Senior-dev review CRIT-3: previous heredoc-based JSON accumulator broke on
+# apostrophes / quotes in detail strings (e.g. "doesn't", common in English
+# comments). Now we write each violation as one JSONL line to a temp file via
+# Python argv (no shell interpolation into Python source); consolidate in
+# a single final pass. Eliminates injection class entirely.
+VIOLATIONS_JSONL=$(mktemp -t mm-style-violations.XXXXXX.jsonl)
+trap 'rm -f "$VIOLATIONS_JSONL"' EXIT
+HAS_REJECT=false
+
+add_violation() {
+    local file="$1" check="$2" severity="$3" line="$4" detail="$5"
+    # Pass strings via argv — Python sees them as bytes-literal string objects
+    # so any single/double-quote, backslash, or $-sign in detail is benign.
+    python3 -c '
+import json, sys
+out = sys.argv[1]
+record = {
+    "file": sys.argv[2],
+    "check": sys.argv[3],
+    "severity": sys.argv[4],
+    "line": sys.argv[5],
+    "detail": sys.argv[6],
+}
+with open(out, "a") as f:
+    f.write(json.dumps(record) + "\n")
+' "$VIOLATIONS_JSONL" "$file" "$check" "$severity" "$line" "$detail"
+    if [[ "$severity" == "REJECT" ]]; then
+        HAS_REJECT=true
+    fi
+}
+
+# ---- helper: portable line count ----
+count_lines() {
+    wc -l < "$1" | tr -d ' '
+}
+
+# ---- CHECK 1: Comment density ----
+# Ratio of comment lines (// or /* ... */) to non-blank code lines.
+# Reject if >25%.
+check_comment_density() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    local result
+    result=$(python3 - "$file" <<'PYEOF'
+import sys, re
+
+file = sys.argv[1]
+with open(file, 'r', errors='replace') as f:
+    lines = f.readlines()
+
+comment_lines = 0
+code_lines = 0
+in_block = False
+
+for raw in lines:
+    line = raw.strip()
+    if not line:
+        continue
+    if in_block:
+        comment_lines += 1
+        if '*/' in line:
+            in_block = False
+        continue
+    if line.startswith('//'):
+        comment_lines += 1
+        continue
+    if '/*' in line:
+        comment_lines += 1
+        if '*/' not in line.split('/*', 1)[1]:
+            in_block = True
+        continue
+    code_lines += 1
+
+total = comment_lines + code_lines
+if total == 0:
+    ratio = 0.0
+else:
+    ratio = comment_lines / total
+
+print(f"{comment_lines} {code_lines} {ratio:.4f}")
+PYEOF
+)
+
+    local comment_lines code_lines ratio
+    read -r comment_lines code_lines ratio <<< "$result"
+
+    # compare with python for portability
+    local reject
+    reject=$(python3 -c "print('yes' if float('$ratio') > 0.25 else 'no')")
+
+    if [[ "$reject" == "yes" ]]; then
+        local pct
+        pct=$(python3 -c "print(f'{float(\"$ratio\")*100:.1f}')")
+        add_violation "$rel_file" "comment-density" "REJECT" "-" \
+            "Comment ratio ${pct}% exceeds 25% limit (${comment_lines} comment lines / $((comment_lines + code_lines)) total). Microsoft samples run 5-15%."
+    fi
+}
+
+# ---- CHECK 2: TODO/FIXME/HACK/XXX ----
+# Grep raw diff for these markers.
+check_todo_fixme() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    # grep returns non-zero when no match; suppress that
+    local matches
+    matches=$(grep -n -E '\b(TODO|FIXME|HACK|XXX)\b' "$file" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+        while IFS= read -r match_line; do
+            local lineno="${match_line%%:*}"
+            local content="${match_line#*:}"
+            add_violation "$rel_file" "todo-fixme" "REJECT" "$lineno" \
+                "Found marker in code: ${content// /,}. Open a tracked issue instead."
+        done <<< "$matches"
+    fi
+}
+
+# ---- CHECK 3: Generic identifier names ----
+# Pattern: common AI-tell names used as identifiers.
+# FLAG (not reject) — context-dependent.
+check_generic_names() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    local pattern='\b(helper|util|data|buffer|temp|tmp|dummy|placeholder|var)[0-9]*\b'
+    local matches
+    matches=$(grep -n -E "$pattern" "$file" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+        while IFS= read -r match_line; do
+            local lineno="${match_line%%:*}"
+            local content="${match_line#*:}"
+            # skip if it appears inside a string literal (heuristic: in quotes)
+            if echo "$content" | grep -qE '"[^"]*'"$pattern"'[^"]*"' 2>/dev/null; then
+                continue
+            fi
+            local word
+            word=$(echo "$content" | grep -oE "$pattern" | head -1)
+            add_violation "$rel_file" "generic-name" "FLAG" "$lineno" \
+                "Generic identifier '${word}' detected. Use domain-specific WDF/HID terms (reqContext, devCtx, batteryStatus, etc.)."
+        done <<< "$matches"
+    fi
+}
+
+# ---- CHECK 4: Mixed casing styles in same file ----
+# Detect presence of BOTH snake_case tokens AND camelCase tokens.
+# We look at non-preprocessor identifiers only.
+check_mixed_casing() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    local result
+    result=$(python3 - "$file" <<'PYEOF'
+import sys, re
+
+file = sys.argv[1]
+with open(file, 'r', errors='replace') as f:
+    src = f.read()
+
+# Strip string literals and comments for cleaner analysis
+src = re.sub(r'"(?:[^"\\]|\\.)*"', '', src)
+src = re.sub(r"'(?:[^'\\]|\\.)*'", '', src)
+src = re.sub(r'//[^\n]*', '', src)
+src = re.sub(r'/\*.*?\*/', '', src, flags=re.DOTALL)
+# Strip preprocessor directives
+src = re.sub(r'^\s*#[^\n]*', '', src, flags=re.MULTILINE)
+
+# Extract identifiers
+idents = re.findall(r'\b[A-Za-z_][A-Za-z0-9_]{2,}\b', src)
+
+has_snake = False
+has_camel = False
+
+for ident in idents:
+    # Skip all-caps (constants/macros), all-lower with no underscore, WDF prefixes
+    if ident.isupper():
+        continue
+    if re.match(r'^(NTSTATUS|BOOLEAN|PVOID|ULONG|UCHAR|USHORT|VOID|TRUE|FALSE|NULL|PDRIVER_OBJECT|PUNICODE_STRING|WDFDRIVER|WDFDEVICE|WDFREQUEST|WDFQUEUE|WDFTIMER|WDFWORKITEM|WDFMEMORY|WDFIOTARGET|WDFFILEOBJECT|WDFUSBDEVICE|WDFUSBPIPE|STATUS_SUCCESS|STATUS_PENDING|STATUS_UNSUCCESSFUL)$', ident):
+        continue
+    # snake_case: has underscore and lower letters around it
+    if '_' in ident and re.search(r'[a-z]_[a-z]', ident):
+        has_snake = True
+    # camelCase: lowercase followed immediately by uppercase (not after underscore)
+    if re.search(r'[a-z][A-Z]', ident):
+        has_camel = True
+    if has_snake and has_camel:
+        break
+
+print('mixed' if (has_snake and has_camel) else 'ok')
+PYEOF
+)
+
+    if [[ "$result" == "mixed" ]]; then
+        add_violation "$rel_file" "mixed-casing" "REJECT" "-" \
+            "File mixes snake_case and camelCase identifiers. Kernel driver files must use one consistent style (WDF convention: camelCase for locals, PascalCase for types, M12Prefix for functions)."
+    fi
+}
+
+# ---- CHECK 5: Over-defensive null checks after _In_ params ----
+# Pattern: function with _In_ annotated parameter, followed closely by
+#   if (param == NULL) return STATUS_INVALID_PARAMETER;
+# This is flagged as soft WARN — DV proves _In_ is never NULL at entry.
+check_defensive_null() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    local result
+    result=$(python3 - "$file" <<'PYEOF'
+import sys, re
+
+file = sys.argv[1]
+with open(file, 'r', errors='replace') as f:
+    lines = f.readlines()
+
+# Find _In_ annotated parameter names from function signatures
+in_params = []
+in_func_sig = False
+brace_depth = 0
+sig_lines = []
+
+findings = []
+
+for i, line in enumerate(lines, 1):
+    # Collect potential function signature lines (up to opening brace)
+    stripped = line.strip()
+    # Simple heuristic: look for _In_ in a line with a type pattern
+    if re.search(r'_In_\s+\w+\s+\*?\s*(\w+)', line):
+        m = re.findall(r'_In_\s+\w+[\w\s\*]*\s+\*?\s*(\w+)\s*[,\)]', line)
+        for param in m:
+            in_params.append((param, i))
+
+# For each _In_ param, look for null check within 20 lines
+for param, param_line in in_params:
+    search_start = param_line
+    search_end = min(param_line + 20, len(lines) + 1)
+    for j in range(search_start, search_end):
+        chk_line = lines[j - 1] if j <= len(lines) else ''
+        # Pattern: if (X == NULL) return STATUS_INVALID_PARAMETER
+        if re.search(rf'if\s*\(\s*{re.escape(param)}\s*==\s*NULL\s*\)', chk_line):
+            if re.search(r'STATUS_INVALID_PARAMETER', chk_line) or (
+                j < len(lines) and re.search(r'STATUS_INVALID_PARAMETER', lines[j])
+            ):
+                findings.append(f"{j}:{param}")
+                break
+
+for f in findings:
+    print(f)
+PYEOF
+)
+
+    if [[ -n "$result" ]]; then
+        while IFS= read -r hit; do
+            local lineno="${hit%%:*}"
+            local param="${hit#*:}"
+            add_violation "$rel_file" "defensive-null-check" "WARN" "$lineno" \
+                "Null check on _In_ parameter '${param}': DV guarantees _In_ is non-NULL at entry. Use NT_ASSERT for debug-mode validation only; remove the runtime check."
+        done <<< "$result"
+    fi
+}
+
+# ---- CHECK 6: Helper function with <3 callers ----
+# Identify static functions and count their call sites within the file.
+# Functions called <3 times are flagged for review (DRY threshold).
+check_helper_callers() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    local result
+    result=$(python3 - "$file" <<'PYEOF'
+import sys, re
+
+file = sys.argv[1]
+with open(file, 'r', errors='replace') as f:
+    src = f.read()
+lines = src.splitlines()
+
+# Find static function definitions (non-WDF-callback, non-entry-point)
+# Pattern: static <type> <FunctionName>(
+static_funcs = []
+for i, line in enumerate(lines, 1):
+    m = re.match(r'\s*(?:_\w+_\s+)*static\s+\w[\w\s\*]+\s+(\w+)\s*\(', line)
+    if m:
+        name = m.group(1)
+        # Skip well-known framework entry points that should have 1 caller
+        if re.match(r'^(DriverEntry|EvtDriver|EvtDevice|EvtIo|EvtTimer|EvtWorkItem|EvtFile)', name):
+            continue
+        static_funcs.append((name, i))
+
+# Count call sites (calls, not the definition line)
+findings = []
+for name, def_line in static_funcs:
+    # Match name followed by ( but not in a declaration/definition context
+    call_pattern = re.compile(r'\b' + re.escape(name) + r'\s*\(')
+    call_sites = []
+    for i, line in enumerate(lines, 1):
+        if i == def_line:
+            continue  # skip the definition line itself
+        if call_pattern.search(line):
+            call_sites.append(i)
+    if 0 < len(call_sites) < 3:
+        findings.append(f"{def_line}:{name}:{len(call_sites)}")
+
+for f in findings:
+    print(f)
+PYEOF
+)
+
+    if [[ -n "$result" ]]; then
+        while IFS= read -r hit; do
+            IFS=: read -r lineno fname callers <<< "$hit"
+            add_violation "$rel_file" "helper-few-callers" "FLAG" "$lineno" \
+                "Static function '${fname}' has only ${callers} caller(s). DRY threshold is 3+. Inline unless growth is planned; document rationale if kept."
+        done <<< "$result"
+    fi
+}
+
+# ---- CHECK 7: Pool tag presence ----
+# Every ExAllocatePoolWithTag / WdfMemoryCreate must use tag 'M12 '.
+# Any other tag => REJECT.
+check_pool_tags() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    local result
+    result=$(python3 - "$file" <<'PYEOF'
+import sys, re
+
+file = sys.argv[1]
+with open(file, 'r', errors='replace') as f:
+    lines = f.readlines()
+
+# Patterns for pool allocation calls that take a tag argument
+alloc_patterns = [
+    # ExAllocatePoolWithTag(type, size, tag)
+    re.compile(r'\bExAllocatePoolWithTag\s*\([^)]*?,\s*[^)]*?,\s*([^)]+?)\s*\)'),
+    # ExAllocatePool2(flags, size, tag)
+    re.compile(r'\bExAllocatePool2\s*\([^)]*?,\s*[^)]*?,\s*([^)]+?)\s*\)'),
+    # WdfMemoryCreate(Attributes, PoolType, PoolTag, BufferSize, ...) — PoolTag is 3rd arg
+    # Senior-dev review MAJ-2: original regex consumed 3 commas before the capture, hitting
+    # the 4th arg (BufferSize). Reduced to 2 leading args so we capture the 3rd (PoolTag).
+    re.compile(r'\bWdfMemoryCreate\s*\([^)]*?,\s*[^)]*?,\s*([^)]+?)\s*,'),
+]
+
+EXPECTED_TAG = "'M12 '"  # four chars: M, 1, 2, space
+
+findings = []
+for i, line in enumerate(lines, 1):
+    for pat in alloc_patterns:
+        m = pat.search(line)
+        if m:
+            tag_expr = m.group(1).strip()
+            # Accept 'M12 ' or the equivalent hex or a named constant that contains M12
+            if tag_expr in ("'M12 '", '"M12 "') or 'M12' in tag_expr:
+                continue
+            findings.append(f"{i}:{tag_expr}")
+
+for f in findings:
+    print(f)
+PYEOF
+)
+
+    if [[ -n "$result" ]]; then
+        while IFS= read -r hit; do
+            local lineno="${hit%%:*}"
+            local tag="${hit#*:}"
+            add_violation "$rel_file" "pool-tag" "REJECT" "$lineno" \
+                "Pool allocation uses tag '${tag}' instead of required 'M12 '. All M12 driver allocations must carry the project pool tag."
+        done <<< "$result"
+    fi
+}
+
+# ---- CHECK 8: clang-format compliance ----
+# Invoke clang-format --dry-run --Werror. Failure => REJECT.
+check_clang_format() {
+    local file="$1"
+    local rel_file="${file#$REPO_ROOT/}"
+
+    if ! command -v clang-format >/dev/null 2>&1; then
+        # clang-format not installed — soft WARN, do not block
+        add_violation "$rel_file" "clang-format" "WARN" "-" \
+            "clang-format not found in PATH. Install clang-format and re-run to validate formatting against WDF preset."
+        return
+    fi
+
+    local cfg_flag=""
+    if [[ -f "$CLANG_FORMAT_CFG" ]]; then
+        cfg_flag="--style=file:${CLANG_FORMAT_CFG}"
+    else
+        # Fallback: inline the WDF preset
+        cfg_flag='--style={BasedOnStyle: Microsoft, IndentWidth: 4, ColumnLimit: 100, AllowShortIfStatementsOnASingleLine: false, AllowShortLoopsOnASingleLine: false, DerivePointerAlignment: false, PointerAlignment: Right, SortIncludes: false}'
+    fi
+
+    local output
+    local exit_code=0
+    # shellcheck disable=SC2086
+    output=$(clang-format --dry-run --Werror $cfg_flag "$file" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        # Truncate output for readability
+        local short_output="${output:0:300}"
+        add_violation "$rel_file" "clang-format" "REJECT" "-" \
+            "clang-format reports formatting violations. Run: clang-format ${cfg_flag} -i ${rel_file}. Output: ${short_output//
+/; }"
+    fi
+}
+
+# ---- run all checks on each file ----
+if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
+    echo "check-style: no .c/.h files found for mode '${MODE}'" >&2
+    echo "  (nothing to check -- pass)" >&2
+    # Still write empty pass outputs
+    python3 - "$RESULTS_JSON" "$RESULTS_MD" "$TIMESTAMP" <<'PYEOF'
+import json, sys
+results_json, results_md, ts = sys.argv[1], sys.argv[2], sys.argv[3]
+
+summary = {"timestamp": ts, "files_checked": 0, "violations": [], "verdict": "PASS"}
+with open(results_json, 'w') as f:
+    json.dump(summary, f, indent=2)
+
+with open(results_md, 'w') as f:
+    f.write(f"# M12 Style Report\n\n**{ts}** | Files checked: 0 | Verdict: **PASS**\n\nNo .c/.h files in scope.\n")
+PYEOF
+    exit 0
+fi
+
+for f in "${TARGET_FILES[@]}"; do
+    echo "check-style: scanning ${f#$REPO_ROOT/} ..."
+    check_comment_density "$f"
+    check_todo_fixme "$f"
+    check_generic_names "$f"
+    check_mixed_casing "$f"
+    check_defensive_null "$f"
+    check_helper_callers "$f"
+    check_pool_tags "$f"
+    check_clang_format "$f"
+done
+
+# ---- produce outputs ----
+python3 - "$RESULTS_JSON" "$RESULTS_MD" "$TIMESTAMP" "$HAS_REJECT" "$VIOLATIONS_JSONL" <<'PYEOF'
+import json, sys
+
+results_json = sys.argv[1]
+results_md = sys.argv[2]
+ts = sys.argv[3]
+has_reject_str = sys.argv[4]
+violations_jsonl = sys.argv[5]
+has_reject = has_reject_str == 'true'
+
+violations = []
+try:
+    with open(violations_jsonl, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                violations.append(json.loads(line))
+except FileNotFoundError:
+    violations = []
+except Exception:
+    violations = []
+
+verdict = "FAIL" if has_reject else "PASS"
+
+# Count by severity
+rejects = [v for v in violations if v['severity'] == 'REJECT']
+flags   = [v for v in violations if v['severity'] == 'FLAG']
+warns   = [v for v in violations if v['severity'] == 'WARN']
+
+# ---- JSON output ----
+summary = {
+    "timestamp": ts,
+    "files_checked": len(set(v['file'] for v in violations)) if violations else 0,
+    "verdict": verdict,
+    "counts": {
+        "REJECT": len(rejects),
+        "FLAG": len(flags),
+        "WARN": len(warns),
+        "total": len(violations)
+    },
+    "violations": violations
+}
+with open(results_json, 'w') as f:
+    json.dump(summary, f, indent=2)
+
+# ---- Markdown output ----
+verdict_badge = "FAIL -- commit blocked" if has_reject else "PASS"
+lines = [
+    "# M12 Style-Guide Report",
+    "",
+    f"**Generated:** {ts}  ",
+    f"**Verdict:** **{verdict_badge}**  ",
+    f"**Violations:** {len(rejects)} REJECT / {len(flags)} FLAG / {len(warns)} WARN",
+    "",
+]
+
+if rejects:
+    lines += ["## Hard failures (REJECT -- must fix before commit/PR)", ""]
+    for v in rejects:
+        lines.append(f"- **[{v['check']}]** \`{v['file']}\` line {v['line']}: {v['detail']}")
+    lines.append("")
+
+if flags:
+    lines += ["## Soft flags (FLAG -- review required)", ""]
+    for v in flags:
+        lines.append(f"- **[{v['check']}]** \`{v['file']}\` line {v['line']}: {v['detail']}")
+    lines.append("")
+
+if warns:
+    lines += ["## Advisory warnings (WARN -- informational)", ""]
+    for v in warns:
+        lines.append(f"- **[{v['check']}]** \`{v['file']}\` line {v['line']}: {v['detail']}")
+    lines.append("")
+
+if not violations:
+    lines += ["## All checks passed", "", "No violations detected."]
+
+lines += [
+    "",
+    "---",
+    "<!-- Generated by scripts/check-style.sh -->",
+]
+
+with open(results_md, 'w') as f:
+    f.write('\n'.join(lines) + '\n')
+
+print(f"check-style: verdict={verdict} | REJECT={len(rejects)} FLAG={len(flags)} WARN={len(warns)}")
+print(f"  -> {results_json}")
+print(f"  -> {results_md}")
+PYEOF
+
+# ---- exit code ----
+if [[ "$HAS_REJECT" == "true" ]]; then
+    echo "check-style: FAIL -- one or more REJECT violations found. See style-report.md." >&2
+    exit 1
+fi
+
+echo "check-style: PASS"
+exit 0

--- a/v2-kmdf-driver/scripts/diagnose-driver.ps1
+++ b/v2-kmdf-driver/scripts/diagnose-driver.ps1
@@ -1,0 +1,140 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Apple Wireless Mouse driver diagnostic script.
+    Run from PowerShell as Administrator.
+#>
+
+$driverName = "applewirelessmouse"
+$sysFile    = "C:\Windows\System32\drivers\$driverName.sys"
+$logFile    = "$env:USERPROFILE\Desktop\apple-mouse-diag.txt"
+
+function Write-Log {
+    param([string]$text)
+    $line = "[$(Get-Date -Format 'HH:mm:ss')] $text"
+    Write-Host $line
+    Add-Content -Path $logFile -Value $line
+}
+
+function Write-Section {
+    param([string]$title)
+    $bar = "=" * 60
+    Write-Log ""
+    Write-Log $bar
+    Write-Log "  $title"
+    Write-Log $bar
+}
+
+# Start fresh log
+"" | Set-Content $logFile
+Write-Log "Apple Wireless Mouse Driver Diagnostic"
+Write-Log "Date: $(Get-Date)"
+
+# ── 1. Driver .sys file ──────────────────────────────────────
+Write-Section "1. Driver .sys file"
+if (Test-Path $sysFile) {
+    $file = Get-Item $sysFile
+    Write-Log "FOUND: $sysFile"
+    Write-Log "  Size:     $($file.Length) bytes"
+    Write-Log "  Modified: $($file.LastWriteTime)"
+
+    # Authenticode signature (built-in, no Sysinternals needed)
+    $sig = Get-AuthenticodeSignature $sysFile
+    Write-Log "  Signature status: $($sig.Status)"
+    Write-Log "  Signer:           $($sig.SignerCertificate.Subject)"
+} else {
+    Write-Log "NOT FOUND: $sysFile  <-- driver binary is missing"
+}
+
+# ── 2. Service config ────────────────────────────────────────
+Write-Section "2. Service config (sc qc)"
+$scOutput = & sc.exe qc $driverName 2>&1
+$scOutput | ForEach-Object { Write-Log "  $_" }
+
+Write-Section "2b. Service state (sc query)"
+$scQuery = & sc.exe query $driverName 2>&1
+$scQuery | ForEach-Object { Write-Log "  $_" }
+
+# ── 3. Autorunsc (Unicode-safe via Select-String) ────────────
+Write-Section "3. Autoruns — registered driver entries"
+$autorunsPath = @(
+    "$env:USERPROFILE\Downloads\autorunsc.exe",
+    "C:\Tools\autorunsc.exe",
+    "C:\Sysinternals\autorunsc.exe",
+    (Get-Command autorunsc.exe -ErrorAction SilentlyContinue)?.Source
+) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+if ($autorunsPath) {
+    Write-Log "Using: $autorunsPath"
+    # -nobanner suppresses header noise; pipe to Select-String handles Unicode
+    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+        Select-String -Pattern "apple" -CaseSensitive:$false |
+        ForEach-Object { Write-Log "  $_" }
+
+    Write-Log ""
+    Write-Log "--- Full driver list (all entries) ---"
+    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+        ForEach-Object { Write-Log "  $_" }
+} else {
+    Write-Log "autorunsc.exe not found in common paths. Skipping."
+    Write-Log "Download from: https://learn.microsoft.com/sysinternals/downloads/autoruns"
+}
+
+# ── 4. Sigcheck (if available) ───────────────────────────────
+Write-Section "4. Sigcheck — deep signature verification"
+$sigcheckPath = @(
+    "$env:USERPROFILE\Downloads\sigcheck.exe",
+    "C:\Tools\sigcheck.exe",
+    "C:\Sysinternals\sigcheck.exe",
+    (Get-Command sigcheck.exe -ErrorAction SilentlyContinue)?.Source
+) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+if ($sigcheckPath -and (Test-Path $sysFile)) {
+    & $sigcheckPath -accepteula -i -a $sysFile 2>&1 |
+        ForEach-Object { Write-Log "  $_" }
+} elseif (-not $sigcheckPath) {
+    Write-Log "sigcheck.exe not found. Skipping."
+} else {
+    Write-Log "Driver .sys not present — skipping sigcheck."
+}
+
+# ── 5. pnputil device info ───────────────────────────────────
+Write-Section "5. PnP devices — Apple HID/BT entries"
+& pnputil /enum-devices 2>&1 |
+    Select-String -Pattern "apple|00001124-0000-1000-8000-00805f9b34fb" -CaseSensitive:$false |
+    ForEach-Object { Write-Log "  $_" }
+
+Write-Section "5b. INF package info (oem0.inf)"
+& pnputil /enum-drivers 2>&1 |
+    Select-String -Pattern "apple|oem0\.inf" -CaseSensitive:$false |
+    ForEach-Object { Write-Log "  $_" }
+
+# ── 6. Windows Event Log errors ──────────────────────────────
+Write-Section "6. System event log — driver/service errors (last 48h)"
+$since = (Get-Date).AddHours(-48)
+Get-WinEvent -LogName System -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.TimeCreated -ge $since -and
+        $_.Id -in @(7000, 7001, 7009, 7011, 7022, 7023, 7026, 7034, 7043) -and
+        ($_.Message -match "apple|wirelessmouse|hid" -or $_.ProviderName -match "apple")
+    } |
+    Sort-Object TimeCreated |
+    ForEach-Object {
+        Write-Log "  [$($_.TimeCreated)] ID=$($_.Id) — $($_.Message -replace '\s+',' ')"
+    }
+
+# ── 7. Registry LowerFilters check ───────────────────────────
+Write-Section "7. Registry — LowerFilters entry"
+$regPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\{745a17a0-74d3-11d0-b6fe-00a0c90f57da}\0005"
+try {
+    $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+    Write-Log "  LowerFilters: $($lf -join ', ')"
+} catch {
+    Write-Log "  Could not read registry key: $_"
+}
+
+# ── Done ─────────────────────────────────────────────────────
+Write-Section "DONE"
+Write-Log "Full log saved to: $logFile"
+Write-Host ""
+Write-Host "Log written to: $logFile" -ForegroundColor Cyan

--- a/v2-kmdf-driver/scripts/diagnose-driver.ps1
+++ b/v2-kmdf-driver/scripts/diagnose-driver.ps1
@@ -30,7 +30,7 @@ function Write-Section {
 Write-Log "Apple Wireless Mouse Driver Diagnostic"
 Write-Log "Date: $(Get-Date)"
 
-# ── 1. Driver .sys file ──────────────────────────────────────
+# -- 1. Driver .sys file --------------------------------------
 Write-Section "1. Driver .sys file"
 if (Test-Path $sysFile) {
     $file = Get-Item $sysFile
@@ -46,7 +46,7 @@ if (Test-Path $sysFile) {
     Write-Log "NOT FOUND: $sysFile  <-- driver binary is missing"
 }
 
-# ── 2. Service config ────────────────────────────────────────
+# -- 2. Service config ----------------------------------------
 Write-Section "2. Service config (sc qc)"
 $scOutput = & sc.exe qc $driverName 2>&1
 $scOutput | ForEach-Object { Write-Log "  $_" }
@@ -55,8 +55,8 @@ Write-Section "2b. Service state (sc query)"
 $scQuery = & sc.exe query $driverName 2>&1
 $scQuery | ForEach-Object { Write-Log "  $_" }
 
-# ── 3. Autorunsc (Unicode-safe via Select-String) ────────────
-Write-Section "3. Autoruns — registered driver entries"
+# -- 3. Autorunsc (Unicode-safe via Select-String) ------------
+Write-Section "3. Autoruns - registered driver entries"
 $autorunsPath = @(
     "$env:USERPROFILE\Downloads\autorunsc.exe",
     "C:\Tools\autorunsc.exe",
@@ -80,8 +80,8 @@ if ($autorunsPath) {
     Write-Log "Download from: https://learn.microsoft.com/sysinternals/downloads/autoruns"
 }
 
-# ── 4. Sigcheck (if available) ───────────────────────────────
-Write-Section "4. Sigcheck — deep signature verification"
+# -- 4. Sigcheck (if available) -------------------------------
+Write-Section "4. Sigcheck - deep signature verification"
 $sigcheckPath = @(
     "$env:USERPROFILE\Downloads\sigcheck.exe",
     "C:\Tools\sigcheck.exe",
@@ -95,11 +95,11 @@ if ($sigcheckPath -and (Test-Path $sysFile)) {
 } elseif (-not $sigcheckPath) {
     Write-Log "sigcheck.exe not found. Skipping."
 } else {
-    Write-Log "Driver .sys not present — skipping sigcheck."
+    Write-Log "Driver .sys not present - skipping sigcheck."
 }
 
-# ── 5. pnputil device info ───────────────────────────────────
-Write-Section "5. PnP devices — Apple HID/BT entries"
+# -- 5. pnputil device info -----------------------------------
+Write-Section "5. PnP devices - Apple HID/BT entries"
 & pnputil /enum-devices 2>&1 |
     Select-String -Pattern "apple|00001124-0000-1000-8000-00805f9b34fb" -CaseSensitive:$false |
     ForEach-Object { Write-Log "  $_" }
@@ -109,8 +109,8 @@ Write-Section "5b. INF package info (oem0.inf)"
     Select-String -Pattern "apple|oem0\.inf" -CaseSensitive:$false |
     ForEach-Object { Write-Log "  $_" }
 
-# ── 6. Windows Event Log errors ──────────────────────────────
-Write-Section "6. System event log — driver/service errors (last 48h)"
+# -- 6. Windows Event Log errors ------------------------------
+Write-Section "6. System event log - driver/service errors (last 48h)"
 $since = (Get-Date).AddHours(-48)
 Get-WinEvent -LogName System -ErrorAction SilentlyContinue |
     Where-Object {
@@ -120,11 +120,11 @@ Get-WinEvent -LogName System -ErrorAction SilentlyContinue |
     } |
     Sort-Object TimeCreated |
     ForEach-Object {
-        Write-Log "  [$($_.TimeCreated)] ID=$($_.Id) — $($_.Message -replace '\s+',' ')"
+        Write-Log "  [$($_.TimeCreated)] ID=$($_.Id) - $($_.Message -replace '\s+',' ')"
     }
 
-# ── 7. Registry LowerFilters check ───────────────────────────
-Write-Section "7. Registry — LowerFilters entry"
+# -- 7. Registry LowerFilters check ---------------------------
+Write-Section "7. Registry - LowerFilters entry"
 $regPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\{745a17a0-74d3-11d0-b6fe-00a0c90f57da}\0005"
 try {
     $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
@@ -133,7 +133,7 @@ try {
     Write-Log "  Could not read registry key: $_"
 }
 
-# ── Done ─────────────────────────────────────────────────────
+# -- Done -----------------------------------------------------
 Write-Section "DONE"
 Write-Log "Full log saved to: $logFile"
 Write-Host ""

--- a/v2-kmdf-driver/scripts/diagnose-m13.ps1
+++ b/v2-kmdf-driver/scripts/diagnose-m13.ps1
@@ -1,0 +1,164 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    M13 driver MVP 1 verification script.
+    Reads diagnostic registry keys written by MagicMouseDriver.sys (1 Hz).
+    Run from PowerShell as Administrator.
+
+.DESCRIPTION
+    MVP 1 success criteria (read from registry, updated every ~1 second):
+      IoctlInterceptCount > 0  — driver loaded; 0x410210 IOCTLs intercepted
+      SdpScanHits > 0          — HIDDescriptorList (attr 0x0206) found in buffer
+      SdpPatchSuccess > 0      — descriptor replaced (Descriptor C injected)
+
+    If SdpScanHits == 0 after re-pair, check LastSdpBytes for the raw SDP
+    header bytes — the scanner may need updating for 0x36-length sequences.
+
+.USAGE
+    # One-shot check:
+    .\diagnose-m13.ps1
+
+    # Live poll (Ctrl+C to stop):
+    .\diagnose-m13.ps1 -Poll
+#>
+
+param(
+    [switch]$Poll,      # poll every 2 seconds until Ctrl+C
+    [switch]$Reset      # zero the counters by removing the Diag key (then re-pair)
+)
+
+$ServiceName  = "MagicMouseDriver"
+$DiagKeyPath  = "HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName\Diag"
+$ParamsPath   = "HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName\Parameters"
+
+function Write-Pass { param($msg) Write-Host "[PASS] $msg" -ForegroundColor Green }
+function Write-Fail { param($msg) Write-Host "[FAIL] $msg" -ForegroundColor Red }
+function Write-Info { param($msg) Write-Host "[INFO] $msg" -ForegroundColor Cyan }
+function Write-Warn { param($msg) Write-Host "[WARN] $msg" -ForegroundColor Yellow }
+
+# ── Service status ────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=== M13 Driver Status ===" -ForegroundColor White
+
+$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($svc) {
+    if ($svc.Status -eq "Running") {
+        Write-Pass "Service '$ServiceName' is RUNNING"
+    } else {
+        Write-Warn "Service '$ServiceName' status: $($svc.Status)"
+    }
+} else {
+    Write-Fail "Service '$ServiceName' not found — driver not installed"
+    Write-Info "Install: pnputil /add-driver MagicMouseDriver.inf /install"
+    exit 1
+}
+
+# ── Configuration (Parameters key) ───────────────────────────────────────────
+Write-Host ""
+Write-Host "=== Configuration ===" -ForegroundColor White
+
+if (Test-Path $ParamsPath) {
+    $params = Get-ItemProperty $ParamsPath
+    $injEnabled = if ($params.EnableInjection -ne $null) { $params.EnableInjection } else { "not set (default 1)" }
+    Write-Info "EnableInjection = $injEnabled"
+    if ($params.EnableInjection -eq 0) {
+        Write-Warn "Injection DISABLED — set EnableInjection=1 to enable"
+    }
+} else {
+    Write-Info "Parameters key not present — EnableInjection defaults to 1 (enabled)"
+}
+
+# ── Reset option ──────────────────────────────────────────────────────────────
+if ($Reset) {
+    if (Test-Path $DiagKeyPath) {
+        Remove-Item -Path $DiagKeyPath -Force -Recurse
+        Write-Info "Diag key cleared. Re-pair mouse to refresh counters."
+    } else {
+        Write-Info "Diag key not present — nothing to reset."
+    }
+}
+
+# ── Diagnostic loop ───────────────────────────────────────────────────────────
+function Show-Diag {
+    Write-Host ""
+    Write-Host "=== M13 Diagnostic Counters ($(Get-Date -Format 'HH:mm:ss')) ===" -ForegroundColor White
+
+    if (-not (Test-Path $DiagKeyPath)) {
+        Write-Warn "Diag key not yet written — driver has not fired its 1 Hz timer yet."
+        Write-Info "Wait up to 2 seconds after driver loads, or re-pair the mouse."
+        return $false
+    }
+
+    $d = Get-ItemProperty $DiagKeyPath
+
+    $ic = $d.IoctlInterceptCount
+    $sh = $d.SdpScanHits
+    $ps = $d.SdpPatchSuccess
+    $bs = $d.LastSdpBufSize
+    $ns = $d.LastPatchStatusHex
+
+    Write-Host "  IoctlInterceptCount : $ic"
+    Write-Host "  SdpScanHits         : $sh"
+    Write-Host "  SdpPatchSuccess     : $ps"
+    Write-Host "  LastSdpBufSize      : $bs bytes"
+    Write-Host "  LastPatchStatusHex  : 0x$('{0:X8}' -f $ns)"
+
+    # LastSdpBytes — hex dump of first 64 bytes
+    if ($d.LastSdpBytes -and $d.LastSdpBytes.Length -gt 0) {
+        $hexStr = ($d.LastSdpBytes | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
+        $previewLen = [Math]::Min($d.LastSdpBytes.Length, 32)
+        $preview = ($d.LastSdpBytes[0..($previewLen-1)] | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
+        Write-Host "  LastSdpBytes[0..31] : $preview"
+        Write-Host "  (Byte 0 type: 0x$('{0:X2}' -f $d.LastSdpBytes[0]) — 0x35=seq-1B, 0x36=seq-2B)"
+    }
+
+    # MVP 1 verdict
+    Write-Host ""
+    $pass = $true
+
+    if ($ic -gt 0) {
+        Write-Pass "IOCTL 0x410210 intercepted ($ic times) — driver loading correctly"
+    } else {
+        Write-Fail "IoctlInterceptCount = 0 — driver not intercepting SDP IOCTLs"
+        Write-Info "  -> Re-pair the mouse to trigger a fresh SDP query"
+        $pass = $false
+    }
+
+    if ($sh -gt 0) {
+        Write-Pass "SDP attribute 0x0206 found ($sh times) — pattern scanner working"
+    } elseif ($ic -gt 0) {
+        Write-Warn "SdpScanHits = 0 despite IOCTL intercepts"
+        Write-Info "  -> Check LastSdpBytes byte[0]: if 0x36, scanner needs 2-byte header support"
+        $pass = $false
+    }
+
+    if ($ps -gt 0) {
+        Write-Pass "Descriptor C injected ($ps times) — MVP 1 COMPLETE"
+        Write-Info "  -> Re-pair mouse, confirm scroll works, check battery in tray"
+    } elseif ($sh -gt 0) {
+        Write-Warn "SdpPatchSuccess = 0 despite scan hits"
+        $statusHex = '0x{0:X8}' -f $ns
+        Write-Info "  -> LastPatchStatusHex = $statusHex"
+        Write-Info "  -> STATUS_BUFFER_TOO_SMALL (0xC0000023) means new desc > buffer"
+        Write-Info "  -> STATUS_INVALID_PARAMETER (0xC000000D) means length field overflow"
+        $pass = $false
+    }
+
+    return $pass
+}
+
+if ($Poll) {
+    Write-Info "Polling every 2 seconds — Ctrl+C to stop. Re-pair mouse to trigger SDP query."
+    while ($true) {
+        Show-Diag | Out-Null
+        Start-Sleep -Seconds 2
+    }
+} else {
+    $ok = Show-Diag
+    Write-Host ""
+    if ($ok) {
+        Write-Pass "MVP 1 verification PASSED"
+    } else {
+        Write-Warn "Not yet passing — re-pair mouse and re-run, or use -Poll to watch live"
+    }
+}

--- a/v2-kmdf-driver/scripts/diagnose-m13.ps1
+++ b/v2-kmdf-driver/scripts/diagnose-m13.ps1
@@ -7,12 +7,12 @@
 
 .DESCRIPTION
     MVP 1 success criteria (read from registry, updated every ~1 second):
-      IoctlInterceptCount > 0  — driver loaded; 0x410210 IOCTLs intercepted
-      SdpScanHits > 0          — HIDDescriptorList (attr 0x0206) found in buffer
-      SdpPatchSuccess > 0      — descriptor replaced (Descriptor C injected)
+      IoctlInterceptCount > 0  - driver loaded; 0x410210 IOCTLs intercepted
+      SdpScanHits > 0          - HIDDescriptorList (attr 0x0206) found in buffer
+      SdpPatchSuccess > 0      - descriptor replaced (Descriptor C injected)
 
     If SdpScanHits == 0 after re-pair, check LastSdpBytes for the raw SDP
-    header bytes — the scanner may need updating for 0x36-length sequences.
+    header bytes - the scanner may need updating for 0x36-length sequences.
 
 .USAGE
     # One-shot check:
@@ -36,7 +36,7 @@ function Write-Fail { param($msg) Write-Host "[FAIL] $msg" -ForegroundColor Red 
 function Write-Info { param($msg) Write-Host "[INFO] $msg" -ForegroundColor Cyan }
 function Write-Warn { param($msg) Write-Host "[WARN] $msg" -ForegroundColor Yellow }
 
-# ── Service status ────────────────────────────────────────────────────────────
+# -- Service status ------------------------------------------------------------
 Write-Host ""
 Write-Host "=== M13 Driver Status ===" -ForegroundColor White
 
@@ -48,43 +48,43 @@ if ($svc) {
         Write-Warn "Service '$ServiceName' status: $($svc.Status)"
     }
 } else {
-    Write-Fail "Service '$ServiceName' not found — driver not installed"
+    Write-Fail "Service '$ServiceName' not found - driver not installed"
     Write-Info "Install: pnputil /add-driver MagicMouseDriver.inf /install"
     exit 1
 }
 
-# ── Configuration (Parameters key) ───────────────────────────────────────────
+# -- Configuration (Parameters key) -------------------------------------------
 Write-Host ""
 Write-Host "=== Configuration ===" -ForegroundColor White
 
 if (Test-Path $ParamsPath) {
     $params = Get-ItemProperty $ParamsPath
-    $injEnabled = if ($params.EnableInjection -ne $null) { $params.EnableInjection } else { "not set (default 1)" }
+    $injEnabled = if ($null -ne $params.EnableInjection) { $params.EnableInjection } else { "not set (default 1)" }
     Write-Info "EnableInjection = $injEnabled"
     if ($params.EnableInjection -eq 0) {
-        Write-Warn "Injection DISABLED — set EnableInjection=1 to enable"
+        Write-Warn "Injection DISABLED - set EnableInjection=1 to enable"
     }
 } else {
-    Write-Info "Parameters key not present — EnableInjection defaults to 1 (enabled)"
+    Write-Info "Parameters key not present - EnableInjection defaults to 1 (enabled)"
 }
 
-# ── Reset option ──────────────────────────────────────────────────────────────
+# -- Reset option --------------------------------------------------------------
 if ($Reset) {
     if (Test-Path $DiagKeyPath) {
         Remove-Item -Path $DiagKeyPath -Force -Recurse
         Write-Info "Diag key cleared. Re-pair mouse to refresh counters."
     } else {
-        Write-Info "Diag key not present — nothing to reset."
+        Write-Info "Diag key not present - nothing to reset."
     }
 }
 
-# ── Diagnostic loop ───────────────────────────────────────────────────────────
+# -- Diagnostic loop -----------------------------------------------------------
 function Show-Diag {
     Write-Host ""
     Write-Host "=== M13 Diagnostic Counters ($(Get-Date -Format 'HH:mm:ss')) ===" -ForegroundColor White
 
     if (-not (Test-Path $DiagKeyPath)) {
-        Write-Warn "Diag key not yet written — driver has not fired its 1 Hz timer yet."
+        Write-Warn "Diag key not yet written - driver has not fired its 1 Hz timer yet."
         Write-Info "Wait up to 2 seconds after driver loads, or re-pair the mouse."
         return $false
     }
@@ -103,13 +103,12 @@ function Show-Diag {
     Write-Host "  LastSdpBufSize      : $bs bytes"
     Write-Host "  LastPatchStatusHex  : 0x$('{0:X8}' -f $ns)"
 
-    # LastSdpBytes — hex dump of first 64 bytes
+    # LastSdpBytes - hex dump of first 64 bytes
     if ($d.LastSdpBytes -and $d.LastSdpBytes.Length -gt 0) {
-        $hexStr = ($d.LastSdpBytes | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
         $previewLen = [Math]::Min($d.LastSdpBytes.Length, 32)
         $preview = ($d.LastSdpBytes[0..($previewLen-1)] | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
         Write-Host "  LastSdpBytes[0..31] : $preview"
-        Write-Host "  (Byte 0 type: 0x$('{0:X2}' -f $d.LastSdpBytes[0]) — 0x35=seq-1B, 0x36=seq-2B)"
+        Write-Host "  (Byte 0 type: 0x$('{0:X2}' -f $d.LastSdpBytes[0]) - 0x35=seq-1B, 0x36=seq-2B)"
     }
 
     # MVP 1 verdict
@@ -117,15 +116,15 @@ function Show-Diag {
     $pass = $true
 
     if ($ic -gt 0) {
-        Write-Pass "IOCTL 0x410210 intercepted ($ic times) — driver loading correctly"
+        Write-Pass "IOCTL 0x410210 intercepted ($ic times) - driver loading correctly"
     } else {
-        Write-Fail "IoctlInterceptCount = 0 — driver not intercepting SDP IOCTLs"
+        Write-Fail "IoctlInterceptCount = 0 - driver not intercepting SDP IOCTLs"
         Write-Info "  -> Re-pair the mouse to trigger a fresh SDP query"
         $pass = $false
     }
 
     if ($sh -gt 0) {
-        Write-Pass "SDP attribute 0x0206 found ($sh times) — pattern scanner working"
+        Write-Pass "SDP attribute 0x0206 found ($sh times) - pattern scanner working"
     } elseif ($ic -gt 0) {
         Write-Warn "SdpScanHits = 0 despite IOCTL intercepts"
         Write-Info "  -> Check LastSdpBytes byte[0]: if 0x36, scanner needs 2-byte header support"
@@ -133,7 +132,7 @@ function Show-Diag {
     }
 
     if ($ps -gt 0) {
-        Write-Pass "Descriptor C injected ($ps times) — MVP 1 COMPLETE"
+        Write-Pass "Descriptor C injected ($ps times) - MVP 1 COMPLETE"
         Write-Info "  -> Re-pair mouse, confirm scroll works, check battery in tray"
     } elseif ($sh -gt 0) {
         Write-Warn "SdpPatchSuccess = 0 despite scan hits"
@@ -148,7 +147,7 @@ function Show-Diag {
 }
 
 if ($Poll) {
-    Write-Info "Polling every 2 seconds — Ctrl+C to stop. Re-pair mouse to trigger SDP query."
+    Write-Info "Polling every 2 seconds - Ctrl+C to stop. Re-pair mouse to trigger SDP query."
     while ($true) {
         Show-Diag | Out-Null
         Start-Sleep -Seconds 2
@@ -159,6 +158,6 @@ if ($Poll) {
     if ($ok) {
         Write-Pass "MVP 1 verification PASSED"
     } else {
-        Write-Warn "Not yet passing — re-pair mouse and re-run, or use -Poll to watch live"
+        Write-Warn "Not yet passing - re-pair mouse and re-run, or use -Poll to watch live"
     }
 }

--- a/v2-kmdf-driver/scripts/install-driver.ps1
+++ b/v2-kmdf-driver/scripts/install-driver.ps1
@@ -1,0 +1,27 @@
+# install-driver.ps1 — Install a pre-signed driver package via pnputil.
+# Standalone: powershell -ExecutionPolicy Bypass -File install-driver.ps1 -InfPath <path>
+# Via queue: INSTALL-DRIVER|<nonce>|<inf-path>
+# Pre-requisite: driver package must already be signed (use sign-driver.ps1 first).
+# Pre-requisite: CN=MagicMouseFix cert must be in LocalMachine\TrustedPublisher.
+# Note: if applewirelessmouse LowerFilter is active, verify no RID sweep is running first
+#       (prior BSOD 0x0000013A from brute-force RID sweep with LowerFilter active 2026-05-09).
+param(
+    [Parameter(Mandatory)][string]$InfPath
+)
+
+if (-not (Test-Path $InfPath)) {
+    Write-Error "INF not found: $InfPath"
+    exit 2
+}
+
+Write-Host "Installing driver from $InfPath ..."
+& pnputil /add-driver $InfPath /install
+$rc = $LASTEXITCODE
+if ($rc -eq 0) {
+    Write-Host "Driver installed successfully."
+} elseif ($rc -eq 3010) {
+    Write-Host "Driver installed — REBOOT REQUIRED to activate."
+} else {
+    Write-Error "pnputil failed ($rc)"
+}
+exit $rc

--- a/v2-kmdf-driver/scripts/install-driver.ps1
+++ b/v2-kmdf-driver/scripts/install-driver.ps1
@@ -1,4 +1,4 @@
-# install-driver.ps1 — Install a pre-signed driver package via pnputil.
+# install-driver.ps1 - Install a pre-signed driver package via pnputil.
 # Standalone: powershell -ExecutionPolicy Bypass -File install-driver.ps1 -InfPath <path>
 # Via queue: INSTALL-DRIVER|<nonce>|<inf-path>
 # Pre-requisite: driver package must already be signed (use sign-driver.ps1 first).
@@ -20,7 +20,7 @@ $rc = $LASTEXITCODE
 if ($rc -eq 0) {
     Write-Host "Driver installed successfully."
 } elseif ($rc -eq 3010) {
-    Write-Host "Driver installed — REBOOT REQUIRED to activate."
+    Write-Host "Driver installed - REBOOT REQUIRED to activate."
 } else {
     Write-Error "pnputil failed ($rc)"
 }

--- a/v2-kmdf-driver/scripts/m12-post-install-smoke-test.ps1
+++ b/v2-kmdf-driver/scripts/m12-post-install-smoke-test.ps1
@@ -1,0 +1,203 @@
+#Requires -Version 5.1
+<#
+M12 Post-Install Smoke Test
+===========================
+Run AFTER `pnputil /add-driver MagicMouseDriver.inf /install` AND re-pairing
+the Magic Mouse v3. Read-only: does NOT modify driver state.
+
+Validates:
+  1. M12 service is registered and Running
+  2. M12 driver is loaded by at least one BTHENUM device with VID&0001004C PID&0323
+  3. HID stack sees a Report ID 0x90 input report on the device (proxy: open the
+     device handle, attempt HidD_GetInputReport(0x90), verify 3-byte response)
+  4. Tray app's view: log in last 60s shows battery percentage
+
+Exit codes:
+  0 — all checks passed (driver functional)
+  2 — driver installed but at least one check failed (degraded)
+  3 — driver not installed or not loaded
+
+Usage (elevated optional but recommended for service query):
+    powershell -NoProfile -ExecutionPolicy Bypass -File m12-post-install-smoke-test.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$results = @()
+$mousePid = '0323'
+
+function Add-Result {
+    param($Name, $Status, $Detail)
+    $script:results += [pscustomobject]@{ Name = $Name; Status = $Status; Detail = $Detail }
+}
+
+# 1. Service check
+try {
+    $svc = Get-Service -Name 'MagicMouseDriver' -ErrorAction Stop
+    if ($svc.Status -eq 'Running') {
+        Add-Result 'service' 'PASS' "MagicMouseDriver service: Running"
+    } else {
+        Add-Result 'service' 'FAIL' "MagicMouseDriver service exists but state=$($svc.Status)"
+    }
+} catch {
+    Add-Result 'service' 'FAIL' "MagicMouseDriver service not found — driver did not install"
+}
+
+# 2. Device + driver binding
+try {
+    $vidPat = 'VID' + [char]0x26 + '0001004C'
+    $pidPat = 'PID' + [char]0x26 + $mousePid
+    $devices = Get-PnpDevice -Class HIDClass -PresentOnly | Where-Object {
+        $_.HardwareID -match $vidPat -and $_.HardwareID -match $pidPat
+    }
+    if (-not $devices) {
+        Add-Result 'pnp-binding' 'FAIL' "No present BTHENUM device matches Apple Magic Mouse v3 hardware ID"
+    } else {
+        $bound = $false
+        foreach ($d in $devices) {
+            $svcKey = (Get-PnpDeviceProperty -InstanceId $d.InstanceId -KeyName 'DEVPKEY_Device_Service' -ErrorAction SilentlyContinue).Data
+            $upperFilters = (Get-PnpDeviceProperty -InstanceId $d.InstanceId -KeyName 'DEVPKEY_Device_LowerFilters' -ErrorAction SilentlyContinue).Data
+            if ($svcKey -eq 'MagicMouseDriver' -or $upperFilters -contains 'MagicMouseDriver') {
+                $bound = $true
+                Add-Result 'pnp-binding' 'PASS' "Bound to: $($d.InstanceId) (svc=$svcKey filters=$upperFilters)"
+                break
+            }
+        }
+        if (-not $bound) {
+            Add-Result 'pnp-binding' 'FAIL' "Found $($devices.Count) Magic Mouse v3 device(s) but none bind MagicMouseDriver"
+        }
+    }
+} catch {
+    Add-Result 'pnp-binding' 'FAIL' "PnP query failed: $_"
+}
+
+# 3. HID descriptor: open device, try HidD_GetInputReport(0x90)
+# We use the ManagedHidWrapper P/Invoke approach — minimal C# inline.
+$hidProbeCs = @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class HidProbe {
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_GetInputReport(IntPtr h, byte[] buf, int len);
+
+    [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern IntPtr CreateFile(string p, uint a, uint s, IntPtr sa, uint cd, uint fa, IntPtr h);
+
+    [DllImport("kernel32.dll")] public static extern bool CloseHandle(IntPtr h);
+
+    public const uint GENERIC_WRITE = 0x40000000, GENERIC_READ = 0x80000000;
+    public const uint FILE_SHARE_READ = 1, FILE_SHARE_WRITE = 2;
+    public const uint OPEN_EXISTING = 3;
+
+    public static int TryReadBattery(string path, out byte flags, out byte percent) {
+        flags = 0; percent = 0;
+        IntPtr h = CreateFile(path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+        if (h.ToInt64() == -1) return Marshal.GetLastWin32Error();
+        try {
+            byte[] buf = new byte[3];
+            buf[0] = 0x90;
+            if (!HidD_GetInputReport(h, buf, 3)) return Marshal.GetLastWin32Error();
+            flags = buf[1]; percent = buf[2];
+            return 0;
+        } finally { CloseHandle(h); }
+    }
+}
+"@
+
+try {
+    Add-Type -TypeDefinition $hidProbeCs -ErrorAction Stop
+
+    # Find the HID device path for the v3 mouse
+    $hidPaths = Get-CimInstance -ClassName Win32_PnPEntity -Filter "DeviceID like '%PID_0323%'" |
+                Where-Object { $_.PNPClass -eq 'HIDClass' -and $_.Status -eq 'OK' }
+
+    if (-not $hidPaths) {
+        Add-Result 'hid-rid-0x90' 'SKIP' 'No HID device path found for Magic Mouse v3'
+    } else {
+        $any = $false
+        foreach ($p in $hidPaths) {
+            # Resolve to \\?\ device interface path — probe HKLM for the interface GUID symbolic link
+            $devPath = $null
+            try {
+                $iface = Get-CimInstance -Namespace root\Microsoft\Windows\DeviceGuard `
+                            -ClassName Win32_PnPDeviceInterface -ErrorAction SilentlyContinue |
+                            Where-Object { $_.DeviceID -eq $p.DeviceID } | Select-Object -First 1
+                if ($iface) { $devPath = $iface.SymbolicLink }
+            } catch {}
+            if (-not $devPath) {
+                # Fallback: derive from the registry mountpoint
+                $devPath = "\\?\HID#" + ($p.DeviceID -replace '\\', '#') + "#{4d1e55b2-f16f-11cf-88cb-001111000030}"
+                $devPath = $devPath.ToLower()
+            }
+            $flags = 0; $percent = 0
+            $err = [HidProbe]::TryReadBattery($devPath, [ref] $flags, [ref] $percent)
+            if ($err -eq 0) {
+                Add-Result 'hid-rid-0x90' 'PASS' "Read battery via RID 0x90: flags=$flags percent=$percent% (path=$devPath)"
+                $any = $true
+                break
+            } else {
+                # Capture for debug; continue trying other paths
+                Add-Result 'hid-rid-0x90' 'TRACE' "path $devPath -> Win32 error $err"
+            }
+        }
+        if (-not $any) {
+            Add-Result 'hid-rid-0x90' 'FAIL' 'All HID paths returned an error on RID 0x90 GetInputReport'
+        }
+    }
+} catch {
+    Add-Result 'hid-rid-0x90' 'FAIL' "HID probe setup failed: $_"
+}
+
+# 4. Tray app log check (last 60s)
+try {
+    $trayLogDir = Join-Path $env:APPDATA 'MagicMouseTray'
+    if (-not (Test-Path $trayLogDir)) {
+        Add-Result 'tray-log' 'SKIP' "Tray log dir not present: $trayLogDir"
+    } else {
+        $latest = Get-ChildItem $trayLogDir -Filter '*.log' -ErrorAction SilentlyContinue |
+                  Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if (-not $latest) {
+            Add-Result 'tray-log' 'SKIP' 'No tray log files found'
+        } else {
+            $cutoff = (Get-Date).AddSeconds(-60)
+            $recent = Get-Content $latest.FullName -Tail 200 | Where-Object {
+                $_ -match '\d{2}:\d{2}:\d{2}'
+            }
+            $batteryLines = $recent | Select-String -Pattern 'battery|0x90|RID 0x90|percent' -SimpleMatch | Select-Object -Last 3
+            if ($batteryLines) {
+                Add-Result 'tray-log' 'PASS' ("Recent battery activity: " + ($batteryLines -join ' | '))
+            } else {
+                Add-Result 'tray-log' 'WARN' "Tray log present, no battery line in tail. Latest: $($latest.LastWriteTime)"
+            }
+        }
+    }
+} catch {
+    Add-Result 'tray-log' 'WARN' "Tray log check error: $_"
+}
+
+# Summary
+Write-Host ""
+Write-Host "=== M12 Post-Install Smoke Test ==="
+$results | Format-Table Name,Status,Detail -AutoSize -Wrap
+
+$failed = ($results | Where-Object Status -eq 'FAIL').Count
+$traceOnly = ($results | Where-Object Status -in 'TRACE') | Measure-Object | Select-Object -ExpandProperty Count
+$realResults = $results | Where-Object Status -ne 'TRACE'
+$realFailed = ($realResults | Where-Object Status -eq 'FAIL').Count
+
+if ($realFailed -eq 0) {
+    Write-Host "RESULT: PASS"
+    exit 0
+} else {
+    $serviceFail = ($results | Where-Object { $_.Name -eq 'service' -and $_.Status -eq 'FAIL' }).Count
+    if ($serviceFail) {
+        Write-Host "RESULT: NOT INSTALLED — driver service missing"
+        exit 3
+    }
+    Write-Host "RESULT: DEGRADED — $realFailed check(s) failed"
+    exit 2
+}

--- a/v2-kmdf-driver/scripts/m12-post-install-smoke-test.ps1
+++ b/v2-kmdf-driver/scripts/m12-post-install-smoke-test.ps1
@@ -13,9 +13,9 @@ Validates:
   4. Tray app's view: log in last 60s shows battery percentage
 
 Exit codes:
-  0 — all checks passed (driver functional)
-  2 — driver installed but at least one check failed (degraded)
-  3 — driver not installed or not loaded
+  0 - all checks passed (driver functional)
+  2 - driver installed but at least one check failed (degraded)
+  3 - driver not installed or not loaded
 
 Usage (elevated optional but recommended for service query):
     powershell -NoProfile -ExecutionPolicy Bypass -File m12-post-install-smoke-test.ps1
@@ -42,7 +42,7 @@ try {
         Add-Result 'service' 'FAIL' "MagicMouseDriver service exists but state=$($svc.Status)"
     }
 } catch {
-    Add-Result 'service' 'FAIL' "MagicMouseDriver service not found — driver did not install"
+    Add-Result 'service' 'FAIL' "MagicMouseDriver service not found - driver did not install"
 }
 
 # 2. Device + driver binding
@@ -74,7 +74,7 @@ try {
 }
 
 # 3. HID descriptor: open device, try HidD_GetInputReport(0x90)
-# We use the ManagedHidWrapper P/Invoke approach — minimal C# inline.
+# We use the ManagedHidWrapper P/Invoke approach - minimal C# inline.
 $hidProbeCs = @"
 using System;
 using System.Runtime.InteropServices;
@@ -120,14 +120,14 @@ try {
     } else {
         $any = $false
         foreach ($p in $hidPaths) {
-            # Resolve to \\?\ device interface path — probe HKLM for the interface GUID symbolic link
+            # Resolve to \\?\ device interface path - probe HKLM for the interface GUID symbolic link
             $devPath = $null
             try {
                 $iface = Get-CimInstance -Namespace root\Microsoft\Windows\DeviceGuard `
                             -ClassName Win32_PnPDeviceInterface -ErrorAction SilentlyContinue |
                             Where-Object { $_.DeviceID -eq $p.DeviceID } | Select-Object -First 1
                 if ($iface) { $devPath = $iface.SymbolicLink }
-            } catch {}
+            } catch { Write-Verbose "Device interface probe failed: $_ - falling back to derived path" }
             if (-not $devPath) {
                 # Fallback: derive from the registry mountpoint
                 $devPath = "\\?\HID#" + ($p.DeviceID -replace '\\', '#') + "#{4d1e55b2-f16f-11cf-88cb-001111000030}"
@@ -163,7 +163,6 @@ try {
         if (-not $latest) {
             Add-Result 'tray-log' 'SKIP' 'No tray log files found'
         } else {
-            $cutoff = (Get-Date).AddSeconds(-60)
             $recent = Get-Content $latest.FullName -Tail 200 | Where-Object {
                 $_ -match '\d{2}:\d{2}:\d{2}'
             }
@@ -184,8 +183,6 @@ Write-Host ""
 Write-Host "=== M12 Post-Install Smoke Test ==="
 $results | Format-Table Name,Status,Detail -AutoSize -Wrap
 
-$failed = ($results | Where-Object Status -eq 'FAIL').Count
-$traceOnly = ($results | Where-Object Status -in 'TRACE') | Measure-Object | Select-Object -ExpandProperty Count
 $realResults = $results | Where-Object Status -ne 'TRACE'
 $realFailed = ($realResults | Where-Object Status -eq 'FAIL').Count
 
@@ -195,9 +192,9 @@ if ($realFailed -eq 0) {
 } else {
     $serviceFail = ($results | Where-Object { $_.Name -eq 'service' -and $_.Status -eq 'FAIL' }).Count
     if ($serviceFail) {
-        Write-Host "RESULT: NOT INSTALLED — driver service missing"
+        Write-Host "RESULT: NOT INSTALLED - driver service missing"
         exit 3
     }
-    Write-Host "RESULT: DEGRADED — $realFailed check(s) failed"
+    Write-Host "RESULT: DEGRADED - $realFailed check(s) failed"
     exit 2
 }

--- a/v2-kmdf-driver/scripts/mm-accept-test.ps1
+++ b/v2-kmdf-driver/scripts/mm-accept-test.ps1
@@ -1,0 +1,621 @@
+<#
+.SYNOPSIS
+    Magic Mouse 2024 acceptance test - 7 acceptance criteria, pass/fail verdict.
+
+.DESCRIPTION
+    Performs read-only checks against the installed driver state and emits:
+      - A results table to stdout
+      - A JSON file to %LOCALAPPDATA%\mm-accept-test-<ISO>.json
+
+    Run from WSL via mm-accept-test.sh, or directly in an admin PowerShell:
+        .\mm-accept-test.ps1
+
+    Checks performed:
+      AC-01  LowerFilters contains MagicMouseDriver (NOT applewirelessmouse)
+      AC-02  COL01 enumerated and Status=Started
+      AC-03  COL02 enumerated and Status=Started
+      AC-04  COL01 declares Wheel (UP=0x0001 U=0x0038) or AC Pan (UP=0x000C U=0x0238)
+      AC-05  COL02 has vendor battery TLC (UsagePage=0xFF00 Usage=0x0014 InputLen>=3)
+      AC-06  Battery readable: HidD_GetInputReport(0x90) on COL02 returns buf[2]=0..100
+      AC-07  Kernel debug log (C:\mm3-debug.log) has 'MagicMouse: Descriptor injected'
+             within last 60 seconds
+      AC-08  Tray app debug log has pct=<0..100> (not pct=-1 or pct=-2) on last line
+
+    Does NOT install/uninstall/modify anything.
+
+.OUTPUTS
+    Exit codes: 0=all pass, 1=at least one fail, 2=usage error
+#>
+
+param(
+    [string]$VendorPid  = 'VID&0001004c_PID&0323',
+    [string]$DebugLog   = 'C:\mm3-debug.log',
+    [int]$DebugLogMaxAgeSecs = 60
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Continue'
+
+# ---------------------------------------------------------------------------
+# P/Invoke shim - HID + SetupAPI (copied from mm-hid-probe.ps1)
+# ---------------------------------------------------------------------------
+$cs = @'
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+public static class MmHid {
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern SafeFileHandle CreateFile(string lpFileName, uint dwDesiredAccess,
+        uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition,
+        uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    public static extern bool HidD_GetInputReport(SafeFileHandle h, byte[] buf, int len);
+    [DllImport("hid.dll")]
+    public static extern bool HidD_GetPreparsedData(SafeFileHandle h, out IntPtr data);
+    [DllImport("hid.dll")]
+    public static extern bool HidD_FreePreparsedData(IntPtr data);
+    [DllImport("hid.dll")]
+    public static extern int HidP_GetCaps(IntPtr data, ref HIDP_CAPS caps);
+    [DllImport("hid.dll")]
+    public static extern int HidP_GetValueCaps(int reportType, [Out] HIDP_VALUE_CAPS[] caps,
+        ref ushort capsLength, IntPtr preparsedData);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct HIDP_CAPS {
+        public ushort Usage, UsagePage, InputReportByteLength, OutputReportByteLength,
+            FeatureReportByteLength;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst=17)]
+        public ushort[] Reserved;
+        public ushort NumberLinkCollectionNodes, NumberInputButtonCaps, NumberInputValueCaps,
+            NumberInputDataIndices, NumberOutputButtonCaps, NumberOutputValueCaps,
+            NumberOutputDataIndices, NumberFeatureButtonCaps, NumberFeatureValueCaps,
+            NumberFeatureDataIndices;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=4)]
+    public struct HIDP_VALUE_CAPS {
+        public ushort UsagePage;
+        public byte ReportID;
+        [MarshalAs(UnmanagedType.U1)] public bool IsAlias;
+        public ushort BitField, LinkCollection, LinkUsage, LinkUsagePage;
+        [MarshalAs(UnmanagedType.U1)] public bool IsRange, IsStringRange, IsDesignatorRange, IsAbsolute;
+        [MarshalAs(UnmanagedType.U1)] public bool HasNull;
+        public byte Reserved;
+        public ushort BitSize, ReportCount;
+        public ushort R1, R2, R3, R4, R5;
+        public uint UnitsExp, Units;
+        public int LogicalMin, LogicalMax, PhysicalMin, PhysicalMax;
+        // Range/NotRange union - first slot is UsageMin/Usage
+        public ushort UsageOrUsageMin, UsageMax, StringIdxOrMin, StringIdxMax;
+        public ushort DesigIdxOrMin, DesigIdxMax, DataIdxOrMin, DataIdxMax;
+    }
+}
+
+public static class MmSetup {
+    [DllImport("setupapi.dll", SetLastError = true)]
+    public static extern IntPtr SetupDiGetClassDevs(ref Guid g, string e, IntPtr p, uint f);
+    [DllImport("setupapi.dll", SetLastError = true)]
+    public static extern bool SetupDiEnumDeviceInterfaces(IntPtr s, IntPtr d, ref Guid g,
+        uint i, ref SP_DEVICE_INTERFACE_DATA r);
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    public static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr s,
+        ref SP_DEVICE_INTERFACE_DATA d, ref SP_DEVICE_INTERFACE_DETAIL_DATA b,
+        uint sz, out uint req, IntPtr di);
+    [DllImport("setupapi.dll")]
+    public static extern bool SetupDiDestroyDeviceInfoList(IntPtr s);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SP_DEVICE_INTERFACE_DATA {
+        public uint cbSize; public Guid InterfaceClassGuid; public uint Flags; public IntPtr R;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct SP_DEVICE_INTERFACE_DETAIL_DATA {
+        public uint cbSize;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst=512)]
+        public string DevicePath;
+    }
+}
+'@
+
+if (-not ([System.Management.Automation.PSTypeName]'MmHid').Type) {
+    Add-Type -TypeDefinition $cs -Language CSharp
+}
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+$HIDP_STATUS_SUCCESS = 0x00110000
+$HID_GUID            = [Guid]'4d1e55b2-f16f-11cf-88cb-001111000030'
+
+# ---------------------------------------------------------------------------
+# Result accumulator
+# ---------------------------------------------------------------------------
+$results = [System.Collections.Generic.List[hashtable]]::new()
+
+function Add-Result {
+    param(
+        [string]$Id,
+        [string]$Name,
+        [bool]  $Pass,
+        [string]$Detail
+    )
+    $results.Add(@{
+        id     = $Id
+        name   = $Name
+        status = if ($Pass) { 'PASS' } else { 'FAIL' }
+        detail = $Detail
+    })
+}
+
+# ---------------------------------------------------------------------------
+# Helper: Resolve BTHENUM device ID for our mouse (by VID/PID)
+# ---------------------------------------------------------------------------
+function Resolve-MouseDeviceId {
+    # Must return the HID-service GUID path ({00001124-...}) -- that is the
+    # node where LowerFilters binds.  The SDP/Device-Identification entry
+    # ({00001200-...}) is also present but has no LowerFilters; returning it
+    # causes AC-01 to always report a false FAIL.
+    $devs = pnputil /enum-devices /connected 2>&1 | Out-String
+    $blocks = $devs -split "(?=Instance ID:)"
+    foreach ($b in $blocks) {
+        if ($b -match "Instance ID:\s+(BTHENUM\\\{00001124-0000-1000-8000-00805[Ff]9[Bb]34[Ff][Bb][^\r\n]*$VendorPid[^\r\n]*)") {
+            return $Matches[1].Trim()
+        }
+    }
+    return $null
+}
+
+# ---------------------------------------------------------------------------
+# Helper: enumerate HID interface paths for the mouse (COL01 and COL02)
+# Filters by VID/PID in the device path.
+# ---------------------------------------------------------------------------
+function Get-MouseHidPaths {
+    $devs = [MmSetup]::SetupDiGetClassDevs([ref]$HID_GUID, $null, [IntPtr]::Zero, 0x12)
+    $paths = @{}
+    $index = 0
+    while ($true) {
+        $iface = New-Object MmSetup+SP_DEVICE_INTERFACE_DATA
+        $iface.cbSize = [System.Runtime.InteropServices.Marshal]::SizeOf($iface)
+        if (-not [MmSetup]::SetupDiEnumDeviceInterfaces($devs, [IntPtr]::Zero, [ref]$HID_GUID, $index, [ref]$iface)) {
+            break
+        }
+        $detail = New-Object MmSetup+SP_DEVICE_INTERFACE_DETAIL_DATA
+        $detail.cbSize = if ([IntPtr]::Size -eq 8) { 8 } else { 6 }
+        [MmSetup]::SetupDiGetDeviceInterfaceDetail($devs, [ref]$iface, [ref]$detail, 512, [ref]$null, [IntPtr]::Zero) | Out-Null
+        if ($detail.DevicePath) {
+            $dp = $detail.DevicePath.ToLower()
+            $isOurMouse = ($dp -match 'vid_05ac.*pid_0323' -or $dp -match 'vid&0001004c.*pid&0323')
+            if ($isOurMouse) {
+                if ($dp -match 'col01') {
+                    $paths['col01'] = $detail.DevicePath
+                } elseif ($dp -match 'col02') {
+                    $paths['col02'] = $detail.DevicePath
+                } else {
+                    # Unified single interface (Apple driver mode)
+                    if (-not $paths.ContainsKey('unified')) {
+                        $paths['unified'] = $detail.DevicePath
+                    }
+                }
+            }
+        }
+        $index++
+    }
+    [MmSetup]::SetupDiDestroyDeviceInfoList($devs) | Out-Null
+    return $paths
+}
+
+# ---------------------------------------------------------------------------
+# Helper: open HID handle (zero-access, avoids err=5 on mouhid-owned interface)
+# ---------------------------------------------------------------------------
+function Open-HidHandle {
+    param([string]$Path)
+    return [MmHid]::CreateFile($Path, 0, 3, [IntPtr]::Zero, 3, 0, [IntPtr]::Zero)
+}
+
+# ---------------------------------------------------------------------------
+# Helper: get HIDP_CAPS + InputValueCaps for a given handle
+# Returns $null on failure.
+# ---------------------------------------------------------------------------
+function Get-HidCaps {
+    param([Microsoft.Win32.SafeHandles.SafeFileHandle]$Handle)
+    $pd = [IntPtr]::Zero
+    if (-not [MmHid]::HidD_GetPreparsedData($Handle, [ref]$pd)) { return $null }
+    try {
+        $caps = New-Object MmHid+HIDP_CAPS
+        $caps.Reserved = [uint16[]]::new(17)
+        if ([MmHid]::HidP_GetCaps($pd, [ref]$caps) -ne $HIDP_STATUS_SUCCESS) { return $null }
+
+        $valueCaps = @()
+        if ($caps.NumberInputValueCaps -gt 0) {
+            $arr = [MmHid+HIDP_VALUE_CAPS[]]::new([int]$caps.NumberInputValueCaps)
+            $len = [uint16]$caps.NumberInputValueCaps
+            if ([MmHid]::HidP_GetValueCaps(0, $arr, [ref]$len, $pd) -eq $HIDP_STATUS_SUCCESS) {
+                $valueCaps = $arr[0..([int]$len-1)]
+            }
+        }
+        return @{ Caps = $caps; ValueCaps = $valueCaps }
+    } finally {
+        [MmHid]::HidD_FreePreparsedData($pd) | Out-Null
+    }
+}
+
+# ===========================================================================
+# AC-01: LowerFilters contains MagicMouseDriver
+# ===========================================================================
+$devId = Resolve-MouseDeviceId
+if (-not $devId) {
+    Add-Result 'AC-01' 'Driver bound (LowerFilters)' $false `
+        'Device not connected/paired - no BTHENUM entry for VID&0001004c_PID&0323'
+} else {
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    try {
+        $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        if ($null -eq $lf) { $lf = @() }
+        $lfStr = ($lf -join ', ')
+        if ($lf -contains 'MagicMouseDriver') {
+            Add-Result 'AC-01' 'Driver bound (LowerFilters)' $true `
+                "LowerFilters=[$lfStr] - MagicMouseDriver present"
+        } else {
+            Add-Result 'AC-01' 'Driver bound (LowerFilters)' $false `
+                "LowerFilters=[$lfStr] - MagicMouseDriver NOT found (applewirelessmouse mode?)"
+        }
+    } catch {
+        Add-Result 'AC-01' 'Driver bound (LowerFilters)' $false `
+            "Cannot read registry at $regPath : $_"
+    }
+}
+
+# ===========================================================================
+# AC-02/AC-03: COL01 + COL02 both enumerated and Started
+# Uses pnputil /enum-devices - parse blocks for COL01 and COL02 status.
+# ===========================================================================
+$pnpOut = pnputil /enum-devices /connected 2>&1 | Out-String
+
+function Get-ColStatus {
+    param([string]$PnpOutput, [string]$ColSuffix)
+    # Split on Instance ID: boundaries, find block with our VID/PID + ColXX
+    $blocks = $PnpOutput -split "(?=Instance ID:)"
+    foreach ($b in $blocks) {
+        if ($b -match "VID&0001004c_PID&0323.*$ColSuffix" -or
+            $b -match "VID_05AC.*PID_0323.*$ColSuffix") {
+            if ($b -match 'Status:\s*(\w+)') {
+                return $Matches[1]
+            }
+            return 'Unknown'
+        }
+    }
+    return $null
+}
+
+$col01Status = Get-ColStatus $pnpOut 'Col01'
+$col02Status = Get-ColStatus $pnpOut 'Col02'
+
+if ($null -eq $col01Status) {
+    Add-Result 'AC-02' 'COL01 enumerated+Started' $false `
+        'COL01 not found in pnputil /enum-devices /connected'
+} else {
+    $pass = ($col01Status -eq 'Started')
+    Add-Result 'AC-02' 'COL01 enumerated+Started' $pass `
+        "COL01 Status=$col01Status$(if (-not $pass) { ' (expected: Started)' })"
+}
+
+if ($null -eq $col02Status) {
+    Add-Result 'AC-03' 'COL02 enumerated+Started' $false `
+        'COL02 not found - battery child PDO missing (descriptor injection may have failed)'
+} else {
+    $pass = ($col02Status -eq 'Started')
+    Add-Result 'AC-03' 'COL02 enumerated+Started' $pass `
+        "COL02 Status=$col02Status$(if (-not $pass) { ' (expected: Started)' })"
+}
+
+# ===========================================================================
+# HID path enumeration (shared for AC-04/AC-05/AC-06)
+# ===========================================================================
+$hidPaths = Get-MouseHidPaths
+
+# ---------------------------------------------------------------------------
+# AC-04: COL01 declares Wheel or AC Pan usage via HidP_GetValueCaps
+# ---------------------------------------------------------------------------
+$col01Path = $hidPaths['col01']
+if (-not $col01Path) {
+    Add-Result 'AC-04' 'COL01 scroll usage declared' $false `
+        'COL01 HID interface path not found (device not enumerated or not in split mode)'
+} else {
+    $h = Open-HidHandle $col01Path
+    if ($h.IsInvalid) {
+        $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        Add-Result 'AC-04' 'COL01 scroll usage declared' $false `
+            "CreateFile on COL01 failed err=$err path=$col01Path"
+    } else {
+        try {
+            $info = Get-HidCaps $h
+            if ($null -eq $info) {
+                Add-Result 'AC-04' 'COL01 scroll usage declared' $false `
+                    "HidP_GetCaps failed on COL01"
+            } else {
+                # Wheel: UP=0x0001 U=0x0038  |  AC Pan: UP=0x000C U=0x0238
+                $hasWheel  = $info.ValueCaps | Where-Object { $_.UsagePage -eq 0x0001 -and $_.UsageOrUsageMin -eq 0x0038 }
+                $hasACPan  = $info.ValueCaps | Where-Object { $_.UsagePage -eq 0x000C -and $_.UsageOrUsageMin -eq 0x0238 }
+                $found     = @()
+                if ($hasWheel) { $found += 'Wheel(UP=0001,U=0038)' }
+                if ($hasACPan) { $found += 'ACPan(UP=000C,U=0238)' }
+                $pass = ($found.Count -gt 0)
+                if ($pass) {
+                    Add-Result 'AC-04' 'COL01 scroll usage declared' $true `
+                        "Scroll usages found: $($found -join ', ')"
+                } else {
+                    $allUsages = ($info.ValueCaps | ForEach-Object { "UP=0x$('{0:X4}' -f $_.UsagePage),U=0x$('{0:X4}' -f $_.UsageOrUsageMin)" }) -join '; '
+                    Add-Result 'AC-04' 'COL01 scroll usage declared' $false `
+                        "No Wheel/ACPan in COL01 ValueCaps. Found: [$allUsages]"
+                }
+            }
+        } finally {
+            $h.Close()
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# AC-05: COL02 has vendor battery TLC (UP=0xFF00 U=0x0014 InputLen>=3)
+# ---------------------------------------------------------------------------
+$col02Path = $hidPaths['col02']
+if (-not $col02Path) {
+    Add-Result 'AC-05' 'COL02 vendor battery TLC' $false `
+        'COL02 HID interface path not found'
+} else {
+    $h = Open-HidHandle $col02Path
+    if ($h.IsInvalid) {
+        $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        Add-Result 'AC-05' 'COL02 vendor battery TLC' $false `
+            "CreateFile on COL02 failed err=$err"
+    } else {
+        try {
+            $info = Get-HidCaps $h
+            if ($null -eq $info) {
+                Add-Result 'AC-05' 'COL02 vendor battery TLC' $false `
+                    "HidP_GetCaps failed on COL02"
+            } else {
+                $caps = $info.Caps
+                $upOk  = ($caps.UsagePage -eq 0xFF00)
+                $uOk   = ($caps.Usage -eq 0x0014)
+                $lenOk = ($caps.InputReportByteLength -ge 3)
+                $pass  = $upOk -and $uOk -and $lenOk
+                $detail = "UP=0x$('{0:X4}' -f $caps.UsagePage) Usage=0x$('{0:X4}' -f $caps.Usage) InputLen=$($caps.InputReportByteLength)"
+                if ($pass) {
+                    Add-Result 'AC-05' 'COL02 vendor battery TLC' $true `
+                        "Battery TLC confirmed: $detail"
+                } else {
+                    $why = @()
+                    if (-not $upOk)  { $why += "UsagePage=0x$('{0:X4}' -f $caps.UsagePage) (expected 0xFF00)" }
+                    if (-not $uOk)   { $why += "Usage=0x$('{0:X4}' -f $caps.Usage) (expected 0x0014)" }
+                    if (-not $lenOk) { $why += "InputReportByteLength=$($caps.InputReportByteLength) < 3" }
+                    Add-Result 'AC-05' 'COL02 vendor battery TLC' $false `
+                        "$($why -join '; ')  [raw: $detail]"
+                }
+            }
+        } finally {
+            $h.Close()
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# AC-06: Battery readable - HidD_GetInputReport(0x90) on COL02
+# ---------------------------------------------------------------------------
+if (-not $col02Path) {
+    Add-Result 'AC-06' 'Battery read (Report 0x90)' $false `
+        'COL02 path not available - skipping read'
+} else {
+    $h = Open-HidHandle $col02Path
+    if ($h.IsInvalid) {
+        $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        Add-Result 'AC-06' 'Battery read (Report 0x90)' $false `
+            "CreateFile on COL02 failed err=$err"
+    } else {
+        try {
+            $buf = New-Object byte[] 3
+            $buf[0] = 0x90
+            $success = $false
+            $lastErr = 0
+            for ($attempt = 0; $attempt -lt 3; $attempt++) {
+                $buf[0] = 0x90
+                if ([MmHid]::HidD_GetInputReport($h, $buf, $buf.Length)) {
+                    $success = $true
+                    break
+                }
+                $lastErr = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+                if ($attempt -lt 2) { Start-Sleep -Milliseconds 50 }
+            }
+            if ($success) {
+                $pct = [int]$buf[2]
+                if ($pct -ge 0 -and $pct -le 100) {
+                    Add-Result 'AC-06' 'Battery read (Report 0x90)' $true `
+                        "buf=[0x$('{0:X2}' -f $buf[0]) 0x$('{0:X2}' -f $buf[1]) 0x$('{0:X2}' -f $buf[2])] battery=$pct%"
+                } else {
+                    Add-Result 'AC-06' 'Battery read (Report 0x90)' $false `
+                        "Report returned but buf[2]=$pct is out of range 0-100"
+                }
+            } else {
+                Add-Result 'AC-06' 'Battery read (Report 0x90)' $false `
+                    "HidD_GetInputReport failed after 3 attempts, err=$lastErr"
+            }
+        } finally {
+            $h.Close()
+        }
+    }
+}
+
+# ===========================================================================
+# AC-07: Kernel debug log has 'MagicMouse: Descriptor injected' within 60s
+# ===========================================================================
+if (-not (Test-Path $DebugLog)) {
+    Add-Result 'AC-07' 'Kernel debug marker (Descriptor injected)' $false `
+        "Debug log not found: $DebugLog (DebugView not running, or path wrong)"
+} else {
+    $cutoff   = (Get-Date).AddSeconds(-$DebugLogMaxAgeSecs)
+    $logMtime = (Get-Item $DebugLog).LastWriteTime
+    # Read file - look for any line with 'Descriptor injected' pattern
+    $matchLine = Get-Content $DebugLog -ErrorAction SilentlyContinue |
+        Select-String -Pattern 'MagicMouse.*Descriptor injected|Descriptor injected.*MagicMouse' |
+        Select-Object -Last 1
+
+    if (-not $matchLine) {
+        Add-Result 'AC-07' 'Kernel debug marker (Descriptor injected)' $false `
+            "No 'MagicMouse: Descriptor injected' line found in $DebugLog"
+    } else {
+        # Try to parse timestamp from DebugView line format: "   N  HH:MM:SS.mmm  message"
+        $line = $matchLine.Line
+        $timestampParsed = $false
+        $withinWindow    = $false
+
+        if ($line -match '\d+\s+(\d{2}:\d{2}:\d{2}\.\d+)\s+') {
+            $timeStr = $Matches[1]
+            try {
+                $today   = (Get-Date).Date
+                $entryTs = [datetime]::ParseExact("$($today.ToString('yyyy-MM-dd')) $timeStr",
+                    'yyyy-MM-dd HH:mm:ss.fff', $null)
+                $timestampParsed = $true
+                $withinWindow    = ($entryTs -ge $cutoff)
+            } catch { }
+        }
+
+        if ($timestampParsed) {
+            if ($withinWindow) {
+                Add-Result 'AC-07' 'Kernel debug marker (Descriptor injected)' $true `
+                    "Found recent log entry: $line"
+            } else {
+                Add-Result 'AC-07' 'Kernel debug marker (Descriptor injected)' $false `
+                    "Entry found but older than ${DebugLogMaxAgeSecs}s: $line"
+            }
+        } else {
+            # Cannot parse timestamp - accept if log file itself was modified recently
+            if ($logMtime -ge $cutoff) {
+                Add-Result 'AC-07' 'Kernel debug marker (Descriptor injected)' $true `
+                    "Found entry (timestamp parse skipped, log modified $(($logMtime).ToString('HH:mm:ss'))): $line"
+            } else {
+                Add-Result 'AC-07' 'Kernel debug marker (Descriptor injected)' $false `
+                    "Entry found but log not updated in ${DebugLogMaxAgeSecs}s. Last modified: $($logMtime.ToString('HH:mm:ss')). Line: $line"
+            }
+        }
+    }
+}
+
+# ===========================================================================
+# AC-08: Tray app debug log has pct=<0..100>
+# ===========================================================================
+$trayLog = Join-Path $env:APPDATA 'MagicMouseTray\debug.log'
+if (-not (Test-Path $trayLog)) {
+    Add-Result 'AC-08' 'Tray app battery reading' $false `
+        "Tray debug log not found: $trayLog (tray app not running or never started)"
+} else {
+    # Get last non-empty line from tray log
+    $lastLine = Get-Content $trayLog -ErrorAction SilentlyContinue |
+        Where-Object { $_.Trim() -ne '' } |
+        Select-Object -Last 1
+
+    if (-not $lastLine) {
+        Add-Result 'AC-08' 'Tray app battery reading' $false `
+            "Tray log is empty: $trayLog"
+    } elseif ($lastLine -match 'pct=(-?\d+)') {
+        $pctVal = [int]$Matches[1]
+        if ($pctVal -ge 0 -and $pctVal -le 100) {
+            Add-Result 'AC-08' 'Tray app battery reading' $true `
+                "Last tray log line: $lastLine"
+        } elseif ($pctVal -eq -1) {
+            Add-Result 'AC-08' 'Tray app battery reading' $false `
+                "pct=-1 (no mouse found/not connected). Last line: $lastLine"
+        } elseif ($pctVal -eq -2) {
+            Add-Result 'AC-08' 'Tray app battery reading' $false `
+                "pct=-2 (Apple driver in unified mode - battery inaccessible). Last line: $lastLine"
+        } else {
+            Add-Result 'AC-08' 'Tray app battery reading' $false `
+                "pct=$pctVal out of expected range. Last line: $lastLine"
+        }
+    } else {
+        Add-Result 'AC-08' 'Tray app battery reading' $false `
+            "No pct=N pattern in last tray log line: $lastLine"
+    }
+}
+
+# ===========================================================================
+# Emit results table
+# ===========================================================================
+# Force array context so .Count works under Set-StrictMode v2 even with 0 matches.
+# Without @(), Where-Object returns $null when no items match, and .Count on $null
+# throws under StrictMode -> downstream variables stay unset.
+$passCount = @($results | Where-Object { $_.status -eq 'PASS' }).Count
+$failCount = @($results | Where-Object { $_.status -eq 'FAIL' }).Count
+$total     = @($results).Count
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "  Magic Mouse 2024 Acceptance Test"      -ForegroundColor Cyan
+Write-Host "  $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+
+$colW = @{Id=6; Status=6; Name=36; Detail=60}
+
+# Header
+$header = "{0,-$($colW.Id)}  {1,-$($colW.Status)}  {2,-$($colW.Name)}  {3}" -f `
+    'CHECK', 'STATUS', 'CRITERION', 'DETAIL'
+Write-Host $header -ForegroundColor White
+Write-Host ('-' * 120)
+
+foreach ($r in $results) {
+    $color = if ($r.status -eq 'PASS') { 'Green' } else { 'Red' }
+    $nameClipped   = if ($r.name.Length   -gt $colW.Name)   { $r.name.Substring(0,$colW.Name-1)   + '...' } else { $r.name }
+    $detailClipped = if ($r.detail.Length -gt $colW.Detail) { $r.detail.Substring(0,$colW.Detail-1) + '...' } else { $r.detail }
+    $line = "{0,-$($colW.Id)}  {1,-$($colW.Status)}  {2,-$($colW.Name)}  {3}" -f `
+        $r.id, $r.status, $nameClipped, $detailClipped
+    Write-Host $line -ForegroundColor $color
+}
+
+Write-Host ('-' * 120)
+
+$verdict = if ($failCount -eq 0) { 'PASS' } else { 'FAIL' }
+$verdictColor = if ($failCount -eq 0) { 'Green' } else { 'Red' }
+Write-Host ""
+Write-Host "VERDICT: $verdict  ($passCount/$total passed)" -ForegroundColor $verdictColor
+if ($failCount -gt 0) {
+    Write-Host ""
+    Write-Host "To roll back and restore native behavior:" -ForegroundColor Yellow
+    Write-Host "  ./scripts/mm-dev.sh rollback" -ForegroundColor Yellow
+}
+Write-Host ""
+
+# ===========================================================================
+# Write JSON results file
+# ===========================================================================
+$isoTs  = (Get-Date -Format 'yyyy-MM-ddTHH-mm-ss')
+$jsonOut = Join-Path $env:LOCALAPPDATA "mm-accept-test-${isoTs}.json"
+
+$jsonPayload = [ordered]@{
+    tool         = 'mm-accept-test'
+    version      = '1.0.0'
+    timestamp    = (Get-Date -Format 'o')
+    device_pid   = $VendorPid
+    verdict      = $verdict
+    pass_count   = $passCount
+    fail_count   = $failCount
+    total_checks = $total
+    checks       = $results | ForEach-Object {
+        [ordered]@{
+            id     = $_.id
+            name   = $_.name
+            status = $_.status
+            detail = $_.detail
+        }
+    }
+} | ConvertTo-Json -Depth 4
+
+try {
+    $jsonPayload | Out-File -FilePath $jsonOut -Encoding UTF8 -Force
+    Write-Host "Results written: $jsonOut" -ForegroundColor Cyan
+} catch {
+    Write-Host "WARNING: could not write JSON results: $_" -ForegroundColor Yellow
+}
+
+# Exit code: 0=all pass, 1=at least one fail
+exit $(if ($failCount -eq 0) { 0 } else { 1 })

--- a/v2-kmdf-driver/scripts/mm-accept-test.ps1
+++ b/v2-kmdf-driver/scripts/mm-accept-test.ps1
@@ -478,7 +478,7 @@ if (-not (Test-Path $DebugLog)) {
                     'yyyy-MM-dd HH:mm:ss.fff', $null)
                 $timestampParsed = $true
                 $withinWindow    = ($entryTs -ge $cutoff)
-            } catch { }
+            } catch { Write-Verbose "Unparseable DebugView timestamp '$timeStr': $_" }
         }
 
         if ($timestampParsed) {

--- a/v2-kmdf-driver/scripts/mm-accept-test.sh
+++ b/v2-kmdf-driver/scripts/mm-accept-test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# mm-accept-test.sh — Magic Mouse 2024 acceptance test (WSL entry point)
+#
+# Runs 8 read-only checks against the currently installed driver:
+#   AC-01  LowerFilters contains MagicMouseDriver (not applewirelessmouse)
+#   AC-02  COL01 (pointer) enumerated and Status=Started
+#   AC-03  COL02 (battery) enumerated and Status=Started
+#   AC-04  COL01 HID report declares Wheel and/or AC Pan usage
+#   AC-05  COL02 has vendor battery TLC (UP=0xFF00 U=0x0014 InputLen>=3)
+#   AC-06  HidD_GetInputReport(0x90) on COL02 returns buf[2]=0..100
+#   AC-07  C:\mm3-debug.log has 'MagicMouse: Descriptor injected' within 60s
+#   AC-08  %APPDATA%\MagicMouseTray\debug.log last line has pct=0..100
+#
+# USAGE:
+#   ./scripts/mm-accept-test.sh            # run all checks
+#   ./scripts/mm-accept-test.sh --help     # show this help
+#
+# OUTPUTS:
+#   Stdout: results table + PASS/FAIL verdict
+#   JSON:   %LOCALAPPDATA%\mm-accept-test-<ISO>.json
+#
+# EXIT CODES:
+#   0  all checks pass
+#   1  at least one check failed
+#   2  usage error or environment problem
+#
+# NOTE: Does NOT install/uninstall/modify any driver. Read-only.
+# If checks fail, consider: ./scripts/mm-dev.sh rollback
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    grep '^#' "$0" | grep -v '^#!/' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Locate repo root and PS1 helper
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PS1_HELPER="$SCRIPT_DIR/mm-accept-test.ps1"
+
+if [[ ! -f "$PS1_HELPER" ]]; then
+    echo "[mm-accept-test] ERROR: PowerShell helper not found: $PS1_HELPER" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Verify we can reach powershell.exe
+# ---------------------------------------------------------------------------
+if ! command -v powershell.exe &>/dev/null; then
+    echo "[mm-accept-test] ERROR: powershell.exe not found in PATH." >&2
+    echo "[mm-accept-test] This script must run from WSL with Windows PowerShell accessible." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Convert WSL path to Windows path for the PS1
+# ---------------------------------------------------------------------------
+WIN_PS1="$(wslpath -w "$PS1_HELPER")"
+
+# ---------------------------------------------------------------------------
+# Optional: pass through WIN_DRIVER_DIR if set, so the sync step in mm-dev.sh
+# keeps the PS1 at the same location the user expects.
+# mm-accept-test.ps1 is self-contained and does not need mm-dev.ps1.
+# ---------------------------------------------------------------------------
+echo "[mm-accept-test] Running acceptance checks via PowerShell..."
+echo "[mm-accept-test] Script: $WIN_PS1"
+echo ""
+
+powershell.exe \
+    -NoProfile \
+    -ExecutionPolicy Bypass \
+    -File "$WIN_PS1" \
+    "$@"
+
+rc=$?
+
+echo ""
+if [[ $rc -eq 0 ]]; then
+    echo "[mm-accept-test] All checks PASSED (exit 0)"
+elif [[ $rc -eq 1 ]]; then
+    echo "[mm-accept-test] One or more checks FAILED (exit 1)" >&2
+    echo "[mm-accept-test] To roll back: ./scripts/mm-dev.sh rollback" >&2
+else
+    echo "[mm-accept-test] PowerShell exited with code $rc" >&2
+fi
+
+exit $rc

--- a/v2-kmdf-driver/scripts/mm-dev.ps1
+++ b/v2-kmdf-driver/scripts/mm-dev.ps1
@@ -232,7 +232,7 @@ function Build-Driver {
     }
 
     Write-Log "Running EWDK msbuild (Rebuild) via temp batch file..."
-    # Write a temp .bat to avoid PowerShell→cmd double-quote mangling.
+    # Write a temp .bat to avoid PowerShell->cmd double-quote mangling.
     # cmd /c with embedded quotes produces '""' is not recognized errors.
     $tempBat = [System.IO.Path]::GetTempFileName() -replace '\.tmp$','.bat'
     @"
@@ -272,7 +272,7 @@ msbuild "$VcxProj" /p:Configuration=Debug /p:Platform=x64 /t:Rebuild /nologo /v:
 # ---------------------------------------------------------------------------
 # SIGN
 # ---------------------------------------------------------------------------
-function Sign-Driver {
+function Invoke-DriverSigning {
     Write-Section "SIGN - $(Get-Date -Format 'HH:mm:ss')"
 
     if (-not (Test-Path $SignToolExe)) {
@@ -354,7 +354,7 @@ function Uninstall-DriverDirect {
                 pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
                 Start-Sleep -Seconds 2
             }
-        } catch { }
+        } catch { Write-Log "LowerFilters cleanup skipped: $_" 'WARN' }
     }
 
     Write-Log "Stopping service..."
@@ -421,7 +421,7 @@ function Install-Driver {
     }
     Write-Log "Device: $devId"
 
-    # Set LowerFilters — MagicMouseDriver(0) below applewirelessmouse(1).
+    # Set LowerFilters - MagicMouseDriver(0) below applewirelessmouse(1).
     # Our driver at index 0 patches SDP completion first; applewirelessmouse sees our
     # combined descriptor and does not re-patch. Swapping (test ee18af4) confirmed
     # applewirelessmouse DOES gesture processing but conflicts with our combined descriptor
@@ -487,7 +487,7 @@ function Install-Driver {
 # ---------------------------------------------------------------------------
 # VERIFY - post-install health check
 # ---------------------------------------------------------------------------
-function Verify-Install {
+function Test-Install {
     Write-Section "VERIFY - $(Get-Date -Format 'HH:mm:ss')"
     $allOk = $true
 
@@ -570,7 +570,7 @@ function Verify-Install {
 # ---------------------------------------------------------------------------
 # ROLLBACK - recovery path: remove our filter entirely
 # ---------------------------------------------------------------------------
-function Rollback-Driver {
+function Restore-Driver {
     Write-Section "ROLLBACK - $(Get-Date -Format 'HH:mm:ss')"
     # Use direct uninstall (no pnputil /delete-driver which hangs in SYSTEM context).
     Uninstall-DriverDirect
@@ -739,21 +739,21 @@ Write-Log "=== mm-dev.ps1 Phase=$Phase ===" 'HEAD'
 $exitCode = 0
 switch ($Phase) {
     'State'    { Get-DriverState }
-    'Build'    { if (-not (Build-Driver))   { $exitCode = 1 } }
-    'Sign'     { if (-not (Sign-Driver))    { $exitCode = 1 } }
-    'Install'  { if (-not (Install-Driver)) { $exitCode = 1 } }
-    'Verify'   { if (-not (Verify-Install)) { $exitCode = 1 } }
-    'Rollback' { if (-not (Rollback-Driver)){ $exitCode = 1 } }
+    'Build'    { if (-not (Build-Driver))         { $exitCode = 1 } }
+    'Sign'     { if (-not (Invoke-DriverSigning)) { $exitCode = 1 } }
+    'Install'  { if (-not (Install-Driver))       { $exitCode = 1 } }
+    'Verify'   { if (-not (Test-Install))         { $exitCode = 1 } }
+    'Rollback' { if (-not (Restore-Driver))       { $exitCode = 1 } }
     'Restore'  { if (-not (Restore-LowerFilters)) { $exitCode = 1 } }
-    'Capture'  { if (-not (Read-Rid27Captures)) { $exitCode = 1 } }
+    'Capture'  { if (-not (Read-Rid27Captures))   { $exitCode = 1 } }
     'Log'      { Show-SessionLog }
     'Debug'    { Show-DebugLog }
     'Full' {
         Get-DriverState
         $ok = Build-Driver
-        if ($ok) { $ok = Sign-Driver }
+        if ($ok) { $ok = Invoke-DriverSigning }
         if ($ok) { $ok = Install-Driver }
-        if ($ok) { $ok = Verify-Install }
+        if ($ok) { $ok = Test-Install }
         Get-DriverState
         if ($ok) {
             Read-Rid27Captures | Out-Null

--- a/v2-kmdf-driver/scripts/mm-dev.ps1
+++ b/v2-kmdf-driver/scripts/mm-dev.ps1
@@ -1,0 +1,769 @@
+<#
+.SYNOPSIS
+    Magic Mouse driver development cycle - state/build/sign/install/capture in one script.
+
+.DESCRIPTION
+    Enforces the loop: Understand state -> Implement -> Test -> Understand state.
+    Every step is timestamped and logged to $SessionLog.
+
+    Run from WSL:
+        powershell.exe -ExecutionPolicy Bypass -File "D:\mm3-driver\scripts\mm-dev.ps1" -Phase Full
+
+    Run directly (Admin PowerShell):
+        .\mm-dev.ps1 -Phase Full
+        .\mm-dev.ps1 -Phase State
+        .\mm-dev.ps1 -Phase Build
+        .\mm-dev.ps1 -Phase Install
+        .\mm-dev.ps1 -Phase Capture
+
+.PARAMETER Phase
+    State    - Snapshot current PnP + driver state
+    Build    - EWDK msbuild (Rebuild)
+    Sign     - signtool sign .sys + .cat
+    Install  - Remove old driver, install new, restart device
+    Verify   - Post-install health check (LowerFilters, COL01 status, oem package)
+    Rollback - Remove our filter driver entirely (recovery path)
+    Restore  - Re-apply LowerFilters without rebuild (use after BT reconnect)
+    Capture  - (Re)start DebugView capturing to $DebugLog
+    Full     - State -> Build -> Sign -> Install -> Verify -> State
+    Log      - Tail last 40 lines of session log
+    Debug    - Tail last 40 MagicMouse lines from debug log
+#>
+param(
+    [ValidateSet('State','Build','Sign','Install','Verify','Rollback','Restore','Capture','Full','Log','Debug')]
+    [string]$Phase = 'Full',
+
+    [string]$EwdkRoot   = 'F:\',
+    [string]$PkgDir     = 'D:\mm3-pkg',
+    [string]$SessionLog = 'C:\mm-dev-session.log',
+    [string]$DebugLog   = 'C:\mm3-debug.log',
+    [string]$Thumbprint = 'B902C2864315E2DE359450024768CE7D01715C38',
+    [string]$TimestampUrl = 'http://timestamp.digicert.com',
+    [string]$VendorPid  = 'VID&0001004c_PID&0323',  # Magic Mouse 2024 - used for device autodetect
+    [string]$DbgViewExe = 'C:\SysinternalsSuite\Dbgview.exe',
+    [string]$SignToolExe = 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+    [switch]$NoElevate    # internal flag - set when re-launched as admin to prevent infinite recursion
+)
+
+# ---------------------------------------------------------------------------
+# Self-elevation - re-launch as admin if needed (UAC prompt once per call)
+# ---------------------------------------------------------------------------
+function Test-IsAdmin {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-IsAdmin) -and -not $NoElevate) {
+    Write-Host "[mm-dev] Not Administrator - elevating via UAC (accept the prompt)..." -ForegroundColor Yellow
+
+    # Build relaunch arg list - preserve all bound params + add -NoElevate sentinel
+    $relaunchArgs = @('-NoProfile','-ExecutionPolicy','Bypass','-File',"$PSCommandPath",'-NoElevate')
+    foreach ($k in $PSBoundParameters.Keys) {
+        $v = $PSBoundParameters[$k]
+        if ($v -is [switch]) {
+            if ($v.IsPresent) { $relaunchArgs += "-$k" }
+        } else {
+            $relaunchArgs += "-$k"
+            $relaunchArgs += "$v"
+        }
+    }
+    if (-not ($PSBoundParameters.ContainsKey('Phase'))) {
+        $relaunchArgs += '-Phase'; $relaunchArgs += "$Phase"
+    }
+
+    try {
+        $proc = Start-Process -FilePath 'powershell.exe' `
+                              -ArgumentList $relaunchArgs `
+                              -Verb RunAs -Wait -PassThru `
+                              -WindowStyle Normal
+        Write-Host "[mm-dev] Elevated phase exited with code $($proc.ExitCode)" -ForegroundColor Cyan
+        Write-Host "[mm-dev] Session log: $SessionLog" -ForegroundColor Cyan
+        exit $proc.ExitCode
+    } catch {
+        Write-Host "[mm-dev] Elevation cancelled or failed: $_" -ForegroundColor Red
+        exit 2
+    }
+}
+
+# Auto-detect device ID by VID/PID (avoids hardcoded MAC that breaks on re-pair)
+function Resolve-DeviceId {
+    $devs = pnputil /enum-devices /connected 2>&1 | Out-String
+    $blocks = $devs -split "(?=Instance ID:)"
+    foreach ($b in $blocks) {
+        if ($b -match "Instance ID:\s+(BTHENUM\\\{00001124[^\r\n]*$VendorPid[^\r\n]*)" ) {
+            return $Matches[1].Trim()
+        }
+    }
+    return $null
+}
+
+# Derive driver source root from script location (scripts\ -> repo root).
+# Guard against $PSScriptRoot being null when called from a scheduled task context.
+$DriverRoot = if ($PSScriptRoot) { Split-Path -Parent $PSScriptRoot } else { 'D:\mm3-driver' }
+$BuildOut   = Join-Path $DriverRoot 'x64\Debug'
+$VcxProj    = Join-Path $DriverRoot 'MagicMouseDriver.vcxproj'
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+function Write-Log {
+    param([string]$Msg, [string]$Level = 'INFO')
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][$Level] $Msg"
+    Add-Content -Path $SessionLog -Value $line -Encoding UTF8
+    switch ($Level) {
+        'ERROR' { Write-Host $line -ForegroundColor Red }
+        'WARN'  { Write-Host $line -ForegroundColor Yellow }
+        'OK'    { Write-Host $line -ForegroundColor Green }
+        'HEAD'  { Write-Host "`n$line" -ForegroundColor Cyan }
+        default { Write-Host $line }
+    }
+}
+
+function Write-Section {
+    param([string]$Title)
+    $bar = '=' * 60
+    $line = "$bar`n=== $Title`n$bar"
+    Add-Content -Path $SessionLog -Value $line -Encoding UTF8
+    Write-Host "`n$line" -ForegroundColor Cyan
+}
+
+# ---------------------------------------------------------------------------
+# STATE
+# ---------------------------------------------------------------------------
+function Get-DriverState {
+    Write-Section "STATE SNAPSHOT - $(Get-Date -Format 'HH:mm:ss')"
+
+    # PnP devices matching our mouse
+    Write-Log "--- PnP devices (Magic Mouse 0x0323) ---"
+    $devs = pnputil /enum-devices /connected 2>&1
+    $relevant = $devs | Select-String -Pattern '0323|MagicMouse|Magic Mouse|COL01|COL02|oem52' -Context 0,5
+    if ($relevant) {
+        $relevant | ForEach-Object { Write-Log $_.Line }
+    } else {
+        Write-Log "(no matching connected devices)" 'WARN'
+    }
+
+    # Our driver package
+    Write-Log "--- Installed driver package ---"
+    $pkgs = pnputil /enum-drivers 2>&1
+    $ourPkg = ($pkgs | Select-String -Pattern 'MagicMouse|magicmouse' -Context 0,6)
+    if ($ourPkg) {
+        $ourPkg | ForEach-Object { Write-Log $_.Line }
+    } else {
+        Write-Log "(MagicMouseDriver not installed)" 'WARN'
+    }
+
+    # COL01 / COL02 status
+    Write-Log "--- HID child devices ---"
+    $col = pnputil /enum-devices 2>&1 | Select-String 'COL01|COL02' -Context 0,4
+    if ($col) {
+        $col | ForEach-Object { Write-Log $_.Line }
+    } else {
+        Write-Log "(COL01/COL02 not found)" 'WARN'
+    }
+
+    # LowerFilters registry
+    Write-Log "--- LowerFilters registry ---"
+    $regPath = 'HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&0001004c_PID&0323\9&73b8b28&0&D0C050CC8C4D_C00000000'
+    try {
+        $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        Write-Log "LowerFilters = $($lf -join ', ')" $(if ($lf -contains 'MagicMouseDriver') {'OK'} else {'WARN'})
+    } catch {
+        Write-Log "Registry key not found (device not paired?)" 'WARN'
+    }
+
+    # Built artifact info
+    Write-Log "--- Build artifact ---"
+    $sys = Join-Path $BuildOut 'MagicMouseDriver.sys'
+    if (Test-Path $sys) {
+        $fi = Get-Item $sys
+        Write-Log "MagicMouseDriver.sys  size=$($fi.Length)  modified=$($fi.LastWriteTime)" 'OK'
+    } else {
+        Write-Log "MagicMouseDriver.sys not found at $BuildOut" 'WARN'
+    }
+
+    # Last debug entries
+    Write-Log "--- Last 15 MagicMouse debug lines ---"
+    if (Test-Path $DebugLog) {
+        $lines = Get-Content $DebugLog | Select-String 'MagicMouse' | Select-Object -Last 15
+        if ($lines) { $lines | ForEach-Object { Write-Log $_.Line } }
+        else { Write-Log "(no MagicMouse entries yet)" }
+    } else {
+        Write-Log "(debug log not found - DebugView not running?)" 'WARN'
+    }
+
+    Write-Log "State snapshot complete." 'OK'
+}
+
+# ---------------------------------------------------------------------------
+# BUILD
+# ---------------------------------------------------------------------------
+function Build-Driver {
+    Write-Section "BUILD - $(Get-Date -Format 'HH:mm:ss')"
+
+    if (-not (Test-Path $VcxProj)) {
+        Write-Log "vcxproj not found: $VcxProj" 'ERROR'
+        return $false
+    }
+
+    # Use SetupBuildEnv.cmd directly (sets env vars and returns).
+    # NOT LaunchBuildEnv.cmd: that wraps SetupBuildEnv in `cmd /k` which spawns
+    # an interactive shell that never exits, hanging the entire pipeline.
+    $ewdkSetup = Join-Path $EwdkRoot 'BuildEnv\SetupBuildEnv.cmd'
+
+    # If not found at $EwdkRoot, scan all ready drives (handles ISO mounted to any letter).
+    if (-not (Test-Path $ewdkSetup)) {
+        Write-Log "EWDK not at $ewdkSetup - scanning drives..." 'WARN'
+        foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+            $candidate = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+            if (Test-Path $candidate) {
+                $ewdkSetup = $candidate
+                Write-Log "Found EWDK at $ewdkSetup" 'OK'
+                break
+            }
+        }
+    }
+
+    if (-not (Test-Path $ewdkSetup)) {
+        Write-Log "EWDK SetupBuildEnv.cmd not found on any drive. Mount the ISO first." 'ERROR'
+        return $false
+    }
+
+    Write-Log "Running EWDK msbuild (Rebuild) via temp batch file..."
+    # Write a temp .bat to avoid PowerShell→cmd double-quote mangling.
+    # cmd /c with embedded quotes produces '""' is not recognized errors.
+    $tempBat = [System.IO.Path]::GetTempFileName() -replace '\.tmp$','.bat'
+    @"
+@echo off
+call "$ewdkSetup" >NUL 2>&1
+if errorlevel 1 (
+    echo [BUILD] EWDK SetupBuildEnv.cmd failed >&2
+    exit /b 1
+)
+msbuild "$VcxProj" /p:Configuration=Debug /p:Platform=x64 /t:Rebuild /nologo /v:minimal /p:SignFiles=false /p:EnableCodeSigning=false
+"@ | Out-File -FilePath $tempBat -Encoding ASCII
+    Write-Log "Batch file: $tempBat"
+    $output = cmd /c $tempBat 2>&1
+    Remove-Item $tempBat -Force -ErrorAction SilentlyContinue
+    $output | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+
+    $sys     = Join-Path $BuildOut 'MagicMouseDriver.sys'
+    $presign = 'C:\mm3-presign\MagicMouseDriver.sys'
+
+    if (Test-Path $sys) {
+        Write-Log "Build succeeded: $sys" 'OK'
+        return $true
+    } elseif (Test-Path $presign) {
+        # SIGNTASK failed and deleted the .sys, but BackupPreSign saved it before sign ran.
+        Write-Log "SIGNTASK deleted .sys - restoring from BackupPreSign ($presign)" 'WARN'
+        Copy-Item $presign $sys -Force
+        Write-Log "Build succeeded (presign restored): $sys" 'OK'
+        return $true
+    } else {
+        Write-Log "Build FAILED - .sys not produced and no presign backup found." 'ERROR'
+        # Show last 20 lines of build output
+        $output | Select-Object -Last 20 | ForEach-Object { Write-Log $_ 'ERROR' }
+        return $false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# SIGN
+# ---------------------------------------------------------------------------
+function Sign-Driver {
+    Write-Section "SIGN - $(Get-Date -Format 'HH:mm:ss')"
+
+    if (-not (Test-Path $SignToolExe)) {
+        # Try to find signtool in common WDK locations
+        $candidates = @(
+            'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+            'C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe'
+        )
+        $SignToolExe = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $SignToolExe) {
+            Write-Log "signtool.exe not found - install Windows SDK/WDK" 'ERROR'
+            return $false
+        }
+    }
+
+    $targets = @(
+        (Join-Path $BuildOut 'MagicMouseDriver.sys'),
+        (Join-Path $BuildOut 'MagicMouseDriver.cat')
+    )
+
+    $ok = $true
+    foreach ($target in $targets) {
+        if (-not (Test-Path $target)) {
+            Write-Log "Not found, skipping: $target" 'WARN'
+            continue
+        }
+        Write-Log "Signing: $(Split-Path -Leaf $target)"
+        $result = & $SignToolExe sign /sm /v /sha1 $Thumbprint /fd SHA256 /t $TimestampUrl $target 2>&1
+        $result | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "Signed OK: $(Split-Path -Leaf $target)" 'OK'
+        } else {
+            Write-Log "Sign FAILED: $(Split-Path -Leaf $target)" 'ERROR'
+            $ok = $false
+        }
+    }
+    return $ok
+}
+
+# ---------------------------------------------------------------------------
+# INSTALL
+# ---------------------------------------------------------------------------
+function Get-CurrentOemPackage {
+    # Robust line-by-line parse of pnputil /enum-drivers to find our oem*.inf number.
+    # Used only for informational Verify checks; Install no longer calls pnputil /add-driver
+    # (it hangs in SYSTEM context due to silent cert-trust dialogs).
+    $out = pnputil /enum-drivers 2>&1
+    $currentOem = $null
+    $candidate  = $null
+    foreach ($line in $out) {
+        if ($line -match 'Published Name:\s+(oem\d+\.inf)') {
+            $candidate = $Matches[1]
+        }
+        if ($line -match 'magicmousedriver\.inf' -and $candidate) {
+            $currentOem = $candidate
+            break
+        }
+    }
+    return $currentOem
+}
+
+function Uninstall-DriverDirect {
+    # Order matters: remove LowerFilters FIRST, restart device (unloads .sys from stack),
+    # THEN sc.exe delete + Remove-Item .sys. Trying to delete a loaded .sys fails with
+    # "used by another process" even after sc.exe delete marks the service for deletion.
+    $devId = Resolve-DeviceId
+    if ($devId) {
+        $rp = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+        try {
+            $lf = (Get-ItemProperty $rp -ErrorAction Stop).LowerFilters
+            if ($lf -contains 'MagicMouseDriver') {
+                $newLf = @($lf | Where-Object { $_ -ne 'MagicMouseDriver' })
+                if ($newLf.Count -gt 0) {
+                    Set-ItemProperty $rp -Name LowerFilters -Value $newLf -Type MultiString
+                } else {
+                    Remove-ItemProperty $rp -Name LowerFilters -ErrorAction SilentlyContinue
+                }
+                Write-Log "LowerFilters: removed MagicMouseDriver - restarting device to unload driver" 'OK'
+                pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+                Start-Sleep -Seconds 2
+            }
+        } catch { }
+    }
+
+    Write-Log "Stopping service..."
+    sc.exe stop MagicMouseDriver 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    Write-Log "Deleting service..."
+    $scDel = sc.exe delete MagicMouseDriver 2>&1
+    $scDel | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+
+    $sysDest = 'C:\Windows\System32\drivers\MagicMouseDriver.sys'
+    if (Test-Path $sysDest) {
+        Remove-Item $sysDest -Force -ErrorAction SilentlyContinue
+        if (Test-Path $sysDest) {
+            Write-Log "$sysDest still locked after device restart - attempting rename workaround" 'WARN'
+            Rename-Item $sysDest "$sysDest.old" -Force -ErrorAction SilentlyContinue
+        } else {
+            Write-Log "Removed $sysDest" 'OK'
+        }
+    }
+}
+
+function Install-Driver {
+    Write-Section "INSTALL - $(Get-Date -Format 'HH:mm:ss')"
+
+    # Uninstall any previous install (no pnputil; direct sc.exe + registry).
+    Uninstall-DriverDirect
+
+    # Step 1: Copy .sys to System32\drivers (INF DestinationDir 12 = drivers\).
+    $sysSrc  = Join-Path $BuildOut 'MagicMouseDriver.sys'
+    $sysDest = 'C:\Windows\System32\drivers\MagicMouseDriver.sys'
+    if (-not (Test-Path $sysSrc)) {
+        Write-Log ".sys not found at $sysSrc" 'ERROR'
+        return $false
+    }
+    Copy-Item $sysSrc $sysDest -Force
+    Write-Log "Copied .sys to $sysDest" 'OK'
+
+    # Step 2: Register kernel service (replaces INF [Install.Services] AddService).
+    # sc.exe requires spaces after '=' - this is intentional PowerShell sc.exe syntax.
+    # Retry once on exit 1072 (marked for deletion): the previous service object may still
+    # be draining references when we arrive here, cleared within ~2s of device restart.
+    Write-Log "Creating kernel service MagicMouseDriver"
+    $scCreateArgs = @('create','MagicMouseDriver','type=','kernel','start=','demand',
+                      'binPath=','system32\drivers\MagicMouseDriver.sys',
+                      'DisplayName=','Magic Mouse Driver')
+    $scOut = sc.exe @scCreateArgs 2>&1
+    $scOut | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    if ($LASTEXITCODE -eq 1072) {
+        Write-Log "sc.exe create returned 1072 (service marked for deletion) - waiting 3s and retrying" 'WARN'
+        Start-Sleep -Seconds 3
+        $scOut = sc.exe @scCreateArgs 2>&1
+        $scOut | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Log "Service created." 'OK'
+    } else {
+        Write-Log "sc.exe create exited $LASTEXITCODE" 'WARN'
+    }
+
+    # Step 3: Resolve device and apply LowerFilters + restart.
+    $devId = Resolve-DeviceId
+    if (-not $devId) {
+        Write-Log "Device not currently connected - driver staged; connect mouse and run Verify" 'WARN'
+        return $true
+    }
+    Write-Log "Device: $devId"
+
+    # Set LowerFilters — MagicMouseDriver(0) below applewirelessmouse(1).
+    # Our driver at index 0 patches SDP completion first; applewirelessmouse sees our
+    # combined descriptor and does not re-patch. Swapping (test ee18af4) confirmed
+    # applewirelessmouse DOES gesture processing but conflicts with our combined descriptor
+    # (produces spurious clicks). Gesture processing is deferred to M14 in our own driver.
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    $targetLf = @('MagicMouseDriver', 'applewirelessmouse')
+    try {
+        $existing = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        $needsUpdate = ($null -eq $existing) -or
+                       ($existing.Count -ne $targetLf.Count) -or
+                       ($existing[0] -ne $targetLf[0]) -or
+                       ($existing[1] -ne $targetLf[1])
+        if ($needsUpdate) {
+            Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+            Write-Log "LowerFilters set: $($targetLf -join ',')" 'OK'
+        } else {
+            Write-Log "LowerFilters already correct: $($existing -join ',')" 'OK'
+        }
+    } catch {
+        Write-Log "Cannot set LowerFilters at $regPath : $_" 'ERROR'
+        return $false
+    }
+
+    # Step 4: Restart device to rebuild stack with new lower filter.
+    Write-Log "Restarting device: $devId"
+    $out = pnputil /restart-device $devId 2>&1
+    $out | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Log "Device restart sent." 'OK'
+    } else {
+        Write-Log "pnputil /restart-device exited $LASTEXITCODE" 'WARN'
+    }
+
+    Start-Sleep -Seconds 4
+
+    # Step 5: Re-apply LowerFilters after restart.
+    # pnputil /restart-device triggers a full BTHENUM re-enumeration. PnP re-runs the selected
+    # driver INF (oem0.inf / applewirelessmouse.inf) which has a replace-flag AddReg:
+    #   HKR,,"LowerFilters",0x00010000,"applewirelessmouse"   <- overwrites our entry
+    # The current stack survives the restart with our driver loaded, but the registry is reset.
+    # Re-applying here ensures the registry matches reality so the NEXT restart (BT reconnect,
+    # reboot) also loads MagicMouseDriver.
+    try {
+        $postLf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        $postNeedsUpdate = ($null -eq $postLf) -or
+                           ($postLf.Count -ne $targetLf.Count) -or
+                           ($postLf[0] -ne $targetLf[0]) -or
+                           ($postLf[1] -ne $targetLf[1])
+        if ($postNeedsUpdate) {
+            Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+            Write-Log "LowerFilters re-applied post-restart (oem0.inf reset guard): $($targetLf -join ',')" 'OK'
+        } else {
+            Write-Log "LowerFilters intact post-restart: $($postLf -join ',')" 'OK'
+        }
+    } catch {
+        Write-Log "Cannot re-apply LowerFilters post-restart: $_" 'WARN'
+    }
+
+    Write-Log "Install complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# VERIFY - post-install health check
+# ---------------------------------------------------------------------------
+function Verify-Install {
+    Write-Section "VERIFY - $(Get-Date -Format 'HH:mm:ss')"
+    $allOk = $true
+
+    # 1. oem package (INFO only - we bypass pnputil /add-driver, so no oem entry is expected)
+    $oem = Get-CurrentOemPackage
+    if ($oem) {
+        Write-Log "oem package: $oem" 'OK'
+    } else {
+        Write-Log "No oem package (expected - using direct sc.exe install)" 'INFO'
+    }
+
+    # 2. Service exists and .sys present?
+    $svc = Get-Service MagicMouseDriver -ErrorAction SilentlyContinue
+    if ($svc) {
+        Write-Log "Service MagicMouseDriver: $($svc.Status)" 'OK'
+    } else {
+        Write-Log "Service MagicMouseDriver not found" 'ERROR'
+        $allOk = $false
+    }
+    $sysDest = 'C:\Windows\System32\drivers\MagicMouseDriver.sys'
+    if (Test-Path $sysDest) {
+        $sz = (Get-Item $sysDest).Length
+        Write-Log ".sys present: $sysDest ($sz bytes)" 'OK'
+    } else {
+        Write-Log ".sys missing: $sysDest" 'ERROR'
+        $allOk = $false
+    }
+
+    # 3. Device connected?
+    $devId = Resolve-DeviceId
+    if (-not $devId) {
+        Write-Log "Device not connected - cannot verify runtime state" 'WARN'
+        return $allOk
+    }
+    Write-Log "Device: $devId" 'OK'
+
+    # 4. LowerFilters has MagicMouseDriver?
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    try {
+        $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        if ($lf -contains 'MagicMouseDriver') {
+            Write-Log "LowerFilters: $($lf -join ',') (MagicMouseDriver bound)" 'OK'
+        } else {
+            Write-Log "LowerFilters: $($lf -join ',') - MagicMouseDriver NOT bound" 'ERROR'
+            $allOk = $false
+        }
+    } catch {
+        Write-Log "Cannot read LowerFilters at $regPath" 'ERROR'
+        $allOk = $false
+    }
+
+    # 5. COL01 (HID mouse child) present?
+    # Use pnputil /enum-devices without /connected - HID children are not "Bluetooth-connected"
+    # but do appear as Started devices under the HID bus.
+    $devAll = pnputil /enum-devices 2>&1 | Out-String
+    $col01Found = $devAll -match "VID&0001004c_PID&0323&Col01"
+    if ($col01Found) {
+        Write-Log "COL01 (HID-compliant mouse): enumerated" 'OK'
+    } else {
+        Write-Log "COL01 not found in device list - HID descriptor may be missing scroll collection" 'WARN'
+    }
+
+    # 6. Diag registry keys (written by driver timer at 1Hz to Services\MagicMouseDriver\Diag)
+    $diagPath = "HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag"
+    if (Test-Path $diagPath) {
+        $diag = Get-ItemProperty $diagPath -ErrorAction SilentlyContinue
+        Write-Log "Diag: IoctlInterceptCount=$($diag.IoctlInterceptCount) SdpScanHits=$($diag.SdpScanHits) SdpPatchSuccess=$($diag.SdpPatchSuccess) LastSdpBufSize=$($diag.LastSdpBufSize)" 'OK'
+    } else {
+        Write-Log "Diag key not yet created at Services\MagicMouseDriver\Diag (driver timer may not have fired or driver not attached to device stack)" 'INFO'
+    }
+
+    if ($allOk) {
+        Write-Log "VERIFY PASSED - driver bound, .sys present, LowerFilters set" 'OK'
+    } else {
+        Write-Log "VERIFY FAILED - see findings above" 'ERROR'
+    }
+    return $allOk
+}
+
+# ---------------------------------------------------------------------------
+# ROLLBACK - recovery path: remove our filter entirely
+# ---------------------------------------------------------------------------
+function Rollback-Driver {
+    Write-Section "ROLLBACK - $(Get-Date -Format 'HH:mm:ss')"
+    # Use direct uninstall (no pnputil /delete-driver which hangs in SYSTEM context).
+    Uninstall-DriverDirect
+    $devId = Resolve-DeviceId
+    if ($devId) {
+        Write-Log "Restarting device to drop filter binding..."
+        pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+    }
+    Write-Log "Rollback complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# RESTORE - re-apply LowerFilters without rebuild (recovery after BT reconnect)
+# ---------------------------------------------------------------------------
+function Restore-LowerFilters {
+    Write-Section "RESTORE LOWERFILTERS - $(Get-Date -Format 'HH:mm:ss')"
+
+    $devId = Resolve-DeviceId
+    if (-not $devId) {
+        Write-Log "Device not connected - cannot restore LowerFilters" 'WARN'
+        return $false
+    }
+    Write-Log "Device: $devId"
+
+    $regPath  = "HKLM:\SYSTEM\CurrentControlSet\Enum\$devId"
+    $targetLf = @('applewirelessmouse', 'MagicMouseDriver')
+    try {
+        $existing = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+        $needsUpdate = ($null -eq $existing) -or
+                       ($existing.Count -ne $targetLf.Count) -or
+                       ($existing[0] -ne $targetLf[0]) -or
+                       ($existing[1] -ne $targetLf[1])
+        if (-not $needsUpdate) {
+            Write-Log "LowerFilters already correct: $($existing -join ',')" 'OK'
+        } else {
+            Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+            Write-Log "LowerFilters restored: $($targetLf -join ',')" 'OK'
+
+            # Start service if not running
+            $svc = Get-Service MagicMouseDriver -ErrorAction SilentlyContinue
+            if ($svc -and $svc.Status -ne 'Running') {
+                sc.exe start MagicMouseDriver 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+                Start-Sleep -Seconds 2
+                Write-Log "Service start requested." 'OK'
+            }
+
+            # Restart device so stack rebuilds with the filter.
+            Write-Log "Restarting device to apply restored LowerFilters..."
+            pnputil /restart-device $devId 2>&1 | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
+            Start-Sleep -Seconds 4
+
+            # Re-apply post-restart guard
+            $postLf = (Get-ItemProperty $regPath -ErrorAction SilentlyContinue).LowerFilters
+            $postNeedsUpdate = ($null -eq $postLf) -or ($postLf[0] -ne $targetLf[0]) -or ($postLf[1] -ne $targetLf[1])
+            if ($postNeedsUpdate) {
+                Set-ItemProperty $regPath -Name LowerFilters -Value $targetLf -Type MultiString
+                Write-Log "LowerFilters re-applied post-restart: $($targetLf -join ',')" 'OK'
+            }
+        }
+    } catch {
+        Write-Log "Cannot restore LowerFilters at $regPath : $_" 'ERROR'
+        return $false
+    }
+
+    Write-Log "Restore complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# DEBUG CAPTURE
+# ---------------------------------------------------------------------------
+function Read-Rid27Captures {
+    # M14: read RID=0x27 ring buffer from registry (no DebugView required).
+    # The driver's 1Hz DiagWorkItem writes:
+    #   Diag\HidReadCount   DWORD   total IRP_MJ_READ completions
+    #   Diag\Rid27Count     DWORD   how many had buf[0]==0x27
+    #   Diag\Rid27SlotsFilled DWORD  slots written (capped at 8)
+    #   Diag\Rid27RingBuf   REG_BINARY  8 x 48 bytes of raw reports
+    Write-Section "CAPTURE (RID=0x27 ring buffer) - $(Get-Date -Format 'HH:mm:ss')"
+
+    $diagKey = 'HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag'
+    if (-not (Test-Path $diagKey)) {
+        Write-Log "Diag registry key not found - driver not loaded or not M14 build" 'ERROR'
+        return $false
+    }
+
+    $props        = Get-ItemProperty $diagKey -ErrorAction SilentlyContinue
+    $hidReads     = $props.HidReadCount
+    $rid27Count   = $props.Rid27Count
+    $slotsFilled  = $props.Rid27SlotsFilled
+    $ringBuf      = $props.Rid27RingBuf   # byte[] or $null
+
+    Write-Log "HidReadCount=$hidReads  Rid27Count=$rid27Count  SlotsFilled=$slotsFilled" 'OK'
+
+    if (-not $slotsFilled -or $slotsFilled -eq 0) {
+        Write-Log "No RID=0x27 captures yet - touch the mouse surface and re-run Capture" 'WARN'
+        return $false
+    }
+
+    if (-not $ringBuf -or $ringBuf.Length -eq 0) {
+        Write-Log "Rid27RingBuf key empty despite SlotsFilled=$slotsFilled" 'WARN'
+        return $false
+    }
+
+    # Dump each filled slot
+    $nSlots = [Math]::Min($slotsFilled, 8)
+    Write-Log "--- RID=0x27 ring buffer: $nSlots slot(s) ---"
+    for ($i = 0; $i -lt $nSlots; $i++) {
+        $offset = $i * 48
+        $slot   = $ringBuf[$offset..($offset + 47)]
+        $hex    = ($slot | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
+        Write-Log "Slot[$i]: $hex"
+
+        # Layout analysis (Linux hid-magicmouse.c reference)
+        $rid     = $slot[0]
+        $flags   = $slot[1]
+        $ts      = [uint16]($slot[2] + ($slot[3] -shl 8))
+        $nFinger = $slot[4]
+        Write-Log "  RID=0x{0:X2}  flags=0x{1:X2}  ts={2}  nFingers={3}" -f $rid,$flags,$ts,$nFinger
+        # Bytes 5..end: per-finger data (7 bytes each in hid-magicmouse v2/v3)
+        if ($nFinger -gt 0) {
+            for ($f = 0; $f -lt $nFinger; $f++) {
+                $foff = 5 + ($f * 9)
+                if ($foff + 8 -ge 48) { break }
+                $absX = [int16]($slot[$foff] + ($slot[$foff+1] -shl 8))
+                $absY = [int16]($slot[$foff+2] + ($slot[$foff+3] -shl 8))
+                Write-Log ("  Finger[$f]: x={0} y={1} raw=[{2}]" -f $absX, $absY,
+                    (($slot[$foff..($foff+8)]) | ForEach-Object { '{0:X2}' -f $_ }) -join ' ')
+            }
+        }
+    }
+
+    Write-Log "Capture complete." 'OK'
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# SHOW LOGS
+# ---------------------------------------------------------------------------
+function Show-SessionLog {
+    Write-Section "SESSION LOG (last 40 lines)"
+    if (Test-Path $SessionLog) {
+        Get-Content $SessionLog | Select-Object -Last 40
+    } else {
+        Write-Log "No session log yet." 'WARN'
+    }
+}
+
+function Show-DebugLog {
+    Write-Section "DEBUG LOG - MagicMouse entries (last 40)"
+    if (Test-Path $DebugLog) {
+        $lines = Get-Content $DebugLog | Select-String 'MagicMouse' | Select-Object -Last 40
+        if ($lines) { $lines | ForEach-Object { Write-Host $_.Line } }
+        else { Write-Log "(no MagicMouse entries)" 'WARN' }
+    } else {
+        Write-Log "Debug log not found - run: .\mm-dev.ps1 -Phase Capture" 'WARN'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# MAIN
+# ---------------------------------------------------------------------------
+Write-Log "=== mm-dev.ps1 Phase=$Phase ===" 'HEAD'
+
+$exitCode = 0
+switch ($Phase) {
+    'State'    { Get-DriverState }
+    'Build'    { if (-not (Build-Driver))   { $exitCode = 1 } }
+    'Sign'     { if (-not (Sign-Driver))    { $exitCode = 1 } }
+    'Install'  { if (-not (Install-Driver)) { $exitCode = 1 } }
+    'Verify'   { if (-not (Verify-Install)) { $exitCode = 1 } }
+    'Rollback' { if (-not (Rollback-Driver)){ $exitCode = 1 } }
+    'Restore'  { if (-not (Restore-LowerFilters)) { $exitCode = 1 } }
+    'Capture'  { if (-not (Read-Rid27Captures)) { $exitCode = 1 } }
+    'Log'      { Show-SessionLog }
+    'Debug'    { Show-DebugLog }
+    'Full' {
+        Get-DriverState
+        $ok = Build-Driver
+        if ($ok) { $ok = Sign-Driver }
+        if ($ok) { $ok = Install-Driver }
+        if ($ok) { $ok = Verify-Install }
+        Get-DriverState
+        if ($ok) {
+            Read-Rid27Captures | Out-Null
+            Write-Log "Full cycle complete - touch mouse surface then run Capture to read ring buffer." 'OK'
+        } else {
+            Write-Log "Full cycle FAILED - check session log: $SessionLog" 'ERROR'
+            $exitCode = 1
+        }
+    }
+}
+
+Write-Log "Done. Session log: $SessionLog (exit=$exitCode)"
+exit $exitCode

--- a/v2-kmdf-driver/scripts/mm-dev.sh
+++ b/v2-kmdf-driver/scripts/mm-dev.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# mm-dev.sh - WSL wrapper for the Magic Mouse driver dev cycle
+#
+# USAGE (from WSL, inside the repo):
+#   ./scripts/mm-dev.sh state          # snapshot current PnP + driver state
+#   ./scripts/mm-dev.sh build          # EWDK msbuild
+#   ./scripts/mm-dev.sh sign           # signtool
+#   ./scripts/mm-dev.sh install        # remove old + install new + restart device
+#   ./scripts/mm-dev.sh capture        # (re)start DebugView
+#   ./scripts/mm-dev.sh full           # state -> build -> sign -> install -> state
+#   ./scripts/mm-dev.sh log            # tail session log
+#   ./scripts/mm-dev.sh debug          # tail MagicMouse entries from DebugView log
+#   ./scripts/mm-dev.sh commit "msg"   # stage driver/ and commit via git.py
+#   ./scripts/mm-dev.sh diff           # show uncommitted driver changes
+#
+# The loop:
+#   1. Edit driver source (WSL)
+#   2. ./scripts/mm-dev.sh full
+#   3. ./scripts/mm-dev.sh capture
+#   4. Test mouse gestures
+#   5. ./scripts/mm-dev.sh debug
+#   6. ./scripts/mm-dev.sh commit "fix: ..."
+#   7. Repeat from 1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+GIT_PY="/home/lesley/projects/scripts/git.py"
+SESSION_LOG="/mnt/c/mm-dev-session.log"
+DEBUG_LOG="/mnt/c/mm3-debug.log"
+
+# Windows-side build directory. WSL repo is SSOT - we sync into here.
+# The .vcxproj lives at the root of WIN_DRIVER_DIR (NOT in a driver/ subfolder).
+WIN_DRIVER_DIR="${WIN_DRIVER_DIR:-/mnt/d/mm3-driver}"
+
+# Scheduled task for headless (no-UAC) execution.
+# Registered once via mm-task-setup.ps1 — see TASK SETUP section in --help.
+TASK_NAME="${MM_TASK_NAME:-MM-Dev-Cycle}"
+QUEUE_DIR="/mnt/c/mm-dev-queue"
+TASK_TIMEOUT="${MM_TASK_TIMEOUT:-600}"   # 10 min default
+
+task_exists() {
+    # Tasks set with RunLevel=Highest require admin to query. From a non-admin
+    # WSL shell, schtasks /query returns "Access is denied" even when the task
+    # IS registered. Distinguish "doesn't exist" from "exists but can't read":
+    #   - "ERROR: The system cannot find ..." -> truly missing -> return 1
+    #   - "ERROR: Access is denied" -> exists, treat as found -> return 0
+    #   - success -> exists -> return 0
+    local out
+    out=$(schtasks.exe /query /tn "$TASK_NAME" 2>&1)
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        return 0
+    fi
+    if echo "$out" | grep -qiE "cannot find|does not exist|not found"; then
+        return 1
+    fi
+    # Any other error (Access denied etc.) -> assume task exists
+    return 0
+}
+
+# Sync WSL repo driver/ + scripts/ into Windows build dir.
+# Idempotent; safe to call before every phase. Build artefacts (x64/, *.cer)
+# in WIN_DRIVER_DIR are preserved (we only overwrite source + scripts).
+sync_to_windows() {
+    if [[ ! -d "$WIN_DRIVER_DIR" ]]; then
+        echo "[mm-dev] ERROR: $WIN_DRIVER_DIR does not exist." >&2
+        echo "[mm-dev] Create it and copy the initial files (vcxproj, *.cer) — then re-run." >&2
+        return 1
+    fi
+    # Source files (driver/* → WIN_DRIVER_DIR/)
+    cp -f "$REPO_ROOT/driver/"*.c    "$WIN_DRIVER_DIR/" 2>/dev/null || true
+    cp -f "$REPO_ROOT/driver/"*.h    "$WIN_DRIVER_DIR/" 2>/dev/null || true
+    cp -f "$REPO_ROOT/driver/"*.inf  "$WIN_DRIVER_DIR/" 2>/dev/null || true
+    cp -f "$REPO_ROOT/driver/MagicMouseDriver.vcxproj" "$WIN_DRIVER_DIR/" 2>/dev/null || true
+    # Scripts (scripts/* → WIN_DRIVER_DIR/scripts/)
+    install -d "$WIN_DRIVER_DIR/scripts"
+    cp -f "$REPO_ROOT/scripts/"*.ps1 "$WIN_DRIVER_DIR/scripts/" 2>/dev/null || true
+    return 0
+}
+
+# Resolve PS1 path: prefer Windows-synced copy (so $PSScriptRoot resolves to
+# WIN_DRIVER_DIR\scripts and $DriverRoot lands on the vcxproj location).
+# Fall back to WSL UNC path only if the sync target is unavailable.
+resolve_ps1_path() {
+    if [[ -f "$WIN_DRIVER_DIR/scripts/mm-dev.ps1" ]]; then
+        # Convert /mnt/d/mm3-driver/scripts/mm-dev.ps1 → D:\mm3-driver\scripts\mm-dev.ps1
+        wslpath -w "$WIN_DRIVER_DIR/scripts/mm-dev.ps1"
+    else
+        wslpath -w "$SCRIPTS_DIR/mm-dev.ps1"
+    fi
+}
+
+phase="${1:-help}"
+
+# Map lowercase phase names -> PowerShell ValidateSet casing (no GNU-sed dep)
+declare -A PHASE_MAP=(
+    [state]=State [build]=Build [sign]=Sign [install]=Install
+    [verify]=Verify [rollback]=Rollback [capture]=Capture
+    [full]=Full   [log]=Log     [debug]=Debug
+)
+
+run_via_task() {
+    local phase_arg="$1"
+    local nonce; nonce="$(date +%s%N)"
+    install -d "$QUEUE_DIR"
+    rm -f "$QUEUE_DIR/result.txt" 2>/dev/null
+
+    # Write request (CRLF for Windows tooling robustness)
+    printf '%s|%s\r\n' "$phase_arg" "$nonce" > "$QUEUE_DIR/request.txt"
+
+    echo "[mm-dev] Triggering scheduled task '$TASK_NAME' (no UAC, runs as SYSTEM)..."
+    if ! schtasks.exe /run /tn "$TASK_NAME" >/dev/null 2>&1; then
+        echo "[mm-dev] schtasks /run failed - falling back to direct PowerShell" >&2
+        return 200
+    fi
+
+    # Poll for result (up to TASK_TIMEOUT seconds)
+    local elapsed=0
+    while (( elapsed < TASK_TIMEOUT )); do
+        if [[ -f "$QUEUE_DIR/result.txt" ]]; then
+            local raw rc res_nonce
+            raw="$(tr -d '\r\n' < "$QUEUE_DIR/result.txt")"
+            rc="${raw%%|*}"
+            res_nonce="${raw#*|}"
+            if [[ "$res_nonce" == "$nonce" ]]; then
+                return "$rc"
+            fi
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+        # Show running indicator every 10 seconds
+        if (( elapsed % 10 == 0 )); then
+            echo "[mm-dev]   ... still running (${elapsed}s elapsed)"
+        fi
+    done
+    echo "[mm-dev] Task timeout after ${TASK_TIMEOUT}s - check C:\\mm-dev-task.log" >&2
+    return 124
+}
+
+run_via_uac() {
+    local phase_arg="$1"
+    local win_ps1; win_ps1="$(resolve_ps1_path)"
+    echo "[mm-dev] Running Phase=$phase_arg via direct PowerShell (UAC prompt expected)..."
+    powershell.exe -ExecutionPolicy Bypass -File "$win_ps1" -Phase "$phase_arg"
+    return $?
+}
+
+run_ps1() {
+    local lookup="${1,,}"  # bash 4+ lowercase
+    local phase_arg="${PHASE_MAP[$lookup]}"
+    if [[ -z "$phase_arg" ]]; then
+        echo "[mm-dev] ERROR: unknown phase '$1'" >&2
+        return 2
+    fi
+    # Sync source/scripts into Windows build dir so $PSScriptRoot resolves correctly
+    if ! sync_to_windows; then
+        return 1
+    fi
+    # Capture line count BEFORE the phase so we can print only this phase's output.
+    # (bash can't reliably write to /mnt/c/mm-dev-session.log - PS owns ACL on it.)
+    local before_lines=0
+    [[ -f "$SESSION_LOG" ]] && before_lines=$(wc -l < "$SESSION_LOG" 2>/dev/null || echo 0)
+
+    local rc
+    if task_exists; then
+        run_via_task "$phase_arg"
+        rc=$?
+        # 200 = task trigger failed; fall back to UAC path
+        if [[ $rc -eq 200 ]]; then
+            run_via_uac "$phase_arg"
+            rc=$?
+        fi
+    else
+        echo "[mm-dev] No scheduled task '$TASK_NAME' registered - using UAC path." >&2
+        echo "[mm-dev] To eliminate UAC prompts, run ONCE from admin PowerShell:" >&2
+        echo "[mm-dev]   $WIN_DRIVER_DIR/scripts/mm-task-setup.ps1" >&2
+        run_via_uac "$phase_arg"
+        rc=$?
+    fi
+
+    # Show all session log lines written since this phase began
+    if [[ -f "$SESSION_LOG" ]]; then
+        local after_lines; after_lines=$(wc -l < "$SESSION_LOG" 2>/dev/null || echo 0)
+        if (( after_lines > before_lines )); then
+            echo "----- session log (Phase=$phase_arg, $((after_lines - before_lines)) new lines) -----"
+            sed -n "$((before_lines + 1)),${after_lines}p" "$SESSION_LOG"
+            echo "------------------------------------"
+        else
+            echo "[mm-dev] WARN: no new session log lines (phase may have crashed before logging)" >&2
+        fi
+    fi
+    if [[ $rc -ne 0 ]]; then
+        echo "[mm-dev] Windows phase FAILED (exit=$rc) - full log: $SESSION_LOG" >&2
+    else
+        echo "[mm-dev] Windows phase OK (exit=0)"
+    fi
+    return $rc
+}
+
+case "$phase" in
+    state|build|sign|install|verify|rollback|capture|full|log|debug)
+        run_ps1 "$phase"
+        exit $?
+        ;;
+
+    commit)
+        msg="${2:-chore: driver update}"
+        echo "[mm-dev] Staging driver/ ..."
+        git -C "$REPO_ROOT" add driver/
+        echo "[mm-dev] Committing: $msg"
+        python3 "$GIT_PY" commit --branch main --message "$msg
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+        echo "[mm-dev] Committed."
+        ;;
+
+    diff)
+        echo "[mm-dev] Uncommitted driver changes:"
+        git -C "$REPO_ROOT" diff driver/
+        git -C "$REPO_ROOT" status driver/
+        ;;
+
+    read-log)
+        lines="${2:-50}"
+        echo "[mm-dev] Session log (last $lines lines):"
+        tail -n "$lines" "$SESSION_LOG" 2>/dev/null || echo "(no session log yet)"
+        ;;
+
+    read-debug)
+        lines="${2:-40}"
+        echo "[mm-dev] MagicMouse debug entries (last $lines):"
+        grep "MagicMouse" "$DEBUG_LOG" 2>/dev/null | tail -n "$lines" || echo "(no entries yet)"
+        ;;
+
+    help|*)
+        cat <<EOF
+mm-dev.sh - Magic Mouse driver dev cycle (WSL wrapper)
+
+LOOP:
+  1. Edit driver/ in WSL
+  2. ./scripts/mm-dev.sh full          ← build + sign + install + state snapshot
+  3. ./scripts/mm-dev.sh capture       ← (re)start DebugView
+  4. Test mouse gestures on Windows
+  5. ./scripts/mm-dev.sh debug         ← read what happened
+  6. ./scripts/mm-dev.sh commit "msg"  ← commit the change
+  7. Repeat
+
+COMMANDS:
+  state       Snapshot PnP devices, driver, registry, debug log tail
+  build       EWDK msbuild Rebuild
+  sign        signtool sign .sys + .cat
+  install     Remove old driver, install new, restart device
+  verify      Post-install health check (LowerFilters, COL01 Started)
+  rollback    Remove our filter driver entirely (recovery path)
+  capture     (Re)start DebugView -> C:\mm3-debug.log
+  full        state + build + sign + install + verify + state
+  log         Tail C:\mm-dev-session.log
+  debug       Tail MagicMouse lines from C:\mm3-debug.log
+  commit MSG  Stage driver/ and commit via git.py
+  diff        Show uncommitted changes in driver/
+  read-log N  Read last N lines of session log (default 50)
+  read-debug N Read last N MagicMouse debug lines (default 40)
+
+EXIT CODES: 0=ok, 1=phase failure (build/sign/install/verify failed), 2=usage,
+            124=task timeout, 200=task trigger failed (fell back to UAC path)
+
+TASK SETUP (one-time, eliminates all future UAC prompts):
+  1. Open admin PowerShell (UAC prompt OK once)
+  2. cd D:\mm3-driver\scripts
+  3. .\mm-task-setup.ps1
+  After that, schtasks /run /tn MM-Dev-Cycle works from WSL with NO UAC.
+  This wrapper auto-detects the task and uses it instead of the UAC path.
+
+ENV OVERRIDES:
+  WIN_DRIVER_DIR    Windows build dir (default: /mnt/d/mm3-driver)
+  MM_TASK_NAME      Scheduled task name (default: MM-Dev-Cycle)
+  MM_TASK_TIMEOUT   Task wait timeout in seconds (default: 600)
+EOF
+        ;;
+esac

--- a/v2-kmdf-driver/scripts/mm-task-runner-addendum.txt
+++ b/v2-kmdf-driver/scripts/mm-task-runner-addendum.txt
@@ -1,0 +1,42 @@
+mm-task-runner.ps1 addendum for A4 (HIDPAYLOAD) phase support
+==============================================================
+
+Add the following block to mm-task-runner.ps1 BEFORE the `else` default block
+(approximately after line 244, after the DISCOVER: case).
+
+Note: File at D:\mm3-driver\scripts\mm-test-A4-hidpayload-capture.ps1
+
+--- PATCH START ---
+    # Special phase prefix "HIDPAYLOAD:*" routes to mm-test-A4-hidpayload-capture.ps1
+    elseif ($phase -like 'HIDPAYLOAD:*') {
+        $a4Script = 'D:\mm3-driver\scripts\mm-test-A4-hidpayload-capture.ps1'
+        if (-not (Test-Path $a4Script)) {
+            Log "ERROR: mm-test-A4-hidpayload-capture.ps1 not found at $a4Script"
+            "127|$nonce" | Set-Content $ResFile -Encoding ASCII
+            exit 127
+        }
+        $extraArg = ($phase -split ':', 2)[1]
+        Log "Using $a4Script arg='$extraArg'"
+        try {
+            if ($extraArg -like 'ETL:*') {
+                $etlPath = ($extraArg -split ':', 2)[1]
+                & $a4Script -ExistingEtl $etlPath
+            } else {
+                & $a4Script
+            }
+            $rc = $LASTEXITCODE
+            if ($null -eq $rc) { $rc = 0 }
+        } catch {
+            Log "Exception running mm-test-A4-hidpayload-capture.ps1: $_"
+            $rc = 99
+        }
+    }
+--- PATCH END ---
+
+WSL dispatch examples:
+  ./scripts/mm-queue-submit.sh "HIDPAYLOAD:Fresh"
+  ./scripts/mm-queue-submit.sh "HIDPAYLOAD:ETL:C:\mm-a4-etw-20260428-220000\a4-capture.etl"
+
+The second form runs Get-WinEvent against an existing ETL file instead of starting
+a new capture session. Useful for re-analyzing large existing ETL files without
+running a new 60-second capture.

--- a/v2-kmdf-driver/scripts/mm-task-setup.ps1
+++ b/v2-kmdf-driver/scripts/mm-task-setup.ps1
@@ -24,9 +24,9 @@ function Test-IsAdmin {
 
 if (-not (Test-IsAdmin)) {
     Write-Host "Not admin - re-launching elevated (accept UAC)..." -ForegroundColor Yellow
-    $args = @('-NoProfile','-ExecutionPolicy','Bypass','-File',"$PSCommandPath")
-    if ($Uninstall) { $args += '-Uninstall' }
-    $proc = Start-Process powershell.exe -ArgumentList $args -Verb RunAs -Wait -PassThru
+    $psArgs = @('-NoProfile','-ExecutionPolicy','Bypass','-File',"$PSCommandPath")
+    if ($Uninstall) { $psArgs += '-Uninstall' }
+    $proc = Start-Process powershell.exe -ArgumentList $psArgs -Verb RunAs -Wait -PassThru
     exit $proc.ExitCode
 }
 

--- a/v2-kmdf-driver/scripts/mm-task-setup.ps1
+++ b/v2-kmdf-driver/scripts/mm-task-setup.ps1
@@ -1,0 +1,116 @@
+# mm-task-setup.ps1 - register the SYSTEM scheduled task 'MM-Dev-Cycle'
+#
+# Run ONCE from an admin PowerShell window. After this:
+#   - WSL can trigger any phase via `schtasks /run /tn MM-Dev-Cycle` (NO UAC)
+#   - The task runs as SYSTEM (highest privilege, no UAC ever)
+#   - mm-dev.sh autodetects the task and uses it
+#
+# To uninstall: .\mm-task-setup.ps1 -Uninstall
+#               (or: schtasks /delete /tn MM-Dev-Cycle /f)
+
+[CmdletBinding()]
+param(
+    [switch]$Uninstall,
+    [string]$TaskName = 'MM-Dev-Cycle',
+    [string]$RunnerScript = (Join-Path $PSScriptRoot 'mm-task-runner.ps1')
+)
+
+# Self-elevate if not admin
+function Test-IsAdmin {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-IsAdmin)) {
+    Write-Host "Not admin - re-launching elevated (accept UAC)..." -ForegroundColor Yellow
+    $args = @('-NoProfile','-ExecutionPolicy','Bypass','-File',"$PSCommandPath")
+    if ($Uninstall) { $args += '-Uninstall' }
+    $proc = Start-Process powershell.exe -ArgumentList $args -Verb RunAs -Wait -PassThru
+    exit $proc.ExitCode
+}
+
+if ($Uninstall) {
+    Write-Host "Removing scheduled task '$TaskName'..." -ForegroundColor Yellow
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+    Write-Host "Done." -ForegroundColor Green
+    exit 0
+}
+
+if (-not (Test-Path $RunnerScript)) {
+    Write-Host "ERROR: runner script not found: $RunnerScript" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Registering scheduled task '$TaskName'..." -ForegroundColor Cyan
+Write-Host "  Runner: $RunnerScript" -ForegroundColor Gray
+
+# On-demand action - fires runner script as SYSTEM with no UI
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+    -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`""
+
+# Run as the CURRENT USER with elevated token (highest privilege).
+# Why not SYSTEM (S-1-5-18): SYSTEM lives in Session 0 and cannot see drives
+# mounted in the user's interactive session - including the EWDK ISO at F:\.
+# A SYSTEM task tried to run F:\LaunchBuildEnv.cmd and silently failed because
+# the path didn't exist from its perspective.
+#
+# InteractiveToken + Highest: runs in the user's session (Session 1), has access
+# to mounted drives, gets admin token automatically when user is logged in.
+# No UAC prompt. No password storage. Trade-off: user must be logged in.
+$currentUser = "$env:USERDOMAIN\$env:USERNAME"
+# LogonType enum values vary by PS version: PS 5.1 uses 'InteractiveToken',
+# PS 7+ uses 'Interactive'. We use the PS 7 name and accept that PS 5.1
+# users would need 'InteractiveToken' instead. Detect at runtime.
+$logonType = if ($PSVersionTable.PSVersion.Major -ge 7) { 'Interactive' } else { 'InteractiveToken' }
+$principal = New-ScheduledTaskPrincipal -UserId $currentUser -RunLevel Highest -LogonType $logonType -ErrorAction Stop
+
+# Settings: on-demand only, no battery restriction, 30-min timeout, deny concurrent
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 30) `
+    -MultipleInstances IgnoreNew `
+    -DisallowDemandStart:$false `
+    -Hidden
+
+try {
+    Register-ScheduledTask -TaskName $TaskName `
+        -Action $action `
+        -Principal $principal `
+        -Settings $settings `
+        -Description 'Magic Mouse driver dev cycle - triggered on demand from WSL via schtasks /run' `
+        -Force -ErrorAction Stop | Out-Null
+} catch {
+    Write-Host "ERROR: Register-ScheduledTask failed: $_" -ForegroundColor Red
+    exit 1
+}
+
+# Verify the principal was actually applied (not silently fallen back to SYSTEM)
+$registered = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $registered) {
+    Write-Host "ERROR: Task verify failed - cannot read back $TaskName" -ForegroundColor Red
+    exit 1
+}
+$actualUser = $registered.Principal.UserId
+$actualLogon = $registered.Principal.LogonType
+
+# Create queue dir
+$queueDir = 'C:\mm-dev-queue'
+if (-not (Test-Path $queueDir)) { New-Item -ItemType Directory $queueDir -Force | Out-Null }
+
+Write-Host "Task '$TaskName' registered." -ForegroundColor Green
+Write-Host "  Principal: $actualUser  LogonType: $actualLogon  RunLevel: $($registered.Principal.RunLevel)" -ForegroundColor Gray
+Write-Host ""
+Write-Host "Verify with:" -ForegroundColor Cyan
+Write-Host "  schtasks /query /tn $TaskName" -ForegroundColor White
+Write-Host ""
+Write-Host "Trigger from WSL or anywhere (no UAC):" -ForegroundColor Cyan
+Write-Host "  schtasks /run /tn $TaskName" -ForegroundColor White
+Write-Host ""
+Write-Host "From WSL (uses the task automatically):" -ForegroundColor Cyan
+Write-Host "  ./scripts/mm-dev.sh full" -ForegroundColor White
+Write-Host ""
+Write-Host "Uninstall:" -ForegroundColor Cyan
+Write-Host "  .\mm-task-setup.ps1 -Uninstall" -ForegroundColor White

--- a/v2-kmdf-driver/scripts/pathA-trust-and-install.ps1
+++ b/v2-kmdf-driver/scripts/pathA-trust-and-install.ps1
@@ -1,0 +1,121 @@
+# PATH-A v3 trust-and-install — runs as SYSTEM via task runner
+# Adds M14 cert to LocalMachine\Root + invokes pnputil /add-driver /install /force
+# Outputs to log file passed as $LogPath argument.
+
+param(
+    [Parameter(Mandatory=$true)][string]$LogPath
+)
+
+$ErrorActionPreference = 'Continue'
+$thumb = '16940C0F937D569363560D5FEC5CD8FA6D6D9BCE'
+$cerPath = 'C:\mm-dev-queue\MagicMouseFix.cer'
+$infPath = 'C:\mm-dev-queue\AppleWirelessMouse.inf'
+
+function Log([string]$msg) {
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    "[$ts] $msg" | Add-Content -Path $LogPath -Encoding ASCII
+}
+
+Log "=== PATH-A trust-and-install start ==="
+Log "Running as: $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
+
+# Step 1: verify cert exists in LocalMachine\My (signing source)
+$signCert = Get-ChildItem Cert:\LocalMachine\My -ErrorAction SilentlyContinue | Where-Object { $_.Thumbprint -eq $thumb }
+if (-not $signCert) {
+    Log "FAIL: M14 cert $thumb not found in Cert:\LocalMachine\My"
+    exit 1
+}
+Log "PASS: cert found in LocalMachine\My (HasPrivateKey=$($signCert.HasPrivateKey))"
+
+# Step 2: import to LocalMachine\Root if missing
+$rootCert = Get-ChildItem Cert:\LocalMachine\Root -ErrorAction SilentlyContinue | Where-Object { $_.Thumbprint -eq $thumb }
+if ($rootCert) {
+    Log "INFO: cert already in LocalMachine\Root"
+} else {
+    Log "Adding cert to LocalMachine\Root..."
+    try {
+        $store = Get-Item Cert:\LocalMachine\Root
+        $store.Open('ReadWrite')
+        $store.Add($signCert)
+        $store.Close()
+        Log "PASS: cert added to LocalMachine\Root"
+    } catch {
+        Log "FAIL: could not add cert to Root: $_"
+        exit 2
+    }
+}
+
+# Step 3: ensure cert is in TrustedPublisher (idempotent)
+$tpCert = Get-ChildItem Cert:\LocalMachine\TrustedPublisher -ErrorAction SilentlyContinue | Where-Object { $_.Thumbprint -eq $thumb }
+if ($tpCert) {
+    Log "INFO: cert already in LocalMachine\TrustedPublisher"
+} else {
+    Log "Adding cert to LocalMachine\TrustedPublisher..."
+    try {
+        $store = Get-Item Cert:\LocalMachine\TrustedPublisher
+        $store.Open('ReadWrite')
+        $store.Add($signCert)
+        $store.Close()
+        Log "PASS: cert added to LocalMachine\TrustedPublisher"
+    } catch {
+        Log "FAIL: could not add cert to TrustedPublisher: $_"
+        exit 3
+    }
+}
+
+# Step 4: verify INF exists
+if (-not (Test-Path $infPath)) {
+    Log "FAIL: INF not found at $infPath"
+    exit 4
+}
+Log "PASS: INF found at $infPath"
+
+# Step 5: pnputil /add-driver /install /force — with timeout safety
+Log "Running pnputil /add-driver $infPath /install /force..."
+$pnpJob = Start-Job -ScriptBlock {
+    param($inf)
+    $output = & pnputil /add-driver $inf /install /force 2>&1 | Out-String
+    return @{ rc = $LASTEXITCODE; output = $output }
+} -ArgumentList $infPath
+
+# Wait up to 90 seconds (pnputil can be slow)
+$completed = Wait-Job $pnpJob -Timeout 90
+if ($completed) {
+    $result = Receive-Job $pnpJob
+    Remove-Job $pnpJob
+    Log "pnputil exited rc=$($result.rc)"
+    Log "--- pnputil output ---"
+    foreach ($line in ($result.output -split "`r?`n")) {
+        if ($line.Trim()) { Log "  $line" }
+    }
+    Log "--- end pnputil output ---"
+    if ($result.rc -eq 0 -or $result.rc -eq 259) {
+        Log "PASS: pnputil install succeeded (rc=$($result.rc))"
+    } else {
+        Log "FAIL: pnputil rc=$($result.rc)"
+        exit 5
+    }
+} else {
+    Log "FAIL: pnputil hung beyond 90s timeout — killing job"
+    Stop-Job $pnpJob
+    Remove-Job $pnpJob -Force
+    exit 6
+}
+
+# Step 6: verify our package registered
+Log "Verifying registration..."
+$enumOut = & pnputil /enum-drivers 2>&1 | Out-String
+$ourEntry = ($enumOut -split '(?=Published Name:)') | Where-Object {
+    $_ -match 'applewirelessmouse' -and $_ -match '6\.3\.0\.0'
+}
+if ($ourEntry) {
+    foreach ($line in (($ourEntry | Out-String) -split "`r?`n" | Select-Object -First 8)) {
+        if ($line.Trim()) { Log "  $line" }
+    }
+    Log "PASS: PATH-A v6.3.0.0 driver registered in DriverStore"
+} else {
+    Log "WARN: PATH-A v6.3.0.0 not visible in pnputil /enum-drivers — install may have failed silently"
+}
+
+Log "=== PATH-A trust-and-install complete ==="
+exit 0

--- a/v2-kmdf-driver/scripts/pathA-trust-and-install.ps1
+++ b/v2-kmdf-driver/scripts/pathA-trust-and-install.ps1
@@ -1,14 +1,17 @@
-# PATH-A v3 trust-and-install — runs as SYSTEM via task runner
+# PATH-A v3 trust-and-install - runs as SYSTEM via task runner
 # Adds M14 cert to LocalMachine\Root + invokes pnputil /add-driver /install /force
 # Outputs to log file passed as $LogPath argument.
 
+# $LogPath is read by the Log helper below. PSReviewUnusedParameter does not follow
+# variable usage into nested function definitions, so it needs to be told explicitly.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'LogPath',
+    Justification = 'Consumed by the Log function defined further down this script.')]
 param(
     [Parameter(Mandatory=$true)][string]$LogPath
 )
 
 $ErrorActionPreference = 'Continue'
 $thumb = '16940C0F937D569363560D5FEC5CD8FA6D6D9BCE'
-$cerPath = 'C:\mm-dev-queue\MagicMouseFix.cer'
 $infPath = 'C:\mm-dev-queue\AppleWirelessMouse.inf'
 
 function Log([string]$msg) {
@@ -70,13 +73,14 @@ if (-not (Test-Path $infPath)) {
 }
 Log "PASS: INF found at $infPath"
 
-# Step 5: pnputil /add-driver /install /force — with timeout safety
+# Step 5: pnputil /add-driver /install /force - with timeout safety
 Log "Running pnputil /add-driver $infPath /install /force..."
+# $using: rather than -ArgumentList: Start-Job param() blocks confuse
+# PSUseUsingScopeModifierInNewRunspaces, and $using: is the idiomatic form.
 $pnpJob = Start-Job -ScriptBlock {
-    param($inf)
-    $output = & pnputil /add-driver $inf /install /force 2>&1 | Out-String
+    $output = & pnputil /add-driver $using:infPath /install /force 2>&1 | Out-String
     return @{ rc = $LASTEXITCODE; output = $output }
-} -ArgumentList $infPath
+}
 
 # Wait up to 90 seconds (pnputil can be slow)
 $completed = Wait-Job $pnpJob -Timeout 90
@@ -96,7 +100,7 @@ if ($completed) {
         exit 5
     }
 } else {
-    Log "FAIL: pnputil hung beyond 90s timeout — killing job"
+    Log "FAIL: pnputil hung beyond 90s timeout - killing job"
     Stop-Job $pnpJob
     Remove-Job $pnpJob -Force
     exit 6
@@ -114,7 +118,7 @@ if ($ourEntry) {
     }
     Log "PASS: PATH-A v6.3.0.0 driver registered in DriverStore"
 } else {
-    Log "WARN: PATH-A v6.3.0.0 not visible in pnputil /enum-drivers — install may have failed silently"
+    Log "WARN: PATH-A v6.3.0.0 not visible in pnputil /enum-drivers - install may have failed silently"
 }
 
 Log "=== PATH-A trust-and-install complete ==="

--- a/v2-kmdf-driver/scripts/run-prefast.ps1
+++ b/v2-kmdf-driver/scripts/run-prefast.ps1
@@ -1,0 +1,233 @@
+<#
+.SYNOPSIS
+    PREfast static analysis gate for M12 driver builds.
+
+.DESCRIPTION
+    Invokes PREfast as part of an EWDK msbuild pass with RunCodeAnalysis=true.
+    Captures per-warning structured output, emits prefast-results.json and
+    prefast-report.md to the OutputDir.
+
+    Exit 0 = 0 warnings (gate passes).
+    Exit 1 = 1+ warnings (gate fails; PR is blocked).
+
+    Designed to be called by Phase 3 driver agents or from run-quality-gates.ps1.
+    No EWDK installed on the host? The script exits 2 with a clear diagnostic.
+
+.PARAMETER SolutionPath
+    Absolute path to M12.sln (or .vcxproj). Must be a Windows path accessible
+    from the admin-queue context.
+
+.PARAMETER Configuration
+    msbuild Configuration property. Default: Release. Valid: Release, Debug.
+
+.PARAMETER Platform
+    msbuild Platform property. Default: x64.
+
+.PARAMETER EwdkRoot
+    Root of the mounted EWDK ISO. Default: F:\  (matches dev-machine convention
+    established in M12-PRODUCTION-HYGIENE-FOR-V1.3.md Section 7).
+
+.PARAMETER OutputDir
+    Directory where prefast-results.json and prefast-report.md are written.
+    Created if absent. Default: C:\mm-dev-queue\prefast-<timestamp>
+
+.PARAMETER LogFile
+    Full path for verbose build log. Default: OutputDir\prefast-build.log
+
+.EXAMPLE
+    # Called by run-quality-gates.ps1 -- no direct invocation needed in Phase 3.
+    .\run-prefast.ps1 -SolutionPath 'C:\src\driver\M12.sln' -Configuration Release -Platform x64
+
+.EXAMPLE
+    # Standalone test (when M12.sln exists, Phase 3+):
+    .\run-prefast.ps1 -SolutionPath '\\wsl.localhost\Ubuntu\home\lesley\projects\Personal\magic-mouse-tray\driver\M12.sln'
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SolutionPath,
+
+    [ValidateSet('Release','Debug')]
+    [string]$Configuration = 'Release',
+
+    [ValidateSet('x64','x86','ARM64')]
+    [string]$Platform = 'x64',
+
+    [string]$EwdkRoot = 'F:\',
+
+    [string]$OutputDir = '',
+
+    [string]$LogFile = ''
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Log {
+    param([string]$Msg, [string]$Level = 'INFO')
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][prefast][$Level] $Msg"
+    if ($script:LogFile) {
+        Add-Content -Path $script:LogFile -Value $line -Encoding UTF8
+    }
+    switch ($Level) {
+        'ERROR' { Write-Host $line -ForegroundColor Red }
+        'WARN'  { Write-Host $line -ForegroundColor Yellow }
+        'OK'    { Write-Host $line -ForegroundColor Green }
+        default { Write-Host $line }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Resolve output paths
+# ---------------------------------------------------------------------------
+if (-not $OutputDir) {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutputDir = "C:\mm-dev-queue\prefast-$ts"
+}
+
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir | Out-Null
+}
+
+if (-not $LogFile) {
+    $LogFile = Join-Path $OutputDir 'prefast-build.log'
+}
+
+$JsonOut = Join-Path $OutputDir 'prefast-results.json'
+$MdOut   = Join-Path $OutputDir 'prefast-report.md'
+
+Write-Log "=== run-prefast.ps1 ==="
+Write-Log "Solution   : $SolutionPath"
+Write-Log "Config     : $Configuration / $Platform"
+Write-Log "EWDK root  : $EwdkRoot"
+Write-Log "Output dir : $OutputDir"
+
+# ---------------------------------------------------------------------------
+# Pre-flight: verify EWDK and solution
+# ---------------------------------------------------------------------------
+$setupCmd = Join-Path $EwdkRoot 'BuildEnv\SetupBuildEnv.cmd'
+if (-not (Test-Path $setupCmd)) {
+    Write-Log "EWDK SetupBuildEnv.cmd not found at: $setupCmd" 'ERROR'
+    Write-Log "Mount the EWDK ISO at $EwdkRoot before running PREfast." 'ERROR'
+    exit 2
+}
+
+if (-not (Test-Path $SolutionPath)) {
+    Write-Log "Solution not found: $SolutionPath" 'ERROR'
+    Write-Log "Phase 3 must create M12.sln before this gate runs." 'ERROR'
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Invoke EWDK msbuild with RunCodeAnalysis=true
+# This is the canonical PREfast invocation pattern for KMDF drivers on EWDK.
+# SetupBuildEnv.cmd sets PATH/INCLUDE/LIB; 'call' ensures it returns before
+# msbuild runs (LaunchBuildEnv.cmd uses /k which spawns interactive shell).
+# ---------------------------------------------------------------------------
+Write-Log "Starting PREfast msbuild pass..." 'INFO'
+
+$buildCmd = @"
+call "$setupCmd" >NUL 2>&1 && msbuild "$SolutionPath" /p:Configuration=$Configuration /p:Platform=$Platform /p:RunCodeAnalysis=true /t:Build /nologo /v:diagnostic
+"@
+
+$rawOutput = cmd /c $buildCmd 2>&1
+$rawOutput | ForEach-Object { Add-Content -Path $LogFile -Value $_ -Encoding UTF8 }
+$buildExitCode = $LASTEXITCODE
+
+Write-Log "msbuild exit code: $buildExitCode"
+
+# ---------------------------------------------------------------------------
+# Parse PREfast warnings from build output
+# PREfast warnings surface as:  <file>(<line>): warning <Cxxxx>: <message>
+# The /analyze flag also emits:  warning C6xxx: <message> [<file>(<line>)]
+# We capture both forms.
+# ---------------------------------------------------------------------------
+$warnings = [System.Collections.Generic.List[hashtable]]::new()
+
+foreach ($line in $rawOutput) {
+    if ($line -match '^(.+?)\((\d+)\)\s*:\s*warning\s+(C\d+)\s*:\s*(.+)$') {
+        $warnings.Add(@{
+            file    = $Matches[1].Trim()
+            line    = [int]$Matches[2]
+            code    = $Matches[3]
+            message = $Matches[4].Trim()
+        })
+    }
+}
+
+$warningCount = $warnings.Count
+Write-Log "PREfast warnings found: $warningCount"
+
+# ---------------------------------------------------------------------------
+# Emit prefast-results.json
+# ---------------------------------------------------------------------------
+$result = @{
+    tool          = 'prefast'
+    timestamp     = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
+    solution      = $SolutionPath
+    configuration = $Configuration
+    platform      = $Platform
+    warning_count = $warningCount
+    build_exit    = $buildExitCode
+    gate_passed   = ($warningCount -eq 0 -and $buildExitCode -eq 0)
+    warnings      = @($warnings)
+}
+
+$resultJson = $result | ConvertTo-Json -Depth 5
+Set-Content -Path $JsonOut -Value $resultJson -Encoding UTF8
+Write-Log "JSON results: $JsonOut" 'OK'
+
+# ---------------------------------------------------------------------------
+# Emit prefast-report.md (PR-comment-ready)
+# ---------------------------------------------------------------------------
+$gateStatus = if ($result.gate_passed) { 'PASS' } else { 'FAIL' }
+$mdLines = [System.Collections.Generic.List[string]]::new()
+$mdLines.Add("## PREfast Static Analysis Report")
+$mdLines.Add("")
+$mdLines.Add("| Field | Value |")
+$mdLines.Add("|---|---|")
+$mdLines.Add("| Gate | $gateStatus |")
+$mdLines.Add("| Warnings | $warningCount |")
+$mdLines.Add("| Configuration | ${Configuration}/$Platform |")
+$mdLines.Add("| msbuild exit | $buildExitCode |")
+$mdLines.Add("| Timestamp | $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') |")
+$mdLines.Add("")
+
+if ($warningCount -gt 0) {
+    $mdLines.Add("### Warnings (must be 0 to pass)")
+    $mdLines.Add("")
+    $mdLines.Add("| # | File | Line | Code | Message |")
+    $mdLines.Add("|---|---|---|---|---|")
+    $i = 1
+    foreach ($w in $warnings) {
+        $fname = Split-Path -Leaf $w.file
+        $mdLines.Add("| $i | $fname | $($w.line) | $($w.code) | $($w.message) |")
+        $i++
+    }
+    $mdLines.Add("")
+    $mdLines.Add("**Action**: Fix all warnings. PREfast gate requires 0 warnings.")
+    $mdLines.Add("See full build log: ``$LogFile``")
+} else {
+    $mdLines.Add("No PREfast warnings. Gate passes.")
+}
+
+Set-Content -Path $MdOut -Value ($mdLines -join "`n") -Encoding UTF8
+Write-Log "Markdown report: $MdOut" 'OK'
+
+# ---------------------------------------------------------------------------
+# Exit
+# 0 = gate passes (0 warnings, clean build)
+# 1 = gate fails (warnings present or build error)
+# 2 = pre-flight failed (EWDK not mounted, solution missing)
+# ---------------------------------------------------------------------------
+if ($result.gate_passed) {
+    Write-Log "PREfast gate: PASS (0 warnings)" 'OK'
+    exit 0
+} else {
+    Write-Log "PREfast gate: FAIL ($warningCount warnings, build_exit=$buildExitCode)" 'ERROR'
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/run-quality-gates.ps1
+++ b/v2-kmdf-driver/scripts/run-quality-gates.ps1
@@ -1,0 +1,316 @@
+<#
+.SYNOPSIS
+    Aggregated quality-gate runner for M12 driver PRs.
+
+.DESCRIPTION
+    Calls run-prefast.ps1 then run-sdv.ps1 sequentially. Aggregates their
+    JSON outputs into a single gate-results.json and gate-report.md.
+
+    Exit 0 only if BOTH PREfast and SDV pass.
+    Exit 1 if either gate fails.
+    Exit 2 if either gate hits a pre-flight error (EWDK missing, solution missing).
+
+    This is the canonical entry point for Phase 3 driver agents. It is also
+    the script whose exit code the admin-task-queue BUILD route checks when
+    agents ask "did quality gates pass?".
+
+    Sequential execution is intentional: PREfast is fast (~1-2 min) and
+    catches issues SDV would also flag. Running SDV on a PREfast-failing tree
+    wastes 5-20 min and produces noise.
+
+.PARAMETER SolutionPath
+    Absolute Windows path to M12.sln.
+
+.PARAMETER Configuration
+    msbuild Configuration property for PREfast. Default: Release.
+
+.PARAMETER Platform
+    msbuild Platform property. Default: x64.
+
+.PARAMETER EwdkRoot
+    Root of the mounted EWDK ISO. Default: F:\
+
+.PARAMETER OutputDir
+    Parent directory for gate output. PREfast and SDV subdirs created inside.
+    Default: C:\mm-dev-queue\quality-gates-<timestamp>
+
+.PARAMETER SkipSdv
+    Skip SDV and run only PREfast. Use when a quick pre-commit check is needed
+    and full SDV turnaround is too slow. SDV is still required before merge.
+
+.EXAMPLE
+    # Full gates (Phase 3 standard run):
+    .\run-quality-gates.ps1 -SolutionPath '\\wsl.localhost\Ubuntu\home\lesley\projects\Personal\magic-mouse-tray\driver\M12.sln'
+
+.EXAMPLE
+    # PREfast only (fast pre-commit check):
+    .\run-quality-gates.ps1 -SolutionPath 'C:\src\driver\M12.sln' -SkipSdv
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SolutionPath,
+
+    [ValidateSet('Release','Debug')]
+    [string]$Configuration = 'Release',
+
+    [ValidateSet('x64','x86','ARM64')]
+    [string]$Platform = 'x64',
+
+    [string]$EwdkRoot = 'F:\',
+
+    [string]$OutputDir = '',
+
+    [switch]$SkipSdv
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Log {
+    param([string]$Msg, [string]$Level = 'INFO')
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][quality-gates][$Level] $Msg"
+    if ($script:MasterLog) {
+        Add-Content -Path $script:MasterLog -Value $line -Encoding UTF8
+    }
+    switch ($Level) {
+        'ERROR' { Write-Host $line -ForegroundColor Red }
+        'WARN'  { Write-Host $line -ForegroundColor Yellow }
+        'OK'    { Write-Host $line -ForegroundColor Green }
+        'HEAD'  { Write-Host "`n$line" -ForegroundColor Cyan }
+        default { Write-Host $line }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+if (-not $OutputDir) {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutputDir = "C:\mm-dev-queue\quality-gates-$ts"
+}
+
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir | Out-Null
+}
+
+$MasterLog   = Join-Path $OutputDir 'quality-gates.log'
+$PrefastDir  = Join-Path $OutputDir 'prefast'
+$SdvDir      = Join-Path $OutputDir 'sdv'
+$JsonOut     = Join-Path $OutputDir 'gate-results.json'
+$MdOut       = Join-Path $OutputDir 'gate-report.md'
+
+Write-Log "=== run-quality-gates.ps1 ===" 'HEAD'
+Write-Log "Solution   : $SolutionPath"
+Write-Log "Config     : $Configuration / $Platform"
+Write-Log "EWDK root  : $EwdkRoot"
+Write-Log "Output dir : $OutputDir"
+Write-Log "Skip SDV   : $($SkipSdv.IsPresent)"
+
+# ---------------------------------------------------------------------------
+# Locate sibling scripts (same directory as this script)
+# ---------------------------------------------------------------------------
+$ScriptDir   = $PSScriptRoot
+$PrefastScr  = Join-Path $ScriptDir 'run-prefast.ps1'
+$SdvScr      = Join-Path $ScriptDir 'run-sdv.ps1'
+
+foreach ($scr in @($PrefastScr, $SdvScr)) {
+    if (-not (Test-Path $scr)) {
+        Write-Log "Required script not found: $scr" 'ERROR'
+        exit 2
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Gate 1: PREfast
+# ---------------------------------------------------------------------------
+Write-Log "--- Gate 1: PREfast ---" 'HEAD'
+$prefastStart = Get-Date
+
+$prefastArgs = @(
+    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PrefastScr,
+    '-SolutionPath', $SolutionPath,
+    '-Configuration', $Configuration,
+    '-Platform', $Platform,
+    '-EwdkRoot', $EwdkRoot,
+    '-OutputDir', $PrefastDir
+)
+$prefastProc = Start-Process powershell.exe -ArgumentList $prefastArgs -Wait -PassThru -NoNewWindow
+$prefastExit = $prefastProc.ExitCode
+$prefastDuration = [int](New-TimeSpan -Start $prefastStart -End (Get-Date)).TotalSeconds
+
+Write-Log "PREfast exit: $prefastExit  (${prefastDuration}s)"
+
+$prefastJson = Join-Path $PrefastDir 'prefast-results.json'
+$prefastData = $null
+if (Test-Path $prefastJson) {
+    $prefastData = Get-Content $prefastJson | ConvertFrom-Json
+}
+
+# ---------------------------------------------------------------------------
+# Gate 2: SDV (skipped if -SkipSdv or PREfast had pre-flight failure)
+# ---------------------------------------------------------------------------
+$sdvExit     = -1
+$sdvDuration = 0
+$sdvData     = $null
+$sdvSkipped  = $false
+
+if ($SkipSdv) {
+    Write-Log "SDV skipped (SkipSdv flag set)." 'WARN'
+    $sdvSkipped = $true
+} elseif ($prefastExit -eq 2) {
+    Write-Log "SDV skipped: PREfast pre-flight failed (EWDK or solution not found)." 'WARN'
+    $sdvSkipped = $true
+} else {
+    Write-Log "--- Gate 2: SDV ---" 'HEAD'
+    $sdvStart = Get-Date
+
+    $sdvArgs = @(
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $SdvScr,
+        '-SolutionPath', $SolutionPath,
+        '-EwdkRoot', $EwdkRoot,
+        '-OutputDir', $SdvDir
+    )
+    $sdvProc = Start-Process powershell.exe -ArgumentList $sdvArgs -Wait -PassThru -NoNewWindow
+    $sdvExit = $sdvProc.ExitCode
+    $sdvDuration = [int](New-TimeSpan -Start $sdvStart -End (Get-Date)).TotalSeconds
+
+    Write-Log "SDV exit: $sdvExit  (${sdvDuration}s)"
+
+    $sdvJsonPath = Join-Path $SdvDir 'sdv-results.json'
+    if (Test-Path $sdvJsonPath) {
+        $sdvData = Get-Content $sdvJsonPath | ConvertFrom-Json
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Aggregate result
+# Gate passes only if both pass (or SDV explicitly skipped with note).
+# SDV skip = gate does NOT fully pass (blocks PR merge; only PREfast-check mode).
+# ---------------------------------------------------------------------------
+$prefastPassed = ($prefastExit -eq 0)
+$sdvPassed     = ($sdvExit -eq 0)
+# Senior-dev review MAJ-1: previous $allPassed had wrong operator precedence
+# (always evaluated as $prefastPassed alone) and was unused downstream.
+# Removed entirely; downstream logic uses $fullyPassed / $preOnlyMode.
+
+# Fully passed = both exit 0 with no skip required.
+# Partial (PREfast only) = informational; merge still blocked pending SDV.
+$fullyPassed = ($prefastExit -eq 0 -and $sdvExit -eq 0)
+$preOnlyMode = ($prefastExit -eq 0 -and $sdvSkipped)
+
+# ---------------------------------------------------------------------------
+# Emit gate-results.json
+# ---------------------------------------------------------------------------
+$aggregate = @{
+    tool           = 'quality-gates'
+    timestamp      = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
+    solution       = $SolutionPath
+    configuration  = "$Configuration/$Platform"
+    fully_passed   = $fullyPassed
+    prefast_only   = $preOnlyMode
+    prefast = @{
+        exit     = $prefastExit
+        passed   = $prefastPassed
+        duration = $prefastDuration
+        warnings = if ($prefastData) { $prefastData.warning_count } else { -1 }
+        report   = (Join-Path $PrefastDir 'prefast-report.md')
+        json     = $prefastJson
+    }
+    sdv = @{
+        exit       = $sdvExit
+        passed     = $sdvPassed
+        skipped    = $sdvSkipped
+        duration   = $sdvDuration
+        violations = if ($sdvData) { $sdvData.violation_count } else { -1 }
+        report     = (Join-Path $SdvDir 'sdv-report.md')
+        json       = (Join-Path $SdvDir 'sdv-results.json')
+    }
+}
+
+$aggregateJson = $aggregate | ConvertTo-Json -Depth 5
+Set-Content -Path $JsonOut -Value $aggregateJson -Encoding UTF8
+Write-Log "Aggregate JSON: $JsonOut" 'OK'
+
+# ---------------------------------------------------------------------------
+# Emit gate-report.md (PR-comment-ready, combines both gates)
+# ---------------------------------------------------------------------------
+$overallStatus = if ($fullyPassed) { 'PASS' } elseif ($preOnlyMode) { 'PARTIAL (SDV pending)' } else { 'FAIL' }
+
+$prefastStatus = if ($prefastPassed) { 'PASS' } elseif ($prefastExit -eq 2) { 'PRE-FLIGHT ERROR' } else { 'FAIL' }
+$sdvStatus     = if ($sdvSkipped)    { 'SKIPPED' } elseif ($sdvPassed) { 'PASS' } elseif ($sdvExit -eq 2) { 'PRE-FLIGHT ERROR' } else { 'FAIL' }
+
+$mdLines = [System.Collections.Generic.List[string]]::new()
+$mdLines.Add("## M12 Quality Gates Report")
+$mdLines.Add("")
+$mdLines.Add("| Gate | Status | Detail | Duration |")
+$mdLines.Add("|---|---|---|---|")
+
+$prefastWarn  = if ($prefastData) { "$($prefastData.warning_count) warnings" } else { 'n/a' }
+$sdvViol      = if ($sdvData) { "$($sdvData.violation_count) violations" } else { if ($sdvSkipped) { 'skipped' } else { 'n/a' } }
+
+$mdLines.Add("| PREfast | $prefastStatus | $prefastWarn | ${prefastDuration}s |")
+$mdLines.Add("| SDV     | $sdvStatus     | $sdvViol     | ${sdvDuration}s |")
+$mdLines.Add("")
+$mdLines.Add("**Overall: $overallStatus**")
+$mdLines.Add("")
+
+if ($fullyPassed) {
+    $mdLines.Add("Both PREfast and SDV passed. PR may proceed to reviewer chain.")
+} elseif ($preOnlyMode) {
+    $mdLines.Add("PREfast passed. SDV was skipped (SkipSdv mode). Full SDV run required before merge.")
+} else {
+    $mdLines.Add("One or more gates failed. PR is blocked until all gates pass.")
+    $mdLines.Add("")
+    if (-not $prefastPassed) {
+        $prefastMd = Join-Path $PrefastDir 'prefast-report.md'
+        $mdLines.Add("**PREfast details**: see ``$prefastMd``")
+    }
+    if (-not $sdvPassed -and -not $sdvSkipped) {
+        $sdvMd = Join-Path $SdvDir 'sdv-report.md'
+        $mdLines.Add("**SDV details**: see ``$sdvMd``")
+    }
+}
+
+$mdLines.Add("")
+$mdLines.Add("---")
+$mdLines.Add("_Generated by run-quality-gates.ps1 at $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')_")
+
+Set-Content -Path $MdOut -Value ($mdLines -join "`n") -Encoding UTF8
+Write-Log "Aggregate report: $MdOut" 'OK'
+
+# ---------------------------------------------------------------------------
+# Copy individual gate reports alongside aggregate for easy browsing
+# ---------------------------------------------------------------------------
+$prefastMdSrc = Join-Path $PrefastDir 'prefast-report.md'
+if (Test-Path $prefastMdSrc) {
+    Copy-Item $prefastMdSrc (Join-Path $OutputDir 'prefast-report.md') -Force
+}
+$sdvMdSrc = Join-Path $SdvDir 'sdv-report.md'
+if (Test-Path $sdvMdSrc) {
+    Copy-Item $sdvMdSrc (Join-Path $OutputDir 'sdv-report.md') -Force
+}
+
+# ---------------------------------------------------------------------------
+# Final summary + exit
+# ---------------------------------------------------------------------------
+Write-Log "=== QUALITY GATES SUMMARY ===" 'HEAD'
+Write-Log "PREfast : $prefastStatus (exit $prefastExit, ${prefastDuration}s)"
+Write-Log "SDV     : $sdvStatus (exit $sdvExit, ${sdvDuration}s)"
+Write-Log "Overall : $overallStatus"
+Write-Log "Output  : $OutputDir"
+
+if ($fullyPassed) {
+    Write-Log "Quality gates: FULLY PASSED" 'OK'
+    exit 0
+} elseif ($prefastExit -eq 2 -or $sdvExit -eq 2) {
+    Write-Log "Quality gates: PRE-FLIGHT ERROR -- EWDK or solution not found" 'ERROR'
+    exit 2
+} else {
+    Write-Log "Quality gates: FAILED -- fix issues and re-run" 'ERROR'
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/run-sdv.ps1
+++ b/v2-kmdf-driver/scripts/run-sdv.ps1
@@ -1,0 +1,295 @@
+<#
+.SYNOPSIS
+    Static Driver Verifier (SDV) gate for M12 driver builds.
+
+.DESCRIPTION
+    Invokes SDV via EWDK msbuild using the sdv target. Parses the SDV report
+    XML/log for violations. Emits sdv-results.json and sdv-report.md to
+    OutputDir for PR-comment integration.
+
+    Exit 0 = 0 violations (gate passes).
+    Exit 1 = 1+ violations (gate fails; PR is blocked).
+    Exit 2 = pre-flight failure (EWDK not mounted, solution missing).
+
+    SDV is substantially slower than PREfast (minutes to hours for complex
+    drivers). For M12 v1 at ~250 LOC total, typical SDV time is 5-20 min.
+
+    Called by Phase 3 driver agents or from run-quality-gates.ps1.
+
+.PARAMETER SolutionPath
+    Absolute Windows path to M12.sln. Must be accessible from the admin-queue
+    context (e.g. \\wsl.localhost\Ubuntu\... or a local copy).
+
+.PARAMETER EwdkRoot
+    Root of the mounted EWDK ISO. Default: F:\
+
+.PARAMETER SdvRuleSet
+    SDV rule-set argument passed to /p:Inputs. Default: /check:default.sdv
+    (runs the standard KMDF/WDM rule set including cancellation, IRP handling,
+    lock discipline, and power management rules).
+
+.PARAMETER OutputDir
+    Directory where sdv-results.json and sdv-report.md are written.
+    Default: C:\mm-dev-queue\sdv-<timestamp>
+
+.PARAMETER LogFile
+    Full path for verbose SDV log. Default: OutputDir\sdv-build.log
+
+.EXAMPLE
+    # Standalone (Phase 3+, when M12.sln exists):
+    .\run-sdv.ps1 -SolutionPath 'C:\src\driver\M12.sln'
+
+.EXAMPLE
+    # With custom rule set:
+    .\run-sdv.ps1 -SolutionPath 'C:\src\driver\M12.sln' -SdvRuleSet '/check:WdfDriverEntry.slic'
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SolutionPath,
+
+    [string]$EwdkRoot = 'F:\',
+
+    [string]$SdvRuleSet = '/check:default.sdv',
+
+    [string]$OutputDir = '',
+
+    [string]$LogFile = ''
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Log {
+    param([string]$Msg, [string]$Level = 'INFO')
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts][sdv][$Level] $Msg"
+    if ($script:LogFile) {
+        Add-Content -Path $script:LogFile -Value $line -Encoding UTF8
+    }
+    switch ($Level) {
+        'ERROR' { Write-Host $line -ForegroundColor Red }
+        'WARN'  { Write-Host $line -ForegroundColor Yellow }
+        'OK'    { Write-Host $line -ForegroundColor Green }
+        default { Write-Host $line }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Resolve output paths
+# ---------------------------------------------------------------------------
+if (-not $OutputDir) {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutputDir = "C:\mm-dev-queue\sdv-$ts"
+}
+
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir | Out-Null
+}
+
+if (-not $LogFile) {
+    $LogFile = Join-Path $OutputDir 'sdv-build.log'
+}
+
+$JsonOut = Join-Path $OutputDir 'sdv-results.json'
+$MdOut   = Join-Path $OutputDir 'sdv-report.md'
+
+Write-Log "=== run-sdv.ps1 ==="
+Write-Log "Solution   : $SolutionPath"
+Write-Log "EWDK root  : $EwdkRoot"
+Write-Log "Rule set   : $SdvRuleSet"
+Write-Log "Output dir : $OutputDir"
+
+# ---------------------------------------------------------------------------
+# Pre-flight: verify EWDK and solution
+# ---------------------------------------------------------------------------
+$setupCmd = Join-Path $EwdkRoot 'BuildEnv\SetupBuildEnv.cmd'
+if (-not (Test-Path $setupCmd)) {
+    Write-Log "EWDK SetupBuildEnv.cmd not found at: $setupCmd" 'ERROR'
+    Write-Log "Mount the EWDK ISO at $EwdkRoot before running SDV." 'ERROR'
+    exit 2
+}
+
+if (-not (Test-Path $SolutionPath)) {
+    Write-Log "Solution not found: $SolutionPath" 'ERROR'
+    Write-Log "Phase 3 must create M12.sln before this gate runs." 'ERROR'
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Invoke SDV via EWDK msbuild /t:sdv
+# Standard invocation documented in Microsoft WDK SDV docs and EWDK conventions.
+# /p:Inputs passes the rule-set file path to the SDV task.
+# Configuration must be Release/x64 -- SDV does not support Debug config.
+# ---------------------------------------------------------------------------
+Write-Log "Starting SDV analysis (this can take 5-20 minutes)..." 'INFO'
+
+$buildCmd = @"
+call "$setupCmd" >NUL 2>&1 && msbuild "$SolutionPath" /t:sdv /p:Inputs="$SdvRuleSet" /p:Configuration=Release /p:Platform=x64 /nologo /v:diagnostic
+"@
+
+$rawOutput = cmd /c $buildCmd 2>&1
+$rawOutput | ForEach-Object { Add-Content -Path $LogFile -Value $_ -Encoding UTF8 }
+$buildExitCode = $LASTEXITCODE
+
+Write-Log "msbuild/sdv exit code: $buildExitCode"
+
+# ---------------------------------------------------------------------------
+# Locate SDV report artifacts
+# SDV writes results to <project-dir>\sdv\ subdirectory.
+# Primary output: sdv.dvl.xml (defect list) and sdv-results.xml.
+# Also: SDV.log (text summary with pass/fail per rule).
+# ---------------------------------------------------------------------------
+$slnDir     = Split-Path -Parent $SolutionPath
+$sdvDir     = Join-Path $slnDir 'sdv'
+$dvlXml     = Join-Path $sdvDir 'sdv.dvl.xml'
+$sdvLog     = Join-Path $sdvDir 'SDV.log'
+$sdvResults = Join-Path $sdvDir 'sdv-results.xml'
+
+Write-Log "Looking for SDV report at: $sdvDir"
+
+# ---------------------------------------------------------------------------
+# Parse violations from SDV.log (text format, reliable fallback)
+# Format per rule: "Rule <name>: PASS | FAIL | TIMEOUT | NOT_APPLICABLE"
+# Also parse sdv.dvl.xml if available for richer structured data.
+# ---------------------------------------------------------------------------
+$violations = [System.Collections.Generic.List[hashtable]]::new()
+$ruleResults = [System.Collections.Generic.List[hashtable]]::new()
+$parseSource = 'none'
+
+if (Test-Path $sdvLog) {
+    $parseSource = 'SDV.log'
+    Write-Log "Parsing: $sdvLog"
+    $logLines = Get-Content $sdvLog
+    foreach ($line in $logLines) {
+        # Match lines like: "Rule WdfFdoAttachDevice: FAIL" or "Rule ...: PASS"
+        if ($line -match 'Rule\s+(\S+)\s*:\s*(PASS|FAIL|TIMEOUT|NOT_APPLICABLE|ERROR)') {
+            $ruleName   = $Matches[1]
+            $ruleStatus = $Matches[2]
+            $entry = @{ rule = $ruleName; status = $ruleStatus }
+            $ruleResults.Add($entry)
+            if ($ruleStatus -eq 'FAIL' -or $ruleStatus -eq 'ERROR') {
+                $violations.Add($entry)
+            }
+        }
+    }
+} elseif (Test-Path $dvlXml) {
+    # Parse DVL XML as fallback -- element: <Defect RuleName="..." Category="..." ... />
+    $parseSource = 'sdv.dvl.xml'
+    Write-Log "Parsing: $dvlXml (DVL XML)"
+    [xml]$dvl = Get-Content $dvlXml
+    $defects = $dvl.SelectNodes('//Defect')
+    foreach ($d in $defects) {
+        $entry = @{
+            rule     = $d.GetAttribute('RuleName')
+            status   = 'FAIL'
+            category = $d.GetAttribute('Category')
+            path     = $d.GetAttribute('SdvDefectPath')
+        }
+        $violations.Add($entry)
+        $ruleResults.Add($entry)
+    }
+} else {
+    Write-Log "No SDV report found at $sdvDir -- SDV may not have run or solution missing M12 project." 'WARN'
+    Write-Log "Raw build log: $LogFile" 'WARN'
+    $parseSource = 'none'
+}
+
+$violationCount = $violations.Count
+Write-Log "SDV violations found: $violationCount (parsed from: $parseSource)"
+
+# ---------------------------------------------------------------------------
+# Gate determination
+# Pass only if: msbuild exit = 0 AND parse succeeded AND 0 FAIL/ERROR rules.
+# Senior-dev review MAJ-3: previous logic falsely PASSED when SDV exited 0 but
+# produced no artifacts (SDK mismatch, cancelled run, missing M12 project).
+# Now: parseSource = 'none' is a hard FAIL even if exit code is 0.
+# A non-zero msbuild exit also fails (infrastructure failure, not just violations).
+# ---------------------------------------------------------------------------
+$reportFound = ($parseSource -ne 'none')
+$gatePassed  = ($violationCount -eq 0 -and $buildExitCode -eq 0 -and $reportFound)
+if (-not $reportFound) {
+    Write-Log "Gate FAIL: SDV produced no parseable report. Cannot confirm what was checked." 'ERROR'
+}
+
+# ---------------------------------------------------------------------------
+# Emit sdv-results.json
+# ---------------------------------------------------------------------------
+$result = @{
+    tool            = 'sdv'
+    timestamp       = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
+    solution        = $SolutionPath
+    rule_set        = $SdvRuleSet
+    violation_count = $violationCount
+    rule_count      = $ruleResults.Count
+    build_exit      = $buildExitCode
+    parse_source    = $parseSource
+    gate_passed     = $gatePassed
+    violations      = @($violations)
+    all_rules       = @($ruleResults)
+}
+
+$resultJson = $result | ConvertTo-Json -Depth 5
+Set-Content -Path $JsonOut -Value $resultJson -Encoding UTF8
+Write-Log "JSON results: $JsonOut" 'OK'
+
+# ---------------------------------------------------------------------------
+# Emit sdv-report.md
+# ---------------------------------------------------------------------------
+$gateStatus = if ($gatePassed) { 'PASS' } else { 'FAIL' }
+
+$mdLines = [System.Collections.Generic.List[string]]::new()
+$mdLines.Add("## Static Driver Verifier (SDV) Report")
+$mdLines.Add("")
+$mdLines.Add("| Field | Value |")
+$mdLines.Add("|---|---|")
+$mdLines.Add("| Gate | $gateStatus |")
+$mdLines.Add("| Violations | $violationCount |")
+$mdLines.Add("| Rules checked | $($ruleResults.Count) |")
+$mdLines.Add("| Rule set | $SdvRuleSet |")
+$mdLines.Add("| msbuild exit | $buildExitCode |")
+$mdLines.Add("| Report source | $parseSource |")
+$mdLines.Add("| Timestamp | $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') |")
+$mdLines.Add("")
+
+if ($violationCount -gt 0) {
+    $mdLines.Add("### Violations (must be 0 to pass)")
+    $mdLines.Add("")
+    $mdLines.Add("| # | Rule | Status | Detail |")
+    $mdLines.Add("|---|---|---|---|")
+    $i = 1
+    foreach ($v in $violations) {
+        $detail = if ($v.ContainsKey('path')) { $v.path } else { '' }
+        $mdLines.Add("| $i | $($v.rule) | $($v.status) | $detail |")
+        $i++
+    }
+    $mdLines.Add("")
+    $mdLines.Add("**Action**: Fix all FAIL/ERROR rules before merge. SDV gate requires 0 violations.")
+    $mdLines.Add("Full SDV log: ``$sdvLog``")
+    $mdLines.Add("Full build log: ``$LogFile``")
+} elseif ($parseSource -eq 'none') {
+    $mdLines.Add("**Warning**: SDV report artifacts not found. SDV may not have run.")
+    $mdLines.Add("Check build log: ``$LogFile``")
+} else {
+    $mdLines.Add("No SDV violations across $($ruleResults.Count) rules. Gate passes.")
+}
+
+Set-Content -Path $MdOut -Value ($mdLines -join "`n") -Encoding UTF8
+Write-Log "Markdown report: $MdOut" 'OK'
+
+# ---------------------------------------------------------------------------
+# Exit
+# 0 = gate passes (0 violations)
+# 1 = gate fails (violations present or build failure)
+# 2 = pre-flight failed (EWDK not mounted, solution missing)
+# ---------------------------------------------------------------------------
+if ($gatePassed) {
+    Write-Log "SDV gate: PASS (0 violations, $($ruleResults.Count) rules checked)" 'OK'
+    exit 0
+} else {
+    Write-Log "SDV gate: FAIL ($violationCount violations, build_exit=$buildExitCode)" 'ERROR'
+    exit 1
+}

--- a/v2-kmdf-driver/scripts/run-sdv.ps1
+++ b/v2-kmdf-driver/scripts/run-sdv.ps1
@@ -147,7 +147,6 @@ $slnDir     = Split-Path -Parent $SolutionPath
 $sdvDir     = Join-Path $slnDir 'sdv'
 $dvlXml     = Join-Path $sdvDir 'sdv.dvl.xml'
 $sdvLog     = Join-Path $sdvDir 'SDV.log'
-$sdvResults = Join-Path $sdvDir 'sdv-results.xml'
 
 Write-Log "Looking for SDV report at: $sdvDir"
 

--- a/v2-kmdf-driver/scripts/sign-and-install.ps1
+++ b/v2-kmdf-driver/scripts/sign-and-install.ps1
@@ -7,7 +7,6 @@
 #   sign-and-install.ps1 -DriverDir 'C:\mm-dev-queue\PATH-A-v5' `
 #                        -InfName  'MagicMouseFixV3.inf' `
 #                        -CatName  'MagicMouseFixV3.cat' `
-#                        -ServiceName 'MagicMouseFixV3' `
 #                        -ExistingCertThumbprint '16940C0F937D569363560D5FEC5CD8FA6D6D9BCE'
 #
 # When -ExistingCertThumbprint is provided, the existing cert in LocalMachine\My is
@@ -17,7 +16,6 @@ param(
     [string]$DriverDir              = (Join-Path $PSScriptRoot "driver"),
     [string]$InfName                = 'AppleWirelessMouse.inf',
     [string]$CatName                = 'applewirelessmouse.cat',
-    [string]$ServiceName            = 'applewirelessmouse',
     [string]$ExistingCertThumbprint = ''   # if empty, create new self-signed cert (v3 default behavior)
 )
 

--- a/v2-kmdf-driver/scripts/sign-and-install.ps1
+++ b/v2-kmdf-driver/scripts/sign-and-install.ps1
@@ -1,0 +1,160 @@
+# Sign and install a patched HID/BT lower-filter driver for Magic Mouse.
+# Run as Administrator in PowerShell.
+# Requires: DSE-disabled boot OR test signing mode (this script enables testsigning).
+#
+# Default targets the v3 reference bundle (AppleWirelessMouse.inf in $PSScriptRoot/driver).
+# For PATH-A v5 (renamed-service bundle), invoke with parameters:
+#   sign-and-install.ps1 -DriverDir 'C:\mm-dev-queue\PATH-A-v5' `
+#                        -InfName  'MagicMouseFixV3.inf' `
+#                        -CatName  'MagicMouseFixV3.cat' `
+#                        -ServiceName 'MagicMouseFixV3' `
+#                        -ExistingCertThumbprint '16940C0F937D569363560D5FEC5CD8FA6D6D9BCE'
+#
+# When -ExistingCertThumbprint is provided, the existing cert in LocalMachine\My is
+# reused instead of creating a new self-signed cert.
+[CmdletBinding()]
+param(
+    [string]$DriverDir              = (Join-Path $PSScriptRoot "driver"),
+    [string]$InfName                = 'AppleWirelessMouse.inf',
+    [string]$CatName                = 'applewirelessmouse.cat',
+    [string]$ServiceName            = 'applewirelessmouse',
+    [string]$ExistingCertThumbprint = ''   # if empty, create new self-signed cert (v3 default behavior)
+)
+
+$DRIVER_DIR = $DriverDir
+$INF = Join-Path $DRIVER_DIR $InfName
+$CAT = Join-Path $DRIVER_DIR $CatName
+
+if (-not (Test-Path $INF)) {
+    Write-Error "Driver files not found. Expected: $INF`nDownload from: https://github.com/tealtadpole/MagicMouse2DriversWin11x64"
+    exit 1
+}
+
+# Step 1 - Use existing cert if thumbprint provided, otherwise create a new self-signed one
+if ($ExistingCertThumbprint) {
+    Write-Host "Step 1: Using existing cert (thumbprint $ExistingCertThumbprint)..."
+    $cert = Get-ChildItem Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq $ExistingCertThumbprint } | Select-Object -First 1
+    if (-not $cert) { Write-Error "Cert with thumbprint $ExistingCertThumbprint not found in LocalMachine\My"; exit 1 }
+    if (-not $cert.HasPrivateKey) { Write-Error "Cert $ExistingCertThumbprint has no private key  -  cannot sign"; exit 1 }
+    Write-Host "  Reused cert: $($cert.Subject) thumb=$($cert.Thumbprint) HasPrivateKey=$($cert.HasPrivateKey)"
+} else {
+    Write-Host "Step 1: Creating self-signed certificate..."
+    $cert = New-SelfSignedCertificate `
+        -Type CodeSigningCert `
+        -Subject "CN=MagicMouseFix" `
+        -CertStoreLocation Cert:\LocalMachine\My `
+        -KeyUsage DigitalSignature `
+        -NotAfter (Get-Date).AddYears(10)
+    Write-Host "  Certificate created: $($cert.Thumbprint)"
+}
+
+New-Item -ItemType Directory -Path "C:\Temp" -Force | Out-Null
+$certPath = "C:\Temp\MagicMouseFix.cer"
+Export-Certificate -Cert $cert -FilePath $certPath -Force | Out-Null
+
+# Step 2 - Trust the cert (required for Windows to accept test-signed drivers)
+Write-Host "Step 2: Trusting certificate..."
+Import-Certificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\TrustedPublisher | Out-Null
+Import-Certificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+
+# Step 3 - Re-enable CatalogFile line in INF (we commented it out earlier)
+Write-Host "Step 3: Restoring CatalogFile line in INF..."
+$content = Get-Content $INF -Raw
+$content = $content -replace '; CatalogFile=applewirelessmouse.cat', 'CatalogFile=applewirelessmouse.cat'
+[System.IO.File]::WriteAllText($INF, $content)
+
+# Step 4 - Generate catalog from driver directory
+Write-Host "Step 4: Generating file catalog..."
+if (Test-Path $CAT) { Remove-Item $CAT -Force }
+New-FileCatalog -Path $DRIVER_DIR -CatalogFilePath $CAT -CatalogVersion 2 | Out-Null
+Write-Host "  Catalog created: $CAT"
+
+# Step 5 - Sign the catalog
+Write-Host "Step 5: Signing catalog..."
+$sig = Set-AuthenticodeSignature -FilePath $CAT -Certificate $cert
+Write-Host "  Signature status: $($sig.Status)"
+
+# Step 6 - Enable test signing (allows test-signed drivers to be selected and loaded)
+Write-Host "Step 6: Enabling test signing mode..."
+bcdedit /set testsigning on | Out-Null
+Write-Host "  Test signing enabled (small watermark will appear after reboot - removable later)"
+
+# Step 7 - Remove prior copies of OUR INF from DriverStore (matches by Original Name).
+# v3 default: matches existing applewirelessmouse.inf entries.
+# v5: matches prior MagicMouseFixV3.inf entries; stock Apple oem10.inf left alone.
+Write-Host "Step 7: Removing prior copies of $InfName from DriverStore..."
+$pnpRaw = (pnputil /enum-drivers 2>$null) | Out-String
+$existing = ($pnpRaw -split '(?=Published Name:)') |
+    Where-Object { $_ -match [regex]::Escape($InfName) } |
+    ForEach-Object { if ($_ -match 'Published Name:\s+(oem\d+\.inf)') { $Matches[1] } }
+if ($existing) {
+    $existing | ForEach-Object {
+        Write-Host "  Removing $_..."
+        pnputil /delete-driver $_ /force 2>$null | Out-Null
+    }
+} else {
+    Write-Host "  No prior $InfName in DriverStore - skipping"
+}
+
+# Step 8 - Install the now-signed package
+Write-Host "Step 8: Installing signed driver package..."
+pnputil /add-driver $INF /install /force
+
+# Step 9 - Register startup repair task (runs startup-repair.ps1 at every boot)
+# Script is copied to a fixed protected path so the scheduled task cannot be hijacked
+# by overwriting a world-writable source directory (LPE mitigation  -  see TEST-PLAN BLK-03).
+Write-Host "Step 9: Registering startup repair task..."
+$repairScript = Join-Path $PSScriptRoot "startup-repair.ps1"
+$installDir   = "C:\Program Files\MagicMouseTray"
+$installedScript = Join-Path $installDir "startup-repair.ps1"
+
+if (Test-Path $repairScript) {
+    $taskName = "MagicMouseTray-StartupRepair"
+
+    # Copy script to protected install directory (Administrators-only write, not world-writable)
+    New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    Copy-Item $repairScript $installedScript -Force
+    # Lock ACL: SYSTEM + Administrators full, Users read-only, no user write
+    icacls $installDir /inheritance:r /grant "SYSTEM:(OI)(CI)F" /grant "Administrators:(OI)(CI)F" /grant "Users:(OI)(CI)RX" | Out-Null
+    Write-Host "  Script installed to: $installedScript"
+
+    # Create and lock the log directory (prevents TOCTOU symlink attack via SYSTEM log rotation  -  BLK-04)
+    $logDir = "C:\ProgramData\MagicMouseTray"
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    icacls $logDir /inheritance:r /grant "SYSTEM:(OI)(CI)F" /grant "Administrators:(OI)(CI)F" /grant "Users:(OI)(CI)R" | Out-Null
+    Write-Host "  Log directory locked: $logDir"
+
+    $taskExists = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    if ($taskExists) {
+        # Update task to point to new install path in case it previously pointed to PSScriptRoot
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+        Write-Host "  Existing task removed  -  re-registering with protected path"
+    }
+
+    $action  = New-ScheduledTaskAction -Execute "powershell.exe" `
+        -Argument "-NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$installedScript`""
+    $trigger = New-ScheduledTaskTrigger -AtStartup
+    $trigger.Delay = "PT30S"   # 30-second delay to let BT stack initialise
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+    $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -RunLevel Highest
+
+    Register-ScheduledTask -TaskName $taskName -Action $action `
+        -Trigger $trigger -Settings $settings -Principal $principal `
+        -Description "Repairs Magic Mouse COL02 battery HID collection at startup" `
+        -Force | Out-Null
+    Write-Host "  Task '$taskName' registered (runs '$installedScript' at startup with 30s delay, as SYSTEM)"
+} else {
+    Write-Host "  WARNING: startup-repair.ps1 not found at $repairScript  -  skipping task registration"
+    Write-Host "  For persistent battery reading across reboots, run Register-ScheduledTask manually."
+}
+
+Write-Host ""
+Write-Host "Done. Now:"
+Write-Host "  1. Remove the Magic Mouse from Bluetooth Settings"
+Write-Host "  2. Re-pair it"
+Write-Host "  3. Test scroll"
+Write-Host "  4. Reboot normally (test signing takes effect at next boot)"
+Write-Host "     Battery reading will be auto-repaired by the startup task."
+Write-Host ""
+Write-Host "After scroll is confirmed working post-reboot:"
+Write-Host "  bcdedit /set testsigning off  (then reboot  -  watermark gone, driver stays)"

--- a/v2-kmdf-driver/scripts/sign-driver.ps1
+++ b/v2-kmdf-driver/scripts/sign-driver.ps1
@@ -1,0 +1,47 @@
+# sign-driver.ps1 — Sign a .sys + .cat pair with a PFX cert.
+# Standalone: powershell -ExecutionPolicy Bypass -File sign-driver.ps1 -SysPath ... -CatPath ... -PfxPath ...
+# Via queue: SIGN|<nonce>|<sys-path>|<cat-path>|<pfx-path>|<pfx-pass-env-var>
+#
+# Empirically validated signtool path: F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe
+# (F:\ is the EWDK ISO drive on this dev machine — confirmed in mm-task-runner.ps1)
+# Fallback: C:\Program Files (x86)\Windows Kits\10\ for machines with WDK/SDK on C:\
+param(
+    [Parameter(Mandatory)][string]$SysPath,
+    [Parameter(Mandatory)][string]$CatPath,
+    [Parameter(Mandatory)][string]$PfxPath,
+    [string]$PfxPassEnvVar = ''
+)
+
+$ErrorActionPreference = 'Continue'
+$tsUrl = 'http://timestamp.digicert.com'
+
+# Auto-discover signtool: try empirical dev-machine path first, then common WDK locations
+$signtoolCandidates = @(
+    'F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+    'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe',
+    'C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe'
+)
+$signtool = $signtoolCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $signtool) {
+    Write-Error "signtool not found in any known location. Mount EWDK ISO to F:\ or install Windows SDK."
+    exit 1
+}
+
+if (-not (Test-Path $SysPath)) { Write-Error ".sys not found: $SysPath"; exit 2 }
+if (-not (Test-Path $CatPath)) { Write-Error ".cat not found: $CatPath"; exit 2 }
+
+$pfxPass  = if ($PfxPassEnvVar) { [Environment]::GetEnvironmentVariable($PfxPassEnvVar) } else { '' }
+$passArgs = if ($pfxPass) { @('/p', $pfxPass) } else { @() }
+
+Write-Host "Signing $SysPath ..."
+& $signtool sign /fd sha256 /tr $tsUrl /td sha256 /f $PfxPath @passArgs $SysPath
+$rc1 = $LASTEXITCODE
+
+Write-Host "Signing $CatPath ..."
+& $signtool sign /fd sha256 /tr $tsUrl /td sha256 /f $PfxPath @passArgs $CatPath
+$rc2 = $LASTEXITCODE
+
+if ($rc1 -ne 0) { Write-Error "sys signing failed ($rc1)"; exit $rc1 }
+if ($rc2 -ne 0) { Write-Error "cat signing failed ($rc2)"; exit $rc2 }
+Write-Host "Both files signed successfully."
+exit 0

--- a/v2-kmdf-driver/scripts/sign-driver.ps1
+++ b/v2-kmdf-driver/scripts/sign-driver.ps1
@@ -1,9 +1,9 @@
-# sign-driver.ps1 — Sign a .sys + .cat pair with a PFX cert.
+# sign-driver.ps1 - Sign a .sys + .cat pair with a PFX cert.
 # Standalone: powershell -ExecutionPolicy Bypass -File sign-driver.ps1 -SysPath ... -CatPath ... -PfxPath ...
 # Via queue: SIGN|<nonce>|<sys-path>|<cat-path>|<pfx-path>|<pfx-pass-env-var>
 #
 # Empirically validated signtool path: F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe
-# (F:\ is the EWDK ISO drive on this dev machine — confirmed in mm-task-runner.ps1)
+# (F:\ is the EWDK ISO drive on this dev machine - confirmed in mm-task-runner.ps1)
 # Fallback: C:\Program Files (x86)\Windows Kits\10\ for machines with WDK/SDK on C:\
 param(
     [Parameter(Mandatory)][string]$SysPath,

--- a/v2-kmdf-driver/scripts/startup-repair-m13.ps1
+++ b/v2-kmdf-driver/scripts/startup-repair-m13.ps1
@@ -1,0 +1,107 @@
+# startup-repair-m13.ps1 - MagicMouseDriver (M13/M14) WDF filter repair
+# SPDX-License-Identifier: MIT
+# ASCII-only script (no UTF-8 BOM required for Windows PowerShell 5.x compatibility).
+#
+# Sets LowerFilters for MagicMouseDriver on paired v3 (0323) and v1 (030D/0310)
+# BTHENUM devices, then pnputil /restart-device to bind the filter without reboot.
+#
+# Usage: powershell -ExecutionPolicy Bypass -File startup-repair-m13.ps1
+
+param(
+    [string]$LogFile = "C:\mm-dev-queue\startup-repair-detail.log",
+    [int]$SettleSeconds = 8
+)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$logDir = Split-Path $LogFile -Parent
+if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+
+function Write-Log { param([string]$Msg)
+    $line = "[$(Get-Date -Format 'HH:mm:ss')] $Msg"
+    Add-Content -Path $LogFile -Value $line -Encoding ASCII
+    Write-Host $line
+}
+
+Write-Log "startup-repair-m13: begin"
+
+$targetPids  = @("0323","030D","0310")
+$svcName     = "MagicMouseDriver"
+$anyReboot   = $false
+$anyRepaired = $false
+
+foreach ($pid4 in $targetPids) {
+    ${pidUpper} = $pid4.ToUpper()
+
+    # Find the BTHENUM HID parent device for this PID.
+    # Hardware ID format: BTHENUM\{00001124...}_VID&NNNN_PID&NNNN
+    $btDevice = Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.InstanceId -match "BTHENUM" -and
+            $_.InstanceId -match "00001124" -and
+            $_.InstanceId -like ("*PID&" + $pid4 + "*") -and
+            $_.Status -eq 'OK'
+        } |
+        Select-Object -First 1
+
+    if (-not $btDevice) {
+        Write-Log "PID 0x${pidUpper}: not paired or not ready - skipping"
+        continue
+    }
+
+    Write-Log "PID 0x${pidUpper}: BTHENUM = $($btDevice.InstanceId)"
+
+    # Count HIDClass child devices.
+    $hidDevices = @(Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Class -eq 'HIDClass' -and
+            $_.InstanceId -like ("*" + $pid4 + "*") -and
+            $_.Status -eq 'OK'
+        })
+    $hidCount = $hidDevices.Count
+    Write-Log "PID 0x${pidUpper}: HID count = $hidCount"
+
+    # Ensure LowerFilters contains MagicMouseDriver.
+    # pnputil /add-driver should have set this, but verify.
+    $devRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDevice.InstanceId
+    if (Test-Path $devRegPath) {
+        $lf = (Get-ItemProperty -Path $devRegPath -Name "LowerFilters" -ErrorAction SilentlyContinue)."LowerFilters"
+        if ($lf -notcontains $svcName) {
+            Write-Log "PID 0x${pidUpper}: adding $svcName to LowerFilters"
+            $newLf = @($lf) + $svcName | Where-Object { $_ }
+            Set-ItemProperty -Path $devRegPath -Name "LowerFilters" -Value $newLf -Type MultiString -ErrorAction SilentlyContinue
+        } else {
+            Write-Log "PID 0x${pidUpper}: LowerFilters already contains $svcName"
+        }
+    }
+
+    # Restart device to bind filter.
+    Write-Log "PID 0x${pidUpper}: pnputil /restart-device $($btDevice.InstanceId)"
+    $restartOut = & pnputil /restart-device "$($btDevice.InstanceId)" 2>&1
+    $restartOut | ForEach-Object { Write-Log "  $_" }
+    Start-Sleep -Seconds $SettleSeconds
+
+    # Recount HID devices after restart.
+    $hidAfter = @(Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Class -eq 'HIDClass' -and
+            $_.InstanceId -like ("*" + $pid4 + "*") -and
+            $_.Status -eq 'OK'
+        })
+    $hidCountAfter = $hidAfter.Count
+
+    if ($hidCountAfter -ge 1) {
+        Write-Log "PID 0X${pidUpper}: HID OK ($hidCountAfter)"
+        $anyRepaired = $true
+    } else {
+        Write-Log "PID 0X${pidUpper}: HID FAIL ($hidCountAfter) after restart"
+    }
+}
+
+if ($anyRepaired) {
+    Write-Log "startup-repair-m13: complete - at least one device repaired"
+    exit 0
+} else {
+    Write-Log "startup-repair-m13: no paired devices found or all repaired already"
+    exit 0
+}

--- a/v2-kmdf-driver/scripts/startup-repair-m13.ps1
+++ b/v2-kmdf-driver/scripts/startup-repair-m13.ps1
@@ -27,7 +27,6 @@ Write-Log "startup-repair-m13: begin"
 
 $targetPids  = @("0323","030D","0310")
 $svcName     = "MagicMouseDriver"
-$anyReboot   = $false
 $anyRepaired = $false
 
 foreach ($pid4 in $targetPids) {

--- a/v2-kmdf-driver/scripts/startup-repair.ps1
+++ b/v2-kmdf-driver/scripts/startup-repair.ps1
@@ -1,0 +1,184 @@
+# startup-repair.ps1 - MagicMouseTray WDF Filter Repair
+# SPDX-License-Identifier: MIT
+#
+# Runs at startup via Windows Scheduled Task (SYSTEM account, 30s delay).
+# Detects whether the WDF filter has enumerated all 3 HID collections (COL01,
+# COL02, COL03). If any are missing the repair triggers pnputil /restart-device
+# on the BTHENUM parent WITH the filter in place, which forces a fresh SDP
+# negotiation. The WDF filter intercepts the SDP IOCTL and injects the fixed
+# 135-byte descriptor, producing:
+#   COL01 -> Generic Desktop Mouse (mouhid, cursor + scroll)
+#   COL02 -> Vendor 0xFF00/0x14 (HIDClass, battery via RID=0x90)
+#   COL03 -> Vendor 0xFF00/0x27 (HIDClass, raw touch data)
+#
+# CRITICAL: DO call pnputil /restart-device WITH the filter registered. The WDF
+# filter produces the correct 3-TLC descriptor on SDP renegotiation -- unlike the
+# old applewirelessmouse.sys which would strip COL02 when the filter was active
+# during descriptor re-processing. Old cycle-without-filter repair is WRONG here.
+#
+# Usage (manual): powershell -ExecutionPolicy Bypass -File startup-repair.ps1
+# Usage (scheduled task): registered by install-driver.ps1 - runs automatically.
+
+param(
+    [string]$LogFile = "C:\ProgramData\MagicMouseTray\startup-repair.log",
+    [int]$SettleSeconds = 12   # wait after restart-device before checking result
+)
+
+$MaxLogBytes = 512KB
+
+function Write-Log {
+    param([string]$Msg)
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Msg"
+    Add-Content -Path $LogFile -Value $line -Encoding UTF8
+}
+
+# ---- bootstrap ----
+$logDir = Split-Path $LogFile -Parent
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+if ((Test-Path $LogFile) -and (Get-Item $LogFile).Length -gt $MaxLogBytes) {
+    $archive = [System.IO.Path]::ChangeExtension($LogFile, "1.log")
+    Move-Item $LogFile $archive -Force
+}
+
+Write-Log "startup-repair: begin (WDF filter mode)"
+
+# PATH-A v5 SRE-Windows fix (S2): only v3 (PID 0323) has multi-TLC enumeration.
+# v1 (030D), v2 (0269), and 0310 use a single TLC and don't have COL02/COL03.
+# Running the LowerFilter dance on those PIDs is what triggered BSOD #2 on
+# 2026-05-08 (failed v1 repair at 16:01:57 → 0xD1 NULL deref at 16:15:42).
+# Restrict the repair scope to v3 only.
+$knownPids = @("0323")
+$paramsTemplate = "HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseFixV3\Parameters"
+$anyRepaired = $false
+
+foreach ($mmPid in $knownPids) {
+    if ($mmPid -ne "0323") {
+        # Defensive guard: if the array is ever expanded, only v3 must run the repair.
+        Write-Log "PID 0x$($mmPid.ToUpper()): skip — only v3 (0323) supports multi-TLC repair (SRE-Windows v5 S2)"
+        continue
+    }
+    # Find BTHENUM parent device (HID service UUID {00001124} only)
+    $btDevice = Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object { $_.InstanceId -match "BTHENUM" -and
+                       $_.InstanceId -match "00001124" -and
+                       $_.InstanceId -match "_PID&$mmPid" -and
+                       $_.Status -eq 'OK' } |
+        Select-Object -First 1
+
+    if (-not $btDevice) {
+        continue  # PID not paired - normal, skip silently
+    }
+
+    Write-Log "PID 0x$($mmPid.ToUpper()): BTHENUM = $($btDevice.InstanceId)"
+
+    # Count HIDClass child devices. COL01 is claimed by mouhid (Mouse class) so
+    # it does NOT appear in HIDClass. Healthy state: BTHENUM parent + COL02 + COL03
+    # = 3 HIDClass devices. Less than 3 means SDP patch did not produce all TLCs.
+    $hidDevices = @(Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object { $_.Class -eq 'HIDClass' -and
+                       $_.InstanceId -match $mmPid -and
+                       $_.Status -eq 'OK' })
+
+    $hidCount = $hidDevices.Count
+    if ($hidCount -ge 3) {
+        Write-Log "PID 0x$($mmPid.ToUpper()): HID OK ($hidCount) - no repair needed"
+        continue
+    }
+
+    Write-Log "PID 0x$($mmPid.ToUpper()): HID count=$hidCount (need 3) - starting WDF repair"
+
+    $btRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDevice.InstanceId
+
+    if (-not (Test-Path $btRegPath)) {
+        Write-Log "ERROR: registry path not found: $btRegPath"
+        continue
+    }
+
+    # Step 1: Verify our patched binary is present (PATH-A v5 renamed from
+    # applewirelessmouse.sys to MagicMouseFixV3.sys — see SRE-Windows v5 review S1).
+    $wdfBin = "C:\Windows\System32\drivers\MagicMouseFixV3.sys"
+    $wdfItem = Get-Item $wdfBin -ErrorAction SilentlyContinue
+    if (-not $wdfItem) {
+        Write-Log "CRITICAL: $wdfBin missing - cannot repair without WDF binary"
+        continue
+    }
+    Write-Log "Step 1: WDF binary present ($($wdfItem.Length) bytes)"
+
+    # Step 2: Verify/set EnableInjection=1
+    $paramsKey = $paramsTemplate
+    if (-not (Test-Path $paramsKey)) {
+        New-Item -Path $paramsKey -Force | Out-Null
+    }
+    $ei = (Get-ItemProperty $paramsKey -Name "EnableInjection" -ErrorAction SilentlyContinue).EnableInjection
+    if ($ei -ne 1) {
+        Write-Log "Step 2: EnableInjection=$ei -- setting to 1"
+        Set-ItemProperty -Path $paramsKey -Name "EnableInjection" -Value 1 -Type DWord
+    } else {
+        Write-Log "Step 2: EnableInjection=1 (OK)"
+    }
+
+    # Step 3: Verify/set LowerFilters on Enum key (PATH-A v5: MagicMouseFixV3, not applewirelessmouse).
+    $lfEnum = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+    if (-not ($lfEnum -contains 'MagicMouseFixV3')) {
+        Write-Log "Step 3: Enum LowerFilters missing MagicMouseFixV3 -- setting"
+        Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value @("MagicMouseFixV3") -Type MultiString -ErrorAction SilentlyContinue
+    } else {
+        Write-Log "Step 3: Enum LowerFilters OK ($($lfEnum -join ', '))"
+    }
+
+    # Step 3b: Verify/set LowerFilters on driver instance (Class) key
+    $driverKey = (Get-ItemProperty -Path $btRegPath -Name Driver -ErrorAction SilentlyContinue).Driver
+    if ($driverKey) {
+        $driverInstPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey"
+        if (Test-Path $driverInstPath) {
+            $lfClass = (Get-ItemProperty $driverInstPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+            if (-not ($lfClass -contains 'MagicMouseFixV3')) {
+                Write-Log "Step 3b: Class key LowerFilters missing -- setting"
+                Set-ItemProperty -Path $driverInstPath -Name LowerFilters -Value @("MagicMouseFixV3") -Type MultiString -ErrorAction SilentlyContinue
+            } else {
+                Write-Log "Step 3b: Class key LowerFilters OK"
+            }
+        }
+    }
+
+    # Step 4: Restart BTHENUM device WITH WDF filter in place.
+    # The filter intercepts IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE and replaces
+    # the HIDDescriptorList with our 135-byte 3-TLC descriptor. This produces the
+    # correct 3 HID child PDOs without needing to remove the filter first.
+    try {
+        Write-Log "Step 4: pnputil /restart-device $($btDevice.InstanceId)"
+        $out = pnputil /restart-device "$($btDevice.InstanceId)" 2>&1
+        $lastLine = ($out | Select-Object -Last 2 | Out-String).TrimEnd()
+        Write-Log "  pnp: $lastLine"
+
+        Write-Log "Step 4: waiting $SettleSeconds seconds for SDP negotiation..."
+        Start-Sleep -Seconds $SettleSeconds
+
+        # Step 5: Verify result
+        $hidAfter = @(Get-PnpDevice -ErrorAction SilentlyContinue |
+            Where-Object { $_.Class -eq 'HIDClass' -and
+                           $_.InstanceId -match $mmPid -and
+                           $_.Status -eq 'OK' })
+        $hidAfterCount = $hidAfter.Count
+
+        if ($hidAfterCount -ge 3) {
+            Write-Log "REPAIRED: HID OK=$hidAfterCount (COL01 mouhid + COL02 battery + COL03 touch)"
+            $anyRepaired = $true
+        } else {
+            Write-Log "WARNING: repair attempted - HID count=$hidAfterCount (need 3)"
+            $hidAfter | ForEach-Object { Write-Log "  found: $($_.InstanceId)" }
+            Write-Log "  Possible causes:"
+            Write-Log "    - MagicMouseFixV3.sys unsigned or wrong binary (run dist/PATH-A-v5/install.ps1)"
+            Write-Log "    - CN=MagicMouseFix cert not in LocalMachine\\TrustedPublisher"
+            Write-Log "    - testsigning BCD not active (bcdedit /set testsigning on)"
+        }
+
+    } catch {
+        Write-Log "ERROR during restart-device: $($_.Exception.Message)"
+    }
+}
+
+Write-Log "startup-repair: complete (repaired=$anyRepaired)"

--- a/v2-kmdf-driver/scripts/startup-repair.ps1
+++ b/v2-kmdf-driver/scripts/startup-repair.ps1
@@ -48,7 +48,7 @@ Write-Log "startup-repair: begin (WDF filter mode)"
 # PATH-A v5 SRE-Windows fix (S2): only v3 (PID 0323) has multi-TLC enumeration.
 # v1 (030D), v2 (0269), and 0310 use a single TLC and don't have COL02/COL03.
 # Running the LowerFilter dance on those PIDs is what triggered BSOD #2 on
-# 2026-05-08 (failed v1 repair at 16:01:57 → 0xD1 NULL deref at 16:15:42).
+# 2026-05-08 (failed v1 repair at 16:01:57 -> 0xD1 NULL deref at 16:15:42).
 # Restrict the repair scope to v3 only.
 $knownPids = @("0323")
 $paramsTemplate = "HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseFixV3\Parameters"
@@ -57,7 +57,7 @@ $anyRepaired = $false
 foreach ($mmPid in $knownPids) {
     if ($mmPid -ne "0323") {
         # Defensive guard: if the array is ever expanded, only v3 must run the repair.
-        Write-Log "PID 0x$($mmPid.ToUpper()): skip — only v3 (0323) supports multi-TLC repair (SRE-Windows v5 S2)"
+        Write-Log "PID 0x$($mmPid.ToUpper()): skip - only v3 (0323) supports multi-TLC repair (SRE-Windows v5 S2)"
         continue
     }
     # Find BTHENUM parent device (HID service UUID {00001124} only)
@@ -98,7 +98,7 @@ foreach ($mmPid in $knownPids) {
     }
 
     # Step 1: Verify our patched binary is present (PATH-A v5 renamed from
-    # applewirelessmouse.sys to MagicMouseFixV3.sys — see SRE-Windows v5 review S1).
+    # applewirelessmouse.sys to MagicMouseFixV3.sys - see SRE-Windows v5 review S1).
     $wdfBin = "C:\Windows\System32\drivers\MagicMouseFixV3.sys"
     $wdfItem = Get-Item $wdfBin -ErrorAction SilentlyContinue
     if (-not $wdfItem) {


### PR DESCRIPTION
Lands magic-tray driver/, driver-keyboard/, driver-test/, and KMDF scripts into v2-kmdf-driver/, keyboard-descriptor-patcher/, driver-test/. Keeps existing v2-kmdf-driver/README.md roadmap. Source magic-tray 2a06226.