### PR TITLE
chore: sync main with the published Pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A free, MIT-licensed **Magic Mouse v3 Windows driver** for the USB-C **Apple Mag
 [Magic Mouse battery percentage on Windows](https://lesleymurfin.github.io/magic-mouse-v3-windows-fix/battery.html) ·
 [Magic Mouse v3 driver FAQ](https://lesleymurfin.github.io/magic-mouse-v3-windows-fix/faq.html)
 
-**Battery percentage:** use [Magic Tray (Windows app)](https://github.com/LesleyMurfin/magic-tray) — a Windows system-tray utility (software, not a physical desk tray) that reads HID Input `0x90` COL02 and installs the KMDF package from this repo. Site: [Magic Tray (Windows app) home](https://lesleymurfin.github.io/magic-tray/).
+**Battery percentage:** use [Magic Tray (Windows app)](https://github.com/LesleyMurfin/magic-tray) — a Windows system-tray utility (software, not a physical desk tray) that reads HID Input `0x90` COL02 and installs the KMDF package from this repo. Site: [Magic Tray (Windows app) home](https://magictray.app/).
 
 **STATUS:** KMDF is what Magic Tray recommends. The v1 patched `applewirelessmouse.sys` is documented below as research; Magic Tray will not use it as a KMDF fallback.
 
-If this helped, **star this repo** and **[Magic Tray](https://github.com/LesleyMurfin/magic-tray)**. Signing goal (Stripe, not GitHub Sponsors): [funding](https://lesleymurfin.github.io/magic-tray/funding.html).
+If this helped, **star this repo** and **[Magic Tray](https://github.com/LesleyMurfin/magic-tray)**. Signing goal (Stripe, not GitHub Sponsors): [funding](https://magictray.app/funding.html).
 
 ## Contents
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -19,7 +19,7 @@
     <a href="battery.html">Battery %</a>
     <a href="faq.html">FAQ</a>
     <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub repo</a>
-    <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray app</a>
+    <a href="https://magictray.app/">Magic Tray app</a>
   </nav>
     <h1>Page not found</h1>
     <p class="lead">That page does not exist on this site. The <strong>Magic Mouse 2024 (v3) Windows driver</strong> pages are all listed below.</p>
@@ -31,7 +31,7 @@
       <li><a href="scroll-fix.html">Magic Mouse scroll not working on Windows 11<small>Symptoms, cause, and the PID lookup table.</small></a></li>
       <li><a href="battery.html">Magic Mouse battery percentage on Windows 11<small>What reads HID report 0x90, and what does not.</small></a></li>
       <li><a href="faq.html">Magic Mouse v3 Windows driver FAQ<small>Boot Camp, signing, Windows 10, uninstall.</small></a></li>
-      <li><a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)<small>Windows system-tray utility for Apple mice. Not a desk tray.</small></a></li>
+      <li><a href="https://magictray.app/">Magic Tray (Windows app)<small>Windows system-tray utility for Apple mice. Not a desk tray.</small></a></li>
     </ul>
   </main>
   <footer>
@@ -39,7 +39,7 @@
       Maintained by Revive Business Solutions / Lesley Murfin.</p>
     <p><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver repo</a> ·
       <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ·
-      <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">Which driver do I need</a> ·
+      <a href="https://magictray.app/drivers.html">Which driver do I need</a> ·
       <a href="llms.txt">llms.txt</a></p>
     <p>Not affiliated with Apple Inc. Apple, Magic Mouse, and Boot Camp are trademarks of Apple Inc.</p>
   </footer>

--- a/docs/battery.html
+++ b/docs/battery.html
@@ -81,12 +81,12 @@
     <a href="battery.html" aria-current="page">Battery %</a>
     <a href="faq.html">FAQ</a>
     <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub repo</a>
-    <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray app</a>
+    <a href="https://magictray.app/">Magic Tray app</a>
   </nav>
     <h1>Magic Mouse battery percentage on Windows 11</h1>
-    <p class="lead">To see <strong>Magic Mouse battery percentage</strong> on <strong>Windows 11</strong>, use the free <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a>: it reads the mouse&rsquo;s HID Input report <code>0x90</code> on collection <strong>COL02</strong> and shows the percentage next to the Windows clock. The <strong>Magic Mouse 2024 (v3) Windows driver</strong> in this repo does not read battery at all &mdash; it is a kernel driver whose job is keeping scroll alive on <strong>PID 0323</strong>. The two are complementary: the driver keeps the HID collections healthy, and a healthy collection stack is what makes the battery read reliable.</p>
+    <p class="lead">To see <strong>Magic Mouse battery percentage</strong> on <strong>Windows 11</strong>, use the free <a href="https://magictray.app/">Magic Tray (Windows app)</a>: it reads the mouse&rsquo;s HID Input report <code>0x90</code> on collection <strong>COL02</strong> and shows the percentage next to the Windows clock. The <strong>Magic Mouse 2024 (v3) Windows driver</strong> in this repo does not read battery at all &mdash; it is a kernel driver whose job is keeping scroll alive on <strong>PID 0323</strong>. The two are complementary: the driver keeps the HID collections healthy, and a healthy collection stack is what makes the battery read reliable.</p>
     <p class="cta">
-      <a class="primary" href="https://lesleymurfin.github.io/magic-tray/">Get Magic Tray (Windows app)</a>
+      <a class="primary" href="https://magictray.app/">Get Magic Tray (Windows app)</a>
       <a class="ghost" href="install.html">Install the scroll driver</a>
     </p>
   </header>
@@ -109,7 +109,7 @@
     <p>No. This project is a kernel-mode KMDF filter driver and it does not read or report battery level. Anything that claims otherwise about this repo is wrong. Reading the battery is userspace work, and it is done by the Magic Tray app.</p>
 
     <h2>How do I check Magic Mouse battery on Windows?</h2>
-    <p>Install <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> and look next to the Windows clock. Magic Tray opens the mouse&rsquo;s HID interface, reads Input report <code>0x90</code> from collection COL02, and renders the percentage in the notification area. Source: the <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo on GitHub</a>.</p>
+    <p>Install <a href="https://magictray.app/">Magic Tray (Windows app)</a> and look next to the Windows clock. Magic Tray opens the mouse&rsquo;s HID interface, reads Input report <code>0x90</code> from collection COL02, and renders the percentage in the notification area. Source: the <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo on GitHub</a>.</p>
     <p class="note">Magic Tray is Windows software &mdash; a system-tray utility for Apple mice on Windows. It is not a desk accessory, a keyboard stand, or a 3D-printed or wooden tray, despite what a shopping search suggests.</p>
 
     <h2>Why does Windows 11 not show the battery level itself?</h2>
@@ -126,14 +126,14 @@
     </ul>
 
     <h2>Does this work on Magic Mouse 1 or Magic Mouse 2?</h2>
-    <p>Battery reporting for older Apple mice is a Magic Tray question, not a question about this driver. This driver targets PID <code>0x0323</code> only; v1 (<code>0x030D</code>) and v2 (<code>0x0269</code>) are served by Apple&rsquo;s Boot Camp INF and the community fixes listed in the <a href="scroll-fix.html">scroll fix table</a>. For what Magic Tray supports, see <a href="https://lesleymurfin.github.io/magic-tray/">the Magic Tray (Windows app) site</a>.</p>
+    <p>Battery reporting for older Apple mice is a Magic Tray question, not a question about this driver. This driver targets PID <code>0x0323</code> only; v1 (<code>0x030D</code>) and v2 (<code>0x0269</code>) are served by Apple&rsquo;s Boot Camp INF and the community fixes listed in the <a href="scroll-fix.html">scroll fix table</a>. For what Magic Tray supports, see <a href="https://magictray.app/">the Magic Tray (Windows app) site</a>.</p>
   </main>
   <footer>
     <p><strong>Magic Mouse 2024 (v3) Windows driver</strong> — MIT licensed, free, no subscription.
       Maintained by Revive Business Solutions / Lesley Murfin.</p>
     <p><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver repo</a> ·
       <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ·
-      <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">Which driver do I need</a> ·
+      <a href="https://magictray.app/drivers.html">Which driver do I need</a> ·
       <a href="llms.txt">llms.txt</a></p>
     <p>Not affiliated with Apple Inc. Apple, Magic Mouse, and Boot Camp are trademarks of Apple Inc.</p>
   </footer>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -207,7 +207,7 @@
     <a href="battery.html">Battery %</a>
     <a href="faq.html" aria-current="page">FAQ</a>
     <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub repo</a>
-    <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray app</a>
+    <a href="https://magictray.app/">Magic Tray app</a>
   </nav>
     <h1>Magic Mouse v3 Windows driver FAQ</h1>
     <p class="lead">Short answers about the <strong>Magic Mouse 2024 (v3) Windows driver</strong>: Apple never shipped a Windows driver for this mouse, <strong>PID 0323</strong> is absent from Boot Camp, and scroll dies on <strong>Windows 11</strong> when a Bluetooth idle disconnect collapses the HID collections. This <strong>Magic Mouse v3 Windows driver</strong> is free, MIT licensed, and self-signed, so Test Mode is required today.</p>
@@ -233,16 +233,16 @@
     <p>Check the Hardware Ids: Device Manager &rarr; Human Interface Devices &rarr; Apple Magic Mouse &rarr; Properties &rarr; Details &rarr; Hardware Ids. <code>PID_0323</code> means v3, and the charge port is USB-C. <code>PID_030D</code> is v1 and <code>PID_0269</code> is v2.</p>
 
     <h2>Is the driver signed, and why do I need Test Mode?</h2>
-    <p>The driver is self-signed today, so Windows only loads it with test signing enabled and Secure Boot off. An EV certificate plus Microsoft attestation signing is the goal, funded off GitHub via Stripe &mdash; see the <a href="https://lesleymurfin.github.io/magic-tray/funding.html">signing and funding page</a> and <a href="install.html#test-mode">what Test Mode actually means</a>.</p>
+    <p>The driver is self-signed today, so Windows only loads it with test signing enabled and Secure Boot off. An EV certificate plus Microsoft attestation signing is the goal, funded off GitHub via Stripe &mdash; see the <a href="https://magictray.app/funding.html">signing and funding page</a> and <a href="install.html#test-mode">what Test Mode actually means</a>.</p>
 
     <h2>Is the Magic Mouse v3 Windows driver free?</h2>
     <p>Yes. It is free and MIT licensed, with no subscription. It is maintained by Revive Business Solutions / Lesley Murfin, and the whole source tree is on <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub</a>.</p>
 
     <h2>Is this the same as Magic Utilities?</h2>
-    <p>No. Magic Utilities is separate paid software sold on subscription. This project is a free, MIT-licensed kernel driver aimed at the 2024 Magic Mouse scroll bug, and the battery percentage side is handled by the free <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a>.</p>
+    <p>No. Magic Utilities is separate paid software sold on subscription. This project is a free, MIT-licensed kernel driver aimed at the 2024 Magic Mouse scroll bug, and the battery percentage side is handled by the free <a href="https://magictray.app/">Magic Tray (Windows app)</a>.</p>
 
     <h2>Does the driver fix the battery percentage on Windows?</h2>
-    <p>No. This kernel driver does not read battery. The free <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> reads HID Input report <code>0x90</code> on collection COL02 and shows the percentage next to the Windows clock. See <a href="battery.html">Magic Mouse battery percentage on Windows 11</a>.</p>
+    <p>No. This kernel driver does not read battery. The free <a href="https://magictray.app/">Magic Tray (Windows app)</a> reads HID Input report <code>0x90</code> on collection COL02 and shows the percentage next to the Windows clock. See <a href="battery.html">Magic Mouse battery percentage on Windows 11</a>.</p>
 
     <h2>Does it support Magic Mouse v1 or v2?</h2>
     <p>No. This driver targets PID <code>0x0323</code> only. Magic Mouse v1 (<code>0x030D</code>) and v2 (<code>0x0269</code>) are covered by Apple&rsquo;s Boot Camp INF and by community fixes from <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici</a> and <a href="https://github.com/tealtadpole/MagicMouse2DriversWin11x64">tealtadpole</a>. The <a href="scroll-fix.html">PID lookup table</a> spells out which one you need.</p>
@@ -264,7 +264,7 @@
       <li><a href="install.html">How to install the Magic Mouse 2024 (v3) Windows driver</a> &mdash; seven steps, Test Mode, rollback.</li>
       <li><a href="scroll-fix.html">Magic Mouse 2024 (v3) scroll not working on Windows 11</a> &mdash; cause and PID table.</li>
       <li><a href="battery.html">Magic Mouse battery percentage on Windows 11</a> &mdash; what reads report <code>0x90</code>.</li>
-      <li><a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> &mdash; Windows system-tray utility that installs this driver and shows battery percentage. Not a desk accessory, stand, or 3D-printed tray.</li>
+      <li><a href="https://magictray.app/">Magic Tray (Windows app)</a> &mdash; Windows system-tray utility that installs this driver and shows battery percentage. Not a desk accessory, stand, or 3D-printed tray.</li>
       <li><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver source and issue tracker on GitHub</a>.</li>
     </ul>
   </main>
@@ -273,7 +273,7 @@
       Maintained by Revive Business Solutions / Lesley Murfin.</p>
     <p><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver repo</a> ·
       <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ·
-      <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">Which driver do I need</a> ·
+      <a href="https://magictray.app/drivers.html">Which driver do I need</a> ·
       <a href="llms.txt">llms.txt</a></p>
     <p>Not affiliated with Apple Inc. Apple, Magic Mouse, and Boot Camp are trademarks of Apple Inc.</p>
   </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,14 +126,14 @@
     <a href="battery.html">Battery %</a>
     <a href="faq.html">FAQ</a>
     <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub repo</a>
-    <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray app</a>
+    <a href="https://magictray.app/">Magic Tray app</a>
   </nav>
     <h1>Magic Mouse 2024 (v3) Windows driver — scroll fix for PID 0323</h1>
-    <p class="lead">Apple ships no Windows driver for the 2024 USB-C Magic Mouse, Bluetooth <strong>PID 0323</strong> — that ID is absent from the Boot Camp INF. This project is a free, MIT-licensed KMDF filter driver that keeps two-finger scroll alive across Bluetooth reconnects on Windows 10 and <strong>Windows 11</strong>. It is the kernel half of the fix; the <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> installs it and shows battery percentage in the tray.</p>
+    <p class="lead">Apple ships no Windows driver for the 2024 USB-C Magic Mouse, Bluetooth <strong>PID 0323</strong> — that ID is absent from the Boot Camp INF. This project is a free, MIT-licensed KMDF filter driver that keeps two-finger scroll alive across Bluetooth reconnects on Windows 10 and <strong>Windows 11</strong>. It is the kernel half of the fix; the <a href="https://magictray.app/">Magic Tray (Windows app)</a> installs it and shows battery percentage in the tray.</p>
     <p class="cta">
       <a class="primary" href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Download the driver on GitHub</a>
       <a class="ghost" href="install.html">Install on Windows 11</a>
-      <a class="ghost" href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a>
+      <a class="ghost" href="https://magictray.app/">Magic Tray (Windows app)</a>
     </p>
   </header>
   <main id="content">
@@ -165,7 +165,7 @@
     <h2 id="what-it-does">What does the Magic Mouse v3 Windows driver do?</h2>
     <p>It is a kernel-mode KMDF filter driver that sits on the mouse's HID stack and prevents the Mode B collapse, so scroll keeps working across Bluetooth reconnects. The repo holds two code paths:</p>
     <ul class="plain">
-      <li><strong>v2 KMDF filter driver</strong> (<code>v2-kmdf-driver/</code>) — the recommended path, targeting full prevention. This is the package the <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> installs via <code>v2-kmdf-driver/Install-KMDF.cmd</code>.</li>
+      <li><strong>v2 KMDF filter driver</strong> (<code>v2-kmdf-driver/</code>) — the recommended path, targeting full prevention. This is the package the <a href="https://magictray.app/">Magic Tray (Windows app)</a> installs via <code>v2-kmdf-driver/Install-KMDF.cmd</code>.</li>
       <li><strong>v1 binary patch</strong> (<code>v1-binary-patch/</code>) — research history: a patched <code>applewirelessmouse.sys</code>, version 1.0.0. It measured a 3.1x improvement over the unpatched baseline and reduces, and may prevent, collection loss. Multi-day prevention was never characterised, and it is not Magic Tray's fallback. Keep it for the analysis, not for daily use.</li>
     </ul>
     <p class="note">The driver restores scroll. It does not change button mapping, gestures, or pointer acceleration.</p>
@@ -186,7 +186,7 @@
     <p>If your Hardware Ids show <code>PID_0269</code> or <code>PID_030D</code>, this repo will not help you — the catalog-signed Boot Camp path already supports those mice.</p>
 
     <h2 id="battery">How do I see Magic Mouse battery percentage on Windows?</h2>
-    <p>Use the Magic Tray app — this driver does not read battery. The 2024 Magic Mouse reports its charge on HID Input report <code>0x90</code>, collection <code>COL02</code>, and parsing that report is userspace work done by the <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a>, which puts the percentage in the Windows notification area. The driver's role is indirect but real: a healthy HID collection stack is what keeps that read reliable, because a Mode B device no longer exposes the collection the battery report lives in.</p>
+    <p>Use the Magic Tray app — this driver does not read battery. The 2024 Magic Mouse reports its charge on HID Input report <code>0x90</code>, collection <code>COL02</code>, and parsing that report is userspace work done by the <a href="https://magictray.app/">Magic Tray (Windows app)</a>, which puts the percentage in the Windows notification area. The driver's role is indirect but real: a healthy HID collection stack is what keeps that read reliable, because a Mode B device no longer exposes the collection the battery report lives in.</p>
     <p>Step-by-step: <a href="battery.html">check Magic Mouse battery percentage on Windows 11</a>.</p>
 
     <h2 id="install">How do I install the Magic Mouse 2024 (v3) Windows driver?</h2>
@@ -194,7 +194,7 @@
 
     <h2 id="price">Is this driver free, and how does it compare to Magic Utilities?</h2>
     <p>It is free and MIT licensed, with no subscription. Magic Utilities is paid software sold on a subscription; this project is not, and nothing here expires or stops scrolling when a licence lapses. It is maintained by Revive Business Solutions / Lesley Murfin and is not affiliated with Apple.</p>
-    <p>Signing is the one thing money buys: the driver is self-signed today and the goal is an EV certificate plus Microsoft attestation signing, funded through Stripe rather than GitHub Sponsors — see the <a href="https://lesleymurfin.github.io/magic-tray/funding.html">driver signing funding page</a>.</p>
+    <p>Signing is the one thing money buys: the driver is self-signed today and the goal is an EV certificate plus Microsoft attestation signing, funded through Stripe rather than GitHub Sponsors — see the <a href="https://magictray.app/funding.html">driver signing funding page</a>.</p>
 
     <h2 id="next">Where to next</h2>
     <div class="grid grid-3">
@@ -231,7 +231,7 @@
       Maintained by Revive Business Solutions / Lesley Murfin.</p>
     <p><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver repo</a> ·
       <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ·
-      <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">Which driver do I need</a> ·
+      <a href="https://magictray.app/drivers.html">Which driver do I need</a> ·
       <a href="llms.txt">llms.txt</a></p>
     <p>Not affiliated with Apple Inc. Apple, Magic Mouse, and Boot Camp are trademarks of Apple Inc.</p>
   </footer>

--- a/docs/install.html
+++ b/docs/install.html
@@ -145,7 +145,7 @@
     <a href="battery.html">Battery %</a>
     <a href="faq.html">FAQ</a>
     <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub repo</a>
-    <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray app</a>
+    <a href="https://magictray.app/">Magic Tray app</a>
   </nav>
     <h1>How to install the Magic Mouse 2024 (v3) Windows driver</h1>
     <p class="lead">Install the <strong>Magic Mouse 2024 (v3) Windows driver</strong> by confirming your mouse is <strong>PID 0323</strong>, enabling Windows Test Mode, and running <code>Install-KMDF.cmd</code> from the <code>v2-kmdf-driver</code> package as administrator. It takes two reboots on Windows 10 (build 14393 or later) or Windows 11 x64. The driver is free, MIT licensed, and self-signed today, which is why Test Mode is still required.</p>
@@ -183,7 +183,7 @@
     <h2>Install steps</h2>
     <ol class="steps">
       <li id="step-1"><strong>Confirm your mouse reports PID 0323.</strong> Open <strong>Device Manager</strong> &rarr; <strong>Human Interface Devices</strong> &rarr; <strong>Apple Magic Mouse</strong> &rarr; Properties &rarr; Details &rarr; <strong>Hardware Ids</strong>, and look for <code>PID_0323</code>. If you see <code>PID_030D</code> or <code>PID_0269</code> you have a v1 or v2 mouse; stop here and read the <a href="scroll-fix.html">Magic Mouse scroll fix table for v1, v2 and v3</a> instead.</li>
-      <li id="step-2"><strong>Download the driver package from the GitHub repo.</strong> Get the <code>v2-kmdf-driver</code> package from the <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix repository on GitHub</a>. That is the recommended path and the same package the <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> installs.</li>
+      <li id="step-2"><strong>Download the driver package from the GitHub repo.</strong> Get the <code>v2-kmdf-driver</code> package from the <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix repository on GitHub</a>. That is the recommended path and the same package the <a href="https://magictray.app/">Magic Tray (Windows app)</a> installs.</li>
       <li id="step-3"><strong>Verify the SHA256 hash of the download.</strong> In PowerShell, run <code>Get-FileHash -Algorithm SHA256 &lt;file&gt;</code> and compare the result with the hash published alongside the download. Do not install a kernel driver whose hash does not match.</li>
       <li id="step-4"><strong>Enable Windows Test Mode.</strong> The KMDF driver is self-signed today, so Windows must be willing to load test-signed kernel code. From an elevated prompt: <code>bcdedit /set testsigning on</code>, then reboot. Secure Boot must be off, or Windows ignores the setting. See <a href="#test-mode">what Test Mode actually means</a> below.</li>
       <li id="step-5"><strong>Install the KMDF driver package.</strong> Run <code>Install-KMDF.cmd</code> from the <code>v2-kmdf-driver</code> folder as administrator. The <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ships the same action, so you can let Magic Tray do this install for you instead of running the script by hand.</li>
@@ -193,7 +193,7 @@
 
     <h2 id="test-mode">What does Test Mode actually mean?</h2>
     <p>Test Mode tells Windows to load kernel drivers that are signed with a certificate Windows does not trust by default. Nothing else about the machine changes, but Windows shows a watermark in the desktop corner, Secure Boot has to stay off, and some anti-cheat and enterprise policies refuse to run while test signing is on. Turning it off is one command and a reboot.</p>
-    <p>This is a funding problem, not a design choice. Kernel drivers need an EV code-signing certificate and Microsoft attestation signing before Windows will load them normally, and that is the stated goal for this driver &mdash; see the <a href="https://lesleymurfin.github.io/magic-tray/funding.html">signing and funding page</a>.</p>
+    <p>This is a funding problem, not a design choice. Kernel drivers need an EV code-signing certificate and Microsoft attestation signing before Windows will load them normally, and that is the stated goal for this driver &mdash; see the <a href="https://magictray.app/funding.html">signing and funding page</a>.</p>
     <p class="note">Do not disable driver signature enforcement on a machine you do not control, and do not install kernel drivers you have not hash-checked.</p>
 
     <h2>Is the v1 binary patch an alternative?</h2>
@@ -210,7 +210,7 @@
       <li><a href="scroll-fix.html">Magic Mouse 2024 (v3) scroll not working on Windows 11</a> &mdash; symptoms, cause, and the PID lookup table.</li>
       <li><a href="battery.html">Magic Mouse battery percentage on Windows 11</a> &mdash; what actually reads the battery.</li>
       <li><a href="faq.html">Magic Mouse v3 Windows driver FAQ</a> &mdash; signing, Boot Camp, v1 and v2 support.</li>
-      <li><a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> &mdash; installs this driver and shows battery percentage in the tray.</li>
+      <li><a href="https://magictray.app/">Magic Tray (Windows app)</a> &mdash; installs this driver and shows battery percentage in the tray.</li>
     </ul>
   </main>
   <footer>
@@ -218,7 +218,7 @@
       Maintained by Revive Business Solutions / Lesley Murfin.</p>
     <p><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver repo</a> ·
       <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ·
-      <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">Which driver do I need</a> ·
+      <a href="https://magictray.app/drivers.html">Which driver do I need</a> ·
       <a href="llms.txt">llms.txt</a></p>
     <p>Not affiliated with Apple Inc. Apple, Magic Mouse, and Boot Camp are trademarks of Apple Inc.</p>
   </footer>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -49,7 +49,7 @@ Magic Tray is a Windows system-tray app that shows Apple Magic Mouse battery per
 Windows notification area. It is software, not a physical desk tray, stand, or 3D-printed accessory.
 Magic Tray installs this repository's KMDF package (`v2-kmdf-driver/Install-KMDF.cmd`).
 
-- Site: https://lesleymurfin.github.io/magic-tray/
+- Site: https://magictray.app/
 - Repository: https://github.com/LesleyMurfin/magic-tray
 
 ## Not this

--- a/docs/scroll-fix.html
+++ b/docs/scroll-fix.html
@@ -81,7 +81,7 @@
     <a href="battery.html">Battery %</a>
     <a href="faq.html">FAQ</a>
     <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">GitHub repo</a>
-    <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray app</a>
+    <a href="https://magictray.app/">Magic Tray app</a>
   </nav>
     <h1>Magic Mouse 2024 (v3) scroll not working on Windows 11</h1>
     <p class="lead">If your <strong>Magic Mouse 2024 (v3)</strong> still moves the cursor on <strong>Windows 11</strong> but two-finger scroll is dead, Windows has collapsed the mouse&rsquo;s HID collections after a Bluetooth idle disconnect. It does not recover on its own. The fix for <strong>PID 0323</strong> is the KMDF filter driver in this project &mdash; the <strong>Magic Mouse v3 Windows driver</strong> &mdash; because Apple never shipped a Windows driver for this mouse.</p>
@@ -150,10 +150,10 @@
         </tr>
       </tbody>
     </table>
-    <p>Unsure after all that? The Magic Tray site keeps a decision page: <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">which Apple mouse driver do I need on Windows</a>.</p>
+    <p>Unsure after all that? The Magic Tray site keeps a decision page: <a href="https://magictray.app/drivers.html">which Apple mouse driver do I need on Windows</a>.</p>
 
     <h2>Will this fix the battery percentage too?</h2>
-    <p>No. The driver restores scroll; it does not read battery. The free <a href="https://lesleymurfin.github.io/magic-tray/">Magic Tray (Windows app)</a> is what shows battery percentage next to the Windows clock, and a healthy HID collection stack is what keeps that read reliable. Details: <a href="battery.html">Magic Mouse battery percentage on Windows 11</a>. Magic Tray is Windows software &mdash; a system-tray utility &mdash; not a desk accessory, stand, or 3D-printed tray.</p>
+    <p>No. The driver restores scroll; it does not read battery. The free <a href="https://magictray.app/">Magic Tray (Windows app)</a> is what shows battery percentage next to the Windows clock, and a healthy HID collection stack is what keeps that read reliable. Details: <a href="battery.html">Magic Mouse battery percentage on Windows 11</a>. Magic Tray is Windows software &mdash; a system-tray utility &mdash; not a desk accessory, stand, or 3D-printed tray.</p>
 
     <h2>Still stuck?</h2>
     <ul class="plain">
@@ -166,7 +166,7 @@
       Maintained by Revive Business Solutions / Lesley Murfin.</p>
     <p><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Driver repo</a> ·
       <a href="https://github.com/LesleyMurfin/magic-tray">Magic Tray (Windows app) repo</a> ·
-      <a href="https://lesleymurfin.github.io/magic-tray/drivers.html">Which driver do I need</a> ·
+      <a href="https://magictray.app/drivers.html">Which driver do I need</a> ·
       <a href="llms.txt">llms.txt</a></p>
     <p>Not affiliated with Apple Inc. Apple, Magic Mouse, and Boot Camp are trademarks of Apple Inc.</p>
   </footer>


### PR DESCRIPTION
Keeps `main` tree-identical to the Pages source branch after #15.